### PR TITLE
A3IDES-415 Fix print speed oscillations when printing large circles in high speed.

### DIFF
--- a/include/marlin/Configuration_A3ides_2209_MINI.h
+++ b/include/marlin/Configuration_A3ides_2209_MINI.h
@@ -711,7 +711,7 @@
 //
 // Use Junction Deviation instead of traditional Jerk Limiting
 //
-//#define JUNCTION_DEVIATION
+#define CLASSIC_JERK
 #if DISABLED(CLASSIC_JERK)
     #define JUNCTION_DEVIATION_MM 0.02 // (mm) Distance from real junction edge
 #endif


### PR DESCRIPTION
Fix print speed oscillations when printing large high polygon count circles in high speed.

Those oscillations manifested itself similar to how slowdown due to planner buffer draining looks like.
JUNCTION_DEVIATION was enabled unnoticed when Marlin submodule was updated as this is Marlin's new default.