### PR TITLE
Text roll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,6 +444,7 @@ target_sources(
           src/guiapi/src/window_icon.c
           src/guiapi/src/window_spin.c
           src/guiapi/src/window_text.c
+          src/guiapi/src/window_scroll_text.c
           src/guiapi/src/window_msgbox.c
           src/guiapi/src/window.c
           src/wui/http_states.c

--- a/src/gui/window_file_list.c
+++ b/src/gui/window_file_list.c
@@ -131,7 +131,8 @@ void window_file_list_init(window_file_list_t *window) {
     window->alignment = ALIGN_LEFT_CENTER;
     window->win.flg |= WINDOW_FLG_ENABLED;
     window->roll.count = window->roll.px_cd = window->roll.phase = window->roll.setup = window->roll.progress = 0;
-    window->last_index = 20;    //just a value different from index;
+    window->last_index = 0;
+    gui_timer_create_txtroll(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
 
     strcpy(window->altpath, "/");
 }
@@ -191,9 +192,9 @@ void window_file_list_draw(window_file_list_t *window) {
             if((window->win.flg & WINDOW_FLG_FOCUSED) && window->index == idx){
                 if(window->index != window->last_index){
                     window->last_index = window->index;
-                    gui_timers_delete_by_window_id(window->win.id);
                     window->roll.setup = window->roll.phase = 0;
-                    gui_timer_create_oneshot(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
+                    gui_timer_restart_txtroll(window->win.id);
+                    gui_timer_change_txtroll_peri_delay(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
                 }
 
                 render_scroll_text_align(rc,

--- a/src/gui/window_file_list.h
+++ b/src/gui/window_file_list.h
@@ -9,6 +9,7 @@
 #define API_WINDOW_FILE_LIST_H_
 
 #include "window.h"
+#include "display_helper.h"
 #include "ffconf.h"
 #include "ff.h"
 
@@ -72,6 +73,8 @@ typedef struct _window_file_list_t {
     //char path[F_MAXPATHNAMELENGTH-_MAX_LFN];
     char altpath[F_MAXPATHNAMELENGTH - 12];
     FILINFO file_items[SDSORT_LIMIT];
+    txtroll_t roll;
+    uint8_t last_index;
 } window_file_list_t;
 
 #pragma pack(pop)

--- a/src/guiapi/include/display_helper.h
+++ b/src/guiapi/include/display_helper.h
@@ -36,7 +36,7 @@ extern void render_text_align(rect_ui16_t rc, const char *text, font_t *font, co
 
 extern void scroll_text_phasing(int16_t win_id, font_t * font, txtroll_t * roll);
 
-extern void render_scroll_text_align(uint8_t focus, rect_ui16_t rc, const char *text, font_t *font,
+extern void render_scroll_text_align(rect_ui16_t rc, const char *text, font_t *font,
     padding_ui8_t padding, uint8_t alignment, color_t clr0, color_t clr1, txtroll_t * roll);
 
 extern void render_icon_align(rect_ui16_t rc, uint16_t id_res, color_t clr0, uint16_t flags);

--- a/src/guiapi/include/display_helper.h
+++ b/src/guiapi/include/display_helper.h
@@ -9,11 +9,35 @@
 #define RENDER_FLG_WORDB 0x1000 // multiline text
 #define RENDER_FLG(a, r) (a | r << 8) // render flag macro (ALIGN and ROPFN)
 
+#define TEXT_ROLL_DELAY_MS 50
+#define TEXT_ROLL_INITIAL_DELAY_MS 4000
+
 #ifdef __cplusplus
 extern "C" {
 #endif //__cplusplus
 
+typedef enum {
+    ROLL_SETUP = 0,
+    ROLL_GO,
+    ROLL_STOP,
+    ROLL_RESTART,
+} TXTROLL_PHASE_t;
+
+typedef struct _txtroll_t {
+    uint8_t phase;
+    uint8_t setup;
+    uint16_t progress;
+    uint16_t count;
+    uint8_t px_cd;
+    rect_ui16_t rect;
+} txtroll_t;
+
 extern void render_text_align(rect_ui16_t rc, const char *text, font_t *font, color_t clr0, color_t clr1, padding_ui8_t padding, uint16_t flags);
+
+extern void scroll_text_phasing(int16_t win_id, font_t * font, txtroll_t * roll);
+
+extern void render_scroll_text_align(uint8_t focus, rect_ui16_t rc, const char *text, font_t *font,
+    padding_ui8_t padding, uint8_t alignment, color_t clr0, color_t clr1, txtroll_t * roll);
 
 extern void render_icon_align(rect_ui16_t rc, uint16_t id_res, color_t clr0, uint16_t flags);
 

--- a/src/guiapi/include/display_helper.h
+++ b/src/guiapi/include/display_helper.h
@@ -24,12 +24,12 @@ typedef enum {
 } TXTROLL_PHASE_t;
 
 typedef struct _txtroll_t {
-    uint8_t phase;
-    uint8_t setup;
+    rect_ui16_t rect;
     uint16_t progress;
     uint16_t count;
+    uint8_t phase;
+    uint8_t setup;
     uint8_t px_cd;
-    rect_ui16_t rect;
 } txtroll_t;
 
 extern void render_text_align(rect_ui16_t rc, const char *text, font_t *font, color_t clr0, color_t clr1, padding_ui8_t padding, uint16_t flags);

--- a/src/guiapi/include/gui.h
+++ b/src/guiapi/include/gui.h
@@ -24,6 +24,7 @@
     #include "window_menu.h"
     #include "window_msgbox.h"
     #include "window_progress.h"
+    #include "window_scroll_text.h"
     #include "screen.h"
 #endif //GUI_WINDOW_SUPPORT
 

--- a/src/guiapi/include/gui_timer.h
+++ b/src/guiapi/include/gui_timer.h
@@ -14,6 +14,8 @@ extern int8_t gui_timer_create_oneshot(uint32_t ms, int16_t win_id);
 
 extern int8_t gui_timer_create_timeout(uint32_t ms, int16_t win_id);
 
+extern int8_t gui_timer_create_txtroll(uint32_t ms, int16_t win_id);
+
 extern void gui_timer_delete(int8_t id);
 
 extern void gui_timers_delete_by_window_id(int16_t win_id);
@@ -23,6 +25,10 @@ extern uint32_t gui_timers_cycle(void);
 extern void gui_timer_reset(int8_t id);
 
 extern int8_t gui_timer_expired(int8_t id);
+
+extern void gui_timer_change_txtroll_peri_delay(uint32_t ms, int16_t win_id);
+
+extern void gui_timer_restart_txtroll(int16_t win_id);
 
 extern int8_t gui_get_menu_timeout_id(void);
 

--- a/src/guiapi/include/guitypes.h
+++ b/src/guiapi/include/guitypes.h
@@ -192,6 +192,10 @@ extern rect_ui16_t rect_align_ui16(rect_ui16_t rc, rect_ui16_t rc1, uint8_t alig
 
 extern point_ui16_t font_meas_text(font_t *pf, const char *str);
 
+extern uint16_t text_rolls_meas(rect_ui16_t rc, const char *text, font_t *pf);
+
+extern rect_ui16_t roll_text_rect_meas(rect_ui16_t rc, const char *text, font_t *font, padding_ui8_t padding, uint16_t flags);
+
 extern int font_line_chars(font_t *pf, const char *str, uint16_t line_width);
 
 extern point_ui16_t icon_meas(const uint8_t *pi);

--- a/src/guiapi/include/window.h
+++ b/src/guiapi/include/window.h
@@ -18,6 +18,7 @@
 #define WINDOW_CLS_MENU 9 // MENU - menu
 #define WINDOW_CLS_MSGBOX 10 // MSGBOX - messagebox with configurable buttons and icon
 #define WINDOW_CLS_PROGRESS 11 // PROGRESS - progress bar with text
+#define WINDOW_CLS_SCROLL_TEXT 12 //SCROLL TEXT - rolling text for too long names
 #define WINDOW_CLS_USER 128 // USER - user defined window classes (WINDOW_CLS_USER+n)
 
 //window flags

--- a/src/guiapi/include/window_menu.h
+++ b/src/guiapi/include/window_menu.h
@@ -4,6 +4,7 @@
 #define _WINDOW_MENU_H
 
 #include "window.h"
+#include "display_helper.h"
 
 typedef struct _window_menu_t window_menu_t;
 
@@ -97,6 +98,9 @@ typedef struct _window_menu_t {
     void *data;
     uint8_t src_event; // source event
     void *src_param; // source event data
+    txtroll_t roll; // text roll variables for too long text
+    uint8_t last_index;
+    uint32_t long_text_flg;
 } window_menu_t;
 
 #pragma pack(pop)

--- a/src/guiapi/include/window_menu.h
+++ b/src/guiapi/include/window_menu.h
@@ -100,7 +100,6 @@ typedef struct _window_menu_t {
     void *src_param; // source event data
     txtroll_t roll; // text roll variables for too long text
     uint8_t last_index;
-    uint32_t long_text_flg;
 } window_menu_t;
 
 #pragma pack(pop)

--- a/src/guiapi/include/window_scroll_text.h
+++ b/src/guiapi/include/window_scroll_text.h
@@ -4,12 +4,28 @@
 
 #include "window.h"
 
-#define TEXT_ROLL_DELAY_MS 100
-#define TEXT_ROLL_INITIAL_DELAY_MS 1000
+#define TEXT_ROLL_DELAY_MS 500
+#define TEXT_ROLL_INITIAL_DELAY_MS 4000
+
+typedef enum {
+    ROLL_SETUP = 0,
+    ROLL_GO = 1,
+    ROLL_STOP = 2,
+    ROLL_RESTART = 3,
+} TXTROLL_PHASE_t;
 
 typedef struct _window_class_scroll_text_t {
     window_class_t cls;
 } window_class_scroll_text_t;
+
+typedef struct _txtroll_t {
+    uint8_t phase;
+    uint8_t setup;
+    uint16_t progress;
+    uint16_t count;
+    uint8_t px_cd;
+    rect_ui16_t rect;
+} txtroll_t;
 
 typedef struct _window_scroll_text_t {
     window_t win;
@@ -19,11 +35,7 @@ typedef struct _window_scroll_text_t {
     char *text;
     padding_ui8_t padding;
     uint8_t alignment;
-    uint8_t roll_flag;
-    uint16_t roll_progress;
-    uint16_t roll_count;
-    uint8_t width_countdown;
-    rect_ui16_t text_rect;
+    txtroll_t roll;
 } window_scroll_text_t;
 
 #ifdef __cplusplus

--- a/src/guiapi/include/window_scroll_text.h
+++ b/src/guiapi/include/window_scroll_text.h
@@ -16,7 +16,12 @@ typedef struct _window_scroll_text_t {
     char *text;
     padding_ui8_t padding;
     uint8_t alignment;
+    uint8_t roll_flag;
     uint32_t timer;
+    uint16_t roll_progress;
+    uint16_t roll_count;
+    uint8_t width_countdown;
+    rect_ui16_t text_rect;
 } window_scroll_text_t;
 
 #ifdef __cplusplus

--- a/src/guiapi/include/window_scroll_text.h
+++ b/src/guiapi/include/window_scroll_text.h
@@ -3,29 +3,11 @@
 #define WINDOW_SCROLL_TEXT_H
 
 #include "window.h"
-
-#define TEXT_ROLL_DELAY_MS 50
-#define TEXT_ROLL_INITIAL_DELAY_MS 4000
-
-typedef enum {
-    ROLL_SETUP = 0,
-    ROLL_GO,
-    ROLL_STOP,
-    ROLL_RESTART,
-} TXTROLL_PHASE_t;
+#include "display_helper.h"
 
 typedef struct _window_class_scroll_text_t {
     window_class_t cls;
 } window_class_scroll_text_t;
-
-typedef struct _txtroll_t {
-    uint8_t phase;
-    uint8_t setup;
-    uint16_t progress;
-    uint16_t count;
-    uint8_t px_cd;
-    rect_ui16_t rect;
-} txtroll_t;
 
 typedef struct _window_scroll_text_t {
     window_t win;

--- a/src/guiapi/include/window_scroll_text.h
+++ b/src/guiapi/include/window_scroll_text.h
@@ -1,0 +1,32 @@
+
+#ifndef WINDOW_SCROLL_TEXT_H
+#define WINDOW_SCROLL_TEXT_H
+
+#include "window.h"
+
+typedef struct _window_class_scroll_text_t {
+    window_class_t cls;
+} window_class_scroll_text_t;
+
+typedef struct _window_scroll_text_t {
+    window_t win;
+    color_t color_back;
+    color_t color_text;
+    font_t *font;
+    char *text;
+    padding_ui8_t padding;
+    uint8_t alignment;
+    uint32_t timer;
+} window_scroll_text_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
+extern const window_class_scroll_text_t window_class_scroll_text;
+
+#ifdef __cplusplus
+}
+#endif //__cplusplus
+
+#endif //WINDOW_SCROLL_TEXT_H

--- a/src/guiapi/include/window_scroll_text.h
+++ b/src/guiapi/include/window_scroll_text.h
@@ -4,14 +4,14 @@
 
 #include "window.h"
 
-#define TEXT_ROLL_DELAY_MS 500
+#define TEXT_ROLL_DELAY_MS 50
 #define TEXT_ROLL_INITIAL_DELAY_MS 4000
 
 typedef enum {
     ROLL_SETUP = 0,
-    ROLL_GO = 1,
-    ROLL_STOP = 2,
-    ROLL_RESTART = 3,
+    ROLL_GO,
+    ROLL_STOP,
+    ROLL_RESTART,
 } TXTROLL_PHASE_t;
 
 typedef struct _window_class_scroll_text_t {

--- a/src/guiapi/include/window_scroll_text.h
+++ b/src/guiapi/include/window_scroll_text.h
@@ -4,6 +4,9 @@
 
 #include "window.h"
 
+#define TEXT_ROLL_DELAY_MS 100
+#define TEXT_ROLL_INITIAL_DELAY_MS 1000
+
 typedef struct _window_class_scroll_text_t {
     window_class_t cls;
 } window_class_scroll_text_t;
@@ -17,7 +20,6 @@ typedef struct _window_scroll_text_t {
     padding_ui8_t padding;
     uint8_t alignment;
     uint8_t roll_flag;
-    uint32_t timer;
     uint16_t roll_progress;
     uint16_t roll_count;
     uint8_t width_countdown;

--- a/src/guiapi/src/display_helper.c
+++ b/src/guiapi/src/display_helper.c
@@ -64,7 +64,7 @@ void scroll_text_phasing(int16_t win_id, font_t * font, txtroll_t * roll){
 
     switch (roll->phase) {
         case ROLL_SETUP:
-            gui_timer_create_periodical(TEXT_ROLL_DELAY_MS, win_id);
+            gui_timer_change_txtroll_peri_delay(TEXT_ROLL_DELAY_MS, win_id);
             if (roll->setup == 1)
                 roll->phase = ROLL_GO;
             window_invalidate(win_id);
@@ -83,14 +83,11 @@ void scroll_text_phasing(int16_t win_id, font_t * font, txtroll_t * roll){
             }
             break;
         case ROLL_STOP:
-            gui_timers_delete_by_window_id(win_id);
             roll->phase = ROLL_RESTART;
-            gui_timer_create_oneshot(TEXT_ROLL_INITIAL_DELAY_MS, win_id);
-            window_invalidate(win_id);
+            gui_timer_change_txtroll_peri_delay(TEXT_ROLL_INITIAL_DELAY_MS, win_id);
             break;
         case ROLL_RESTART:
             roll->setup = 0;
-            gui_timer_create_oneshot(TEXT_ROLL_INITIAL_DELAY_MS, win_id);
             roll->phase = ROLL_SETUP;
             window_invalidate(win_id);
             break;

--- a/src/guiapi/src/display_helper.c
+++ b/src/guiapi/src/display_helper.c
@@ -40,10 +40,14 @@ void render_text_align(rect_ui16_t rc, const char *text, font_t *font, color_t c
         if (wh_txt.x && wh_txt.y) {
             rect_ui16_t rc_txt = rect_align_ui16(rc_pad, rect_ui16(0, 0, wh_txt.x, wh_txt.y), flags & ALIGN_MASK);
             rc_txt = rect_intersect_ui16(rc_pad, rc_txt);
+            uint8_t unused_pxls = 0;
+            if(strlen(text) * font->w > rc_txt.w){
+                unused_pxls = rc_txt.w % font->w;
+            }
             rect_ui16_t rc_t = { rc.x, rc.y, rc.w, rc_txt.y - rc.y };
             rect_ui16_t rc_b = { rc.x, rc_txt.y + rc_txt.h, rc.w, (rc.y + rc.h) - (rc_txt.y + rc_txt.h) };
             rect_ui16_t rc_l = { rc.x, rc.y, rc_txt.x - rc.x, rc.h };
-            rect_ui16_t rc_r = { rc_txt.x + rc_txt.w, rc.y, (rc.x + rc.w) - (rc_txt.x + rc_txt.w), rc.h };
+            rect_ui16_t rc_r = { rc_txt.x + rc_txt.w - unused_pxls, rc.y, (rc.x + rc.w) - (rc_txt.x + rc_txt.w) + unused_pxls, rc.h };
             display->fill_rect(rc_t, clr0);
             display->fill_rect(rc_b, clr0);
             display->fill_rect(rc_l, clr0);
@@ -105,10 +109,16 @@ void render_scroll_text_align(rect_ui16_t rc, const char *text, font_t *font,
         roll->rect = roll_text_rect_meas(rc, text, font, padding, alignment);
         roll->count = text_rolls_meas(roll->rect, text, font);
         roll->progress = roll->px_cd = roll->phase = 0;
-        if(roll->count == 0)
+        if(roll->count == 0) {
             roll->setup = 2;
-        else
+        } else {
+            uint8_t unused_pxls = roll->rect.w % font->w;
+            if (unused_pxls) {
+                rect_ui16_t rc_unused_pxls = {roll->rect.x + roll->rect.w - unused_pxls, roll->rect.y, unused_pxls, roll->rect.h};
+                display->fill_rect(rc_unused_pxls, clr_back);
+            }
             roll->setup = 1;
+        }
     }
 
     const char *str = text;

--- a/src/guiapi/src/display_helper.c
+++ b/src/guiapi/src/display_helper.c
@@ -53,6 +53,8 @@ void render_text_align(rect_ui16_t rc, const char *text, font_t *font, color_t c
 }
 
 void scroll_text_phasing(int16_t win_id, font_t * font, txtroll_t * roll){
+    if(roll->setup == 2)
+        return;
 
     switch (roll->phase) {
         case ROLL_SETUP:
@@ -100,8 +102,11 @@ void render_scroll_text_align(uint8_t focus, rect_ui16_t rc, const char *text, f
     if (roll->setup == 0) {
         roll->rect = roll_text_rect_meas(rc, text, font, padding, alignment);
         roll->count = text_rolls_meas(roll->rect, text, font);
-        roll->progress = roll->px_cd = 0;
-        roll->setup = 1;
+        roll->progress = roll->px_cd = roll->phase = 0;
+        if(roll->count == 0)
+            roll->setup = 2;
+        else
+            roll->setup = 1;
     }
 
     const char *str = text;

--- a/src/guiapi/src/display_helper.c
+++ b/src/guiapi/src/display_helper.c
@@ -2,6 +2,8 @@
 
 #include "display_helper.h"
 #include "display.h"
+#include "gui_timer.h"
+#include "window.h"
 
 void render_text_align(rect_ui16_t rc, const char *text, font_t *font, color_t clr0, color_t clr1, padding_ui8_t padding, uint16_t flags) {
     rect_ui16_t rc_pad = rect_ui16_sub_padding_ui8(rc, padding);
@@ -91,11 +93,11 @@ void scroll_text_phasing(int16_t win_id, font_t * font, txtroll_t * roll){
     }
 }
 
-void render_scroll_text_align(uint8_t focus, rect_ui16_t rc, const char *text, font_t *font,
+void render_scroll_text_align(rect_ui16_t rc, const char *text, font_t *font,
     padding_ui8_t padding, uint8_t alignment, color_t clr_back, color_t clr_text, txtroll_t * roll) {
 
     if (text == 0) {
-        display->fill_rect(rc, focus ? clr_text : clr_back);
+        display->fill_rect(rc, clr_back);
         return;
     }
 
@@ -122,15 +124,15 @@ void render_scroll_text_align(uint8_t focus, rect_ui16_t rc, const char *text, f
         rect_ui16_t rc_t = { rc.x, rc.y, rc.w, set_txt_rc.y - rc.y };
         rect_ui16_t rc_b = { rc.x, set_txt_rc.y + set_txt_rc.h, rc.w, (rc.y + rc.h) - (set_txt_rc.y + set_txt_rc.h) };
         rect_ui16_t rc_l = { rc.x, rc.y, set_txt_rc.x - rc.x, rc.h };
-        rect_ui16_t rc_r = { rc.x + set_txt_rc.w, rc.y, (rc.x + rc.w) - (set_txt_rc.x + set_txt_rc.w), rc.h };
-        display->fill_rect(rc_t, focus ? clr_text : clr_back);
-        display->fill_rect(rc_b, focus ? clr_text : clr_back);
-        display->fill_rect(rc_l, focus ? clr_text : clr_back);
-        display->fill_rect(rc_r, focus ? clr_text : clr_back);
+        rect_ui16_t rc_r = { set_txt_rc.x + set_txt_rc.w, rc.y, (rc.x + rc.w) - (set_txt_rc.x + set_txt_rc.w), rc.h };
+        display->fill_rect(rc_t, clr_back);
+        display->fill_rect(rc_b, clr_back);
+        display->fill_rect(rc_l, clr_back);
+        display->fill_rect(rc_r, clr_back);
 
-        display->draw_text(set_txt_rc, str, font, focus ? clr_text : clr_back, focus ? clr_back : clr_text);
+        display->draw_text(set_txt_rc, str, font, clr_back, clr_text);
     } else {
-        display->fill_rect(rc, focus ? clr_text : clr_back);
+        display->fill_rect(rc, clr_back);
     }
 }
 

--- a/src/guiapi/src/gui_timer.c
+++ b/src/guiapi/src/gui_timer.c
@@ -11,6 +11,7 @@
 #define GUI_TIMER_1SHT 1
 #define GUI_TIMER_PERI 2
 #define GUI_MENU_TIMEOUT 3
+#define GUI_TIMER_TXTROLL 4
 
 #pragma pack(push)
 #pragma pack(1)
@@ -22,8 +23,8 @@ typedef struct _gui_timer_t {
         uint32_t flags : 8;
         struct
         {
-            uint32_t f_reserved0 : 6;
-            uint32_t f_timer : 2;
+            uint32_t f_reserved0 : 5;
+            uint32_t f_timer : 3;
         };
     };
     int16_t win_id;
@@ -69,6 +70,10 @@ int8_t gui_timer_create_oneshot(uint32_t ms, int16_t win_id) {
 
 int8_t gui_timer_create_periodical(uint32_t ms, int16_t win_id) {
     return gui_timer_new(GUI_TIMER_PERI, ms, win_id);
+}
+
+int8_t gui_timer_create_txtroll(uint32_t ms, int16_t win_id) {
+    return gui_timer_new(GUI_TIMER_TXTROLL, ms, win_id);
 }
 
 int8_t gui_timer_create_timeout(uint32_t ms, int16_t win_id) {
@@ -120,6 +125,10 @@ uint32_t gui_timers_cycle(void) {
                     case GUI_MENU_TIMEOUT:
                         gui_timers[id].delay = 0;
                         break;
+                    case GUI_TIMER_TXTROLL:
+                        screen_dispatch_event(window_ptr(gui_timers[id].win_id), WINDOW_EVENT_TIMER, (void *)(int)id);
+                        gui_timers[id].start = tick;
+                        break;
                     }
                 } else if (diff_min < diff)
                     diff_min = diff;
@@ -142,6 +151,28 @@ int8_t gui_timer_expired(int8_t id) {
         return gui_timers[id].delay == 0 ? 1 : 0;
 
     return -1;
+}
+
+void gui_timer_change_txtroll_peri_delay(uint32_t ms, int16_t win_id){
+    if (gui_timer_count != -1){
+        for (uint8_t id = 0; id < GUI_MAX_TIMERS; id++){
+            if (gui_timers[id].win_id == win_id){
+                gui_timers[id].delay = ms;
+                break;
+            }
+        }
+    }
+}
+
+void gui_timer_restart_txtroll(int16_t win_id){
+    if (gui_timer_count != -1){
+        for (uint8_t id = 0; id < GUI_MAX_TIMERS; id++){
+            if (gui_timers[id].win_id == win_id){
+                gui_timers[id].start = HAL_GetTick();
+                break;
+            }
+        }
+    }
 }
 
 int8_t gui_get_menu_timeout_id(void) {

--- a/src/guiapi/src/guitypes.c
+++ b/src/guiapi/src/guitypes.c
@@ -121,11 +121,9 @@ point_ui16_t font_meas_text(font_t *pf, const char *str) {
 
 uint16_t text_rolls_meas(rect_ui16_t rc, const char *text, font_t *pf) {
 
-    uint16_t meas_x, len = strlen(text);
-    if (rc.h < pf->h || len * pf->w < rc.w)
-        return 0;
-    meas_x = len * pf->w - rc.w;
-    meas_x /= pf->w;
+    uint16_t meas_x = 0, len = strlen(text);
+    if (len * pf->w > rc.w)
+        meas_x = len - rc.w / pf->w;
     return meas_x;
 }
 

--- a/src/guiapi/src/guitypes.c
+++ b/src/guiapi/src/guitypes.c
@@ -119,6 +119,29 @@ point_ui16_t font_meas_text(font_t *pf, const char *str) {
     return point_ui16((uint16_t)w, (uint16_t)h);
 }
 
+uint16_t text_rolls_meas(rect_ui16_t rc, const char *text, font_t *pf) {
+
+    uint16_t meas_x, len = strlen(text);
+    if (rc.h < pf->h || len * pf->w < rc.w)
+        return 0;
+    meas_x = len * pf->w - rc.w;
+    meas_x /= pf->w;
+    return meas_x;
+}
+
+rect_ui16_t roll_text_rect_meas(rect_ui16_t rc, const char *text, font_t *font, padding_ui8_t padding, uint16_t flags) {
+
+    rect_ui16_t rc_pad = rect_ui16_sub_padding_ui8(rc, padding);
+    point_ui16_t wh_txt = font_meas_text(font, text);
+    if (wh_txt.x && wh_txt.y) {
+        rect_ui16_t rc_txt = rect_align_ui16(rc_pad, rect_ui16(0, 0, wh_txt.x, wh_txt.y), flags & ALIGN_MASK);
+        rc_txt = rect_intersect_ui16(rc_pad, rc_txt);
+        return rc_txt;
+    }
+    rect_ui16_t empty = { 0, 0, 0, 0 };
+    return empty;
+}
+
 int font_line_chars(font_t *pf, const char *str, uint16_t line_width) {
     int w = 0;
     int char_w = pf->w;

--- a/src/guiapi/src/guitypes.c
+++ b/src/guiapi/src/guitypes.c
@@ -131,13 +131,12 @@ rect_ui16_t roll_text_rect_meas(rect_ui16_t rc, const char *text, font_t *font, 
 
     rect_ui16_t rc_pad = rect_ui16_sub_padding_ui8(rc, padding);
     point_ui16_t wh_txt = font_meas_text(font, text);
+    rect_ui16_t rc_txt = {0,0,0,0};
     if (wh_txt.x && wh_txt.y) {
-        rect_ui16_t rc_txt = rect_align_ui16(rc_pad, rect_ui16(0, 0, wh_txt.x, wh_txt.y), flags & ALIGN_MASK);
+        rc_txt = rect_align_ui16(rc_pad, rect_ui16(0, 0, wh_txt.x, wh_txt.y), flags & ALIGN_MASK);
         rc_txt = rect_intersect_ui16(rc_pad, rc_txt);
-        return rc_txt;
     }
-    rect_ui16_t empty = { 0, 0, 0, 0 };
-    return empty;
+    return rc_txt;
 }
 
 int font_line_chars(font_t *pf, const char *str, uint16_t line_width) {

--- a/src/guiapi/src/window.c
+++ b/src/guiapi/src/window.c
@@ -444,6 +444,9 @@ void window_set_color_back(int16_t id, color_t clr) {
         case WINDOW_CLS_TEXT:
             ((window_text_t *)window)->color_back = clr;
             break;
+        case WINDOW_CLS_SCROLL_TEXT:
+            ((window_scroll_text_t *)window)->color_back = clr;
+            break;
         }
         _window_invalidate((window_t *)window);
     }
@@ -455,6 +458,8 @@ color_t window_get_color_back(int16_t id) {
         switch (window->cls->cls_id) {
         case WINDOW_CLS_TEXT:
             return ((window_text_t *)window)->color_back;
+        case WINDOW_CLS_SCROLL_TEXT:
+            return ((window_scroll_text_t *)window)->color_back;
         }
     }
     return COLOR_BLACK;
@@ -467,6 +472,9 @@ void window_set_color_text(int16_t id, color_t clr) {
         case WINDOW_CLS_TEXT:
             ((window_text_t *)window)->color_text = clr;
             break;
+        case WINDOW_CLS_SCROLL_TEXT:
+            ((window_scroll_text_t *)window)->color_text = clr;
+            break;
         }
         _window_invalidate((window_t *)window);
     }
@@ -478,6 +486,8 @@ color_t window_get_color_text(int16_t id) {
         switch (window->cls->cls_id) {
         case WINDOW_CLS_TEXT:
             return ((window_text_t *)window)->color_text;
+        case WINDOW_CLS_SCROLL_TEXT:
+            return ((window_scroll_text_t *)window)->color_text;
         }
     }
     return COLOR_BLACK;
@@ -559,6 +569,9 @@ void window_set_padding(int16_t id, padding_ui8_t padding) {
         case WINDOW_CLS_TEXT:
             ((window_text_t *)window)->padding = padding;
             break;
+        case WINDOW_CLS_SCROLL_TEXT:
+            ((window_scroll_text_t *)window)->padding = padding;
+            break;
         }
         _window_invalidate((window_t *)window);
     }
@@ -570,6 +583,9 @@ void window_set_alignment(int16_t id, uint8_t alignment) {
         switch (window->cls->cls_id) {
         case WINDOW_CLS_TEXT:
             ((window_text_t *)window)->alignment = alignment;
+            break;
+        case WINDOW_CLS_SCROLL_TEXT:
+            ((window_scroll_text_t *)window)->alignment = alignment;
             break;
         }
         _window_invalidate((window_t *)window);

--- a/src/guiapi/src/window.c
+++ b/src/guiapi/src/window.c
@@ -33,6 +33,7 @@ const window_class_t *window_classes[] = {
     (window_class_t *)(&window_class_menu), //  9  MENU
     (window_class_t *)(&window_class_msgbox), // 10  MSGBOX
     (window_class_t *)(&window_class_progress), // 11  PROGRESS
+    (window_class_t *)(&window_class_scroll_text), // 12 SCROLL_TEXT
 };
 
 const uint16_t window_class_count = sizeof(window_classes) / sizeof(window_class_t *);
@@ -344,6 +345,9 @@ void window_set_text(int16_t id, const char *text) {
         case WINDOW_CLS_TEXT:
             ((window_text_t *)window)->text = (char *)text;
             break;
+        case WINDOW_CLS_SCROLL_TEXT:
+            ((window_scroll_text_t *)window)->text = (char *)text;
+            break;
         }
         _window_invalidate((window_t *)window);
     }
@@ -355,6 +359,8 @@ char *window_get_text(int16_t id) {
         switch (window->cls->cls_id) {
         case WINDOW_CLS_TEXT:
             return ((window_text_t *)window)->text;
+        case WINDOW_CLS_SCROLL_TEXT:
+            return ((window_scroll_text_t *)window)->text;
         }
     }
     return 0;

--- a/src/guiapi/src/window_menu.c
+++ b/src/guiapi/src/window_menu.c
@@ -157,14 +157,13 @@ void window_menu_draw(window_menu_t *window) {
                     gui_timer_create_oneshot(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
                 }
 
-                render_scroll_text_align(1,
-                    rc,
+                render_scroll_text_align(rc,
                     item->label,
                     window->font,
                     padding,
                     window->alignment,
-                    color_text,
                     color_back,
+                    color_text,
                     &window->roll);
             } else {
                 render_text_align(rc, item->label, window->font,

--- a/src/guiapi/src/window_menu.c
+++ b/src/guiapi/src/window_menu.c
@@ -42,7 +42,8 @@ void window_menu_init(window_menu_t *window) {
     window->data = NULL;
     window->win.flg |= WINDOW_FLG_ENABLED;
     window->roll.count = window->roll.px_cd = window->roll.phase = window->roll.setup = window->roll.progress = 0;
-    window->last_index = 20;    //just a value different from index;
+    window->last_index = 0;
+    gui_timer_create_txtroll(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
 }
 
 void window_menu_done(window_menu_t *window) {
@@ -152,9 +153,9 @@ void window_menu_draw(window_menu_t *window) {
             if((window->win.flg & WINDOW_FLG_FOCUSED) && window->index == idx){
                 if(window->index != window->last_index){
                     window->last_index = window->index;
-                    gui_timers_delete_by_window_id(window->win.id);
                     window->roll.setup = window->roll.phase = 0;
-                    gui_timer_create_oneshot(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
+                    gui_timer_restart_txtroll(window->win.id);
+                    gui_timer_change_txtroll_peri_delay(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
                 }
 
                 render_scroll_text_align(rc,

--- a/src/guiapi/src/window_scroll_text.c
+++ b/src/guiapi/src/window_scroll_text.c
@@ -21,8 +21,7 @@ void window_scroll_text_draw(window_scroll_text_t *window) {
 
     if (((window->win.flg & (WINDOW_FLG_INVALID | WINDOW_FLG_VISIBLE)) == (WINDOW_FLG_INVALID | WINDOW_FLG_VISIBLE))) {
 
-        render_scroll_text_align( (window->win.flg & WINDOW_FLG_FOCUSED) ? 1 : 0,
-            window->win.rect,
+        render_scroll_text_align( window->win.rect,
             window->text,
             window->font,
             window->padding,

--- a/src/guiapi/src/window_scroll_text.c
+++ b/src/guiapi/src/window_scroll_text.c
@@ -3,6 +3,7 @@
  */
 
 #include "window_scroll_text.h"
+#include "gui_timer.h"
 #include "gui.h"
 #include "stm32f4xx_hal.h"
 #include "display.h"
@@ -15,6 +16,7 @@ void window_scroll_text_init(window_scroll_text_t *window) {
     window->padding = gui_defaults.padding;
     window->alignment = gui_defaults.alignment;
     window->roll.phase = window->roll.setup = window->roll.px_cd = window->roll.count = 0;
+    gui_timer_create_txtroll(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
 }
 
 void window_scroll_text_draw(window_scroll_text_t *window) {

--- a/src/guiapi/src/window_scroll_text.c
+++ b/src/guiapi/src/window_scroll_text.c
@@ -4,12 +4,100 @@
 
 #include "window_scroll_text.h"
 #include "gui.h"
+#include "stm32f4xx_hal.h"
+#include "display.h"
+#include "display_helper.h"
+
+#define TEXT_ROLL_DELAY_MS 100
+#define TEXT_ROLL_INITIAL_DELAY_MS 1000
 
 void window_scroll_text_init(window_scroll_text_t *window) {
     window->color_back = gui_defaults.color_back;
     window->color_text = gui_defaults.color_text;
     window->font = gui_defaults.font;
     window->text = 0;
+    window->width_countdown = 0;
     window->padding = gui_defaults.padding;
     window->alignment = gui_defaults.alignment;
+    window->roll_progress = window->roll_count = window->timer = 0;
 }
+
+void window_scroll_text_draw(window_scroll_text_t *window) {
+
+    if (window->roll_flag == 0) {
+        window->text_rect = roll_text_rect_meas(window->win.rect, window->text, window->font, window->padding, window->alignment);
+        window->timer = HAL_GetTick();
+        window->roll_progress = window->width_countdown = 0;
+    }
+
+    if (window->roll_flag == 0 && HAL_GetTick() - window->timer >= TEXT_ROLL_INITIAL_DELAY_MS) {
+        window->roll_flag = 1;
+        window->roll_count = text_rolls_meas(window->text_rect, window->text, window->font);
+        window->timer = HAL_GetTick();
+    }
+
+    if (window->roll_flag & 1 && HAL_GetTick() - window->timer >= TEXT_ROLL_DELAY_MS) {
+        window->timer = HAL_GetTick();
+        window->win.flg |= WINDOW_FLG_INVALID;
+    }
+
+    if (((window->win.flg & (WINDOW_FLG_INVALID | WINDOW_FLG_VISIBLE)) == (WINDOW_FLG_INVALID | WINDOW_FLG_VISIBLE))) {
+        /*       render_scroll_text_align(window->win.rect,
+            window->text,
+            window->font,
+            (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back,
+            (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_back : window->color_text,
+            window->text_rect,
+            window->roll_flag,
+            window->roll_progress,
+            window->roll_count,
+            window->width_countdown);
+*/
+
+        const char *str = window->text;
+
+        rect_ui16_t set_txt_rc = window->text_rect;
+        if (window->roll_count) {
+            if (window->width_countdown == 0) {
+                window->width_countdown = window->font->w - 1;
+                window->roll_count--;
+                window->roll_progress++;
+            } else {
+                str += 1 + window->roll_progress / window->font->w;
+                set_txt_rc.x += window->width_countdown;
+                set_txt_rc.w -= window->width_countdown--;
+            }
+        } else {
+            window->roll_flag = 0;
+        }
+
+        if (set_txt_rc.w && set_txt_rc.h) {
+            rect_ui16_t rc_t = { window->win.rect.x, window->win.rect.y, window->win.rect.w, set_txt_rc.y - window->win.rect.y };
+            rect_ui16_t rc_b = { window->win.rect.x, set_txt_rc.y + set_txt_rc.h, window->win.rect.w, (window->win.rect.y + window->win.rect.h) - (set_txt_rc.y + set_txt_rc.h) };
+            rect_ui16_t rc_l = { window->win.rect.x, window->win.rect.y, set_txt_rc.x - window->win.rect.x, window->win.rect.h };
+            rect_ui16_t rc_r = { set_txt_rc.x + set_txt_rc.w, window->win.rect.y, (window->win.rect.x + window->win.rect.w) - (set_txt_rc.x + set_txt_rc.w), window->win.rect.h };
+            display->fill_rect(rc_t, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
+            display->fill_rect(rc_b, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
+            display->fill_rect(rc_l, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
+            display->fill_rect(rc_r, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
+
+            display->draw_text(set_txt_rc, str, window->font, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back,
+                (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_back : window->color_text);
+        } else {
+            display->fill_rect(window->win.rect, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
+        }
+
+        window->win.flg &= ~WINDOW_FLG_INVALID;
+    }
+}
+
+const window_class_scroll_text_t window_class_scroll_text = {
+    {
+        WINDOW_CLS_SCROLL_TEXT,
+        sizeof(window_scroll_text_t),
+        (window_init_t *)window_scroll_text_init,
+        0,
+        (window_draw_t *)window_scroll_text_draw,
+        0,
+    },
+};

--- a/src/guiapi/src/window_scroll_text.c
+++ b/src/guiapi/src/window_scroll_text.c
@@ -71,7 +71,6 @@ void window_scroll_text_draw(window_scroll_text_t *window) {
         } else {
             display->fill_rect(window->win.rect, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
         }
-
         window->win.flg &= ~WINDOW_FLG_INVALID;
     }
 }
@@ -81,7 +80,6 @@ void window_scroll_text_event(window_scroll_text_t *window, uint8_t event, void 
 
         switch (window->roll.phase) {
         case ROLL_SETUP:
-            gui_timers_delete_by_window_id(window->win.id);
             gui_timer_create_periodical(TEXT_ROLL_DELAY_MS, window->win.id);
             if (window->roll.setup == 1)
                 window->roll.phase = ROLL_GO;
@@ -102,12 +100,13 @@ void window_scroll_text_event(window_scroll_text_t *window, uint8_t event, void 
             break;
         case ROLL_STOP:
             gui_timers_delete_by_window_id(window->win.id);
-            gui_timer_create_periodical(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
             window->roll.phase = ROLL_RESTART;
+            gui_timer_create_oneshot(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
             window_invalidate(window->win.id);
             break;
         case ROLL_RESTART:
             window->roll.setup = 0;
+            gui_timer_create_oneshot(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
             window->roll.phase = ROLL_SETUP;
             window_invalidate(window->win.id);
             break;
@@ -116,6 +115,7 @@ void window_scroll_text_event(window_scroll_text_t *window, uint8_t event, void 
 }
 
 void window_scroll_text_done(window_scroll_text_t *window) {
+    gui_timers_delete_by_window_id(window->win.id);
 }
 
 const window_class_scroll_text_t window_class_scroll_text = {

--- a/src/guiapi/src/window_scroll_text.c
+++ b/src/guiapi/src/window_scroll_text.c
@@ -8,9 +8,6 @@
 #include "display.h"
 #include "display_helper.h"
 
-#define TEXT_ROLL_DELAY_MS 100
-#define TEXT_ROLL_INITIAL_DELAY_MS 1000
-
 void window_scroll_text_init(window_scroll_text_t *window) {
     window->color_back = gui_defaults.color_back;
     window->color_text = gui_defaults.color_text;
@@ -19,29 +16,22 @@ void window_scroll_text_init(window_scroll_text_t *window) {
     window->width_countdown = 0;
     window->padding = gui_defaults.padding;
     window->alignment = gui_defaults.alignment;
-    window->roll_progress = window->roll_count = window->timer = 0;
+    window->roll_progress = window->roll_count = window->roll_flag = 0;
 }
 
 void window_scroll_text_draw(window_scroll_text_t *window) {
 
     if (window->roll_flag == 0) {
-        window->text_rect = roll_text_rect_meas(window->win.rect, window->text, window->font, window->padding, window->alignment);
-        window->timer = HAL_GetTick();
-        window->roll_progress = window->width_countdown = 0;
-    }
-
-    if (window->roll_flag == 0 && HAL_GetTick() - window->timer >= TEXT_ROLL_INITIAL_DELAY_MS) {
-        window->roll_flag = 1;
-        window->roll_count = text_rolls_meas(window->text_rect, window->text, window->font);
-        window->timer = HAL_GetTick();
-    }
-
-    if (window->roll_flag & 1 && HAL_GetTick() - window->timer >= TEXT_ROLL_DELAY_MS) {
-        window->timer = HAL_GetTick();
-        window->win.flg |= WINDOW_FLG_INVALID;
+        if (window->text != 0) {
+            window->text_rect = roll_text_rect_meas(window->win.rect, window->text, window->font, window->padding, window->alignment);
+            window->roll_count = text_rolls_meas(window->text_rect, window->text, window->font);
+            window->roll_flag = 1;
+            window->roll_progress = window->width_countdown = 0;
+        }
     }
 
     if (((window->win.flg & (WINDOW_FLG_INVALID | WINDOW_FLG_VISIBLE)) == (WINDOW_FLG_INVALID | WINDOW_FLG_VISIBLE))) {
+
         /*       render_scroll_text_align(window->win.rect,
             window->text,
             window->font,
@@ -52,23 +42,20 @@ void window_scroll_text_draw(window_scroll_text_t *window) {
             window->roll_progress,
             window->roll_count,
             window->width_countdown);
-*/
+        */
+
+        if (window->text == 0) {
+            display->fill_rect(window->win.rect, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
+            return;
+        }
 
         const char *str = window->text;
+        str += window->roll_progress;
 
-        rect_ui16_t set_txt_rc = window->text_rect;
-        if (window->roll_count) {
-            if (window->width_countdown == 0) {
-                window->width_countdown = window->font->w - 1;
-                window->roll_count--;
-                window->roll_progress++;
-            } else {
-                str += 1 + window->roll_progress / window->font->w;
-                set_txt_rc.x += window->width_countdown;
-                set_txt_rc.w -= window->width_countdown--;
-            }
-        } else {
-            window->roll_flag = 0;
+        volatile rect_ui16_t set_txt_rc = window->text_rect;
+        if (window->width_countdown != 0) {
+            set_txt_rc.x += window->width_countdown;
+            set_txt_rc.w -= window->width_countdown--;
         }
 
         if (set_txt_rc.w && set_txt_rc.h) {
@@ -91,13 +78,31 @@ void window_scroll_text_draw(window_scroll_text_t *window) {
     }
 }
 
+void window_scroll_text_event(window_scroll_text_t *window, uint8_t event, void *param) {
+    if (event == WINDOW_EVENT_TIMER) {
+        if (window->roll_count || window->width_countdown) {
+            if (window->width_countdown == 0) {
+                window->width_countdown = window->font->w - 1;
+                window->roll_count--;
+                window->roll_progress++;
+            }
+        } else {
+            window->roll_flag = 0;
+        }
+        window_invalidate(window->win.id);
+    }
+}
+
+void window_scroll_text_done(window_scroll_text_t *window) {
+}
+
 const window_class_scroll_text_t window_class_scroll_text = {
     {
         WINDOW_CLS_SCROLL_TEXT,
         sizeof(window_scroll_text_t),
         (window_init_t *)window_scroll_text_init,
-        0,
+        (window_done_t *)window_scroll_text_done,
         (window_draw_t *)window_scroll_text_draw,
-        0,
+        (window_event_t *)window_scroll_text_event,
     },
 };

--- a/src/guiapi/src/window_scroll_text.c
+++ b/src/guiapi/src/window_scroll_text.c
@@ -1,0 +1,15 @@
+/*
+ * 	window_scroll_text.c
+ */
+
+#include "window_scroll_text.h"
+#include "gui.h"
+
+void window_scroll_text_init(window_scroll_text_t *window) {
+    window->color_back = gui_defaults.color_back;
+    window->color_text = gui_defaults.color_text;
+    window->font = gui_defaults.font;
+    window->text = 0;
+    window->padding = gui_defaults.padding;
+    window->alignment = gui_defaults.alignment;
+}

--- a/src/guiapi/src/window_scroll_text.c
+++ b/src/guiapi/src/window_scroll_text.c
@@ -6,7 +6,6 @@
 #include "gui.h"
 #include "stm32f4xx_hal.h"
 #include "display.h"
-//#include "display_helper.h"
 
 void window_scroll_text_init(window_scroll_text_t *window) {
     window->color_back = gui_defaults.color_back;
@@ -22,95 +21,23 @@ void window_scroll_text_draw(window_scroll_text_t *window) {
 
     if (((window->win.flg & (WINDOW_FLG_INVALID | WINDOW_FLG_VISIBLE)) == (WINDOW_FLG_INVALID | WINDOW_FLG_VISIBLE))) {
 
-        /*  render_scroll_text_align(window->win.rect,
+        render_scroll_text_align( (window->win.flg & WINDOW_FLG_FOCUSED) ? 1 : 0,
+            window->win.rect,
             window->text,
             window->font,
+            window->padding,
+            window->alignment,
             (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back,
             (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_back : window->color_text,
-            window->text_rect,
-            window->roll_flag,
-            window->roll_progress,
-            window->roll_count,
-            window->width_countdown);
-        */
+            &window->roll);
 
-        if (window->text == 0) {
-            display->fill_rect(window->win.rect, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
-            window->win.flg &= ~WINDOW_FLG_INVALID;
-            return;
-        }
-
-        if (window->roll.setup == 0) {
-            window->roll.rect = roll_text_rect_meas(window->win.rect, window->text, window->font, window->padding, window->alignment);
-            window->roll.count = text_rolls_meas(window->roll.rect, window->text, window->font);
-            window->roll.progress = window->roll.px_cd = 0;
-            window->roll.setup = 1;
-        }
-
-        const char *str = window->text;
-        str += window->roll.progress;
-
-        rect_ui16_t set_txt_rc = window->roll.rect;
-        if (window->roll.px_cd != 0) {
-            set_txt_rc.x += window->roll.px_cd;
-            set_txt_rc.w -= window->roll.px_cd;
-        }
-
-        if (set_txt_rc.w && set_txt_rc.h) {
-            rect_ui16_t rc_t = { window->win.rect.x, window->win.rect.y, window->win.rect.w, set_txt_rc.y - window->win.rect.y };
-            rect_ui16_t rc_b = { window->win.rect.x, set_txt_rc.y + set_txt_rc.h, window->win.rect.w, (window->win.rect.y + window->win.rect.h) - (set_txt_rc.y + set_txt_rc.h) };
-            rect_ui16_t rc_l = { window->win.rect.x, window->win.rect.y, set_txt_rc.x - window->win.rect.x, window->win.rect.h };
-            rect_ui16_t rc_r = { set_txt_rc.x + set_txt_rc.w, window->win.rect.y, (window->win.rect.x + window->win.rect.w) - (set_txt_rc.x + set_txt_rc.w), window->win.rect.h };
-            display->fill_rect(rc_t, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
-            display->fill_rect(rc_b, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
-            display->fill_rect(rc_l, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
-            display->fill_rect(rc_r, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
-
-            display->draw_text(set_txt_rc, str, window->font, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back,
-                (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_back : window->color_text);
-        } else {
-            display->fill_rect(window->win.rect, (window->win.flg & WINDOW_FLG_FOCUSED) ? window->color_text : window->color_back);
-        }
         window->win.flg &= ~WINDOW_FLG_INVALID;
     }
 }
 
 void window_scroll_text_event(window_scroll_text_t *window, uint8_t event, void *param) {
     if (event == WINDOW_EVENT_TIMER) {
-
-        switch (window->roll.phase) {
-        case ROLL_SETUP:
-            gui_timer_create_periodical(TEXT_ROLL_DELAY_MS, window->win.id);
-            if (window->roll.setup == 1)
-                window->roll.phase = ROLL_GO;
-            window_invalidate(window->win.id);
-            break;
-        case ROLL_GO:
-            if (window->roll.count > 0 || window->roll.px_cd > 0) {
-                if (window->roll.px_cd == 0) {
-                    window->roll.px_cd = window->font->w;
-                    window->roll.count--;
-                    window->roll.progress++;
-                }
-                window->roll.px_cd--;
-                window_invalidate(window->win.id);
-            } else {
-                window->roll.phase = ROLL_STOP;
-            }
-            break;
-        case ROLL_STOP:
-            gui_timers_delete_by_window_id(window->win.id);
-            window->roll.phase = ROLL_RESTART;
-            gui_timer_create_oneshot(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
-            window_invalidate(window->win.id);
-            break;
-        case ROLL_RESTART:
-            window->roll.setup = 0;
-            gui_timer_create_oneshot(TEXT_ROLL_INITIAL_DELAY_MS, window->win.id);
-            window->roll.phase = ROLL_SETUP;
-            window_invalidate(window->win.id);
-            break;
-        }
+        scroll_text_phasing(window->win.id, window->font, &window->roll);
     }
 }
 


### PR DESCRIPTION
A3IDES-446

Text rolling is a new text render function.
Implemented in:
  window_scroll_text_t - class window that can be created with window_create_ptr(WINDOW_CLS_SCROLL_TEXT, ...) (its still buggy in some cases (BIG font), fix is waiting for GUI c++ rework)
  window_menu - if focused menu item is too long, after 4s it starts rolling
  window_file_list - if focused file name is too long, after 4s it starts rolling