### PR TITLE
Zlib causes unaligned access to uint32_t vars, propagated the -mno-un…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,9 +225,11 @@ endif()
 # disable unaligned access
 #
 # * Otherwise, with optimizations turned on, the firmware crashes on startup.
-# * TODO: investigate and potentially turn on again
-# caused by zlib, propagated this switch directly to it, seems to be solved now
-# keeping it commented here for emergency situations ;)
+#
+# The main problem was caused by zlib, thus this switch was propagated directly
+# to it, it seems to be solved now
+# And let's keep this line commented here for emergency situations ;)
+#
 # add_compile_options(-mno-unaligned-access)
 
 # configure linker script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,9 @@ endif()
 #
 # * Otherwise, with optimizations turned on, the firmware crashes on startup.
 # * TODO: investigate and potentially turn on again
-add_compile_options(-mno-unaligned-access)
+# caused by zlib, propagated this switch directly to it, seems to be solved now
+# keeping it commented here for emergency situations ;)
+# add_compile_options(-mno-unaligned-access)
 
 # configure linker script
 if(BOOTLOADER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,9 +226,8 @@ endif()
 #
 # * Otherwise, with optimizations turned on, the firmware crashes on startup.
 #
-# The main problem was caused by zlib, thus this switch was propagated directly
-# to it, it seems to be solved now
-# And let's keep this line commented here for emergency situations ;)
+# The main problem was caused by zlib, thus this switch was propagated directly to it, it seems to
+# be solved now And let's keep this line commented here for emergency situations ;)
 #
 # add_compile_options(-mno-unaligned-access)
 

--- a/lib/Middlewares/Third_Party/zlib/CMakeLists.txt
+++ b/lib/Middlewares/Third_Party/zlib/CMakeLists.txt
@@ -17,4 +17,6 @@ add_library(
   zutil.c
   )
 
+target_compile_options(zlib PUBLIC -mno-unaligned-access)
+
 target_include_directories(zlib PUBLIC .)


### PR DESCRIPTION
…aligned-access just to the zlib library and removed from the whole project for increased speed and shorter code.

A3IDES-563