### PR TITLE
Use crlf on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,3 @@ repos:
       args: [--markdown-linebreak-ext=md]
     - id: end-of-file-fixer
     - id: mixed-line-ending
-      args: ['--fix=lf']

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,5 @@
     "ccls.clang.extraArgs": ["-fno-ms-compatibility"],
     "cmake.buildDirectory": "${workspaceFolder}/build-vscode",
     "cmake.cmakePath": "${workspaceFolder}/.dependencies/cmake-3.15.5/bin/cmake",
-    "cmake.generator": "Ninja",
-    "files.eol": "\n"
+    "cmake.generator": "Ninja"
 }


### PR DESCRIPTION
I think this is the correct solution of CRLF vs LF.
I think it is fool-proof. As .gitattributes configuration has precedence over global configuration.
But it is not safe against malicious committer, as he can remove/modify .gitattributes file before commit and don't stage this change.

Alternative solution would be to force check-in as-is check-out as-is in .gitattributes.