### PR TITLE
Fix printing time showing incorrect 'days' value

### DIFF
--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -180,7 +180,7 @@ struct pduration_t : duration_t {
             s = this->second() % 60;
 
         if (d) {
-            sprintf(buffer, "%i3d %2ih %2im", d, h, m);
+            sprintf(buffer, "%3id %2ih %2im", d, h, m);
         } else if (h) {
             sprintf(buffer, "     %2ih %2im", h, m);
         } else if (m) {


### PR DESCRIPTION
Fixes issue #7.