### PR TITLE
Clone submodules via HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "TMCStepper"]
 	path = lib/TMCStepper
-	url = git@github.com:prusa3d/TMCStepper.git
+	url = https://github.com/prusa3d/TMCStepper.git
 [submodule "Marlin"]
 	path = lib/Marlin
-	url = git@github.com:prusa3d/Marlin.git
+	url = https://github.com/prusa3d/Marlin.git
 [submodule "inih"]
 	path = lib/inih
-	url = git@github.com:benhoyt/inih.git
+	url = https://github.com/benhoyt/inih.git


### PR DESCRIPTION
As all the submodules are now public repositories, we should not require ssh being set up to clone this repo successfully.