### PR TITLE
Fix stack corruption.

### DIFF
--- a/src/common/bsod.c
+++ b/src/common/bsod.c
@@ -251,8 +251,15 @@ void _bsod(const char *fmt, const char *file_name, int line_number, ...) {
     pc = strrchr(file_name, '\\');
     if (pc != 0)
         file_name = pc + 1;
+    {
+		char text[TERM_PRINTF_MAX];
 
-    vterm_printf(&term, fmt, args); //print text to terminal
+		int ret = vsnprintf(text, sizeof(text), fmt, args);
+
+		const size_t range = ret < TERM_PRINTF_MAX ? ret : TERM_PRINTF_MAX;
+		for (size_t i = 0; i < range; i++)
+			term_write_char(&term, text[i]);
+    }
     term_printf(&term, "\n");
     if (file_name != 0)
         term_printf(&term, "%s", file_name); //print filename

--- a/src/guiapi/include/term.h
+++ b/src/guiapi/include/term.h
@@ -80,8 +80,6 @@ extern void term_write_char(term_t *pt, uint8_t ch);
 
 extern int term_printf(term_t *pt, const char *fmt, ...);
 
-extern int vterm_printf(term_t *pt, const char *fmt, va_list va);
-
 #ifdef __cplusplus
 }
 #endif //__cplusplus

--- a/src/guiapi/src/term.c
+++ b/src/guiapi/src/term.c
@@ -176,26 +176,18 @@ void term_write_char(term_t *pt, uint8_t ch) {
 }
 
 int term_printf(term_t *pt, const char *fmt, ...) {
-    int ret;
-
     va_list va;
     va_start(va, fmt);
 
-    ret = vterm_printf(pt, fmt, va);
+    char text[TERM_PRINTF_MAX];
+
+    int ret = vsnprintf(text, sizeof(text), fmt, va);
+
+    const size_t range = ret < TERM_PRINTF_MAX ? ret : TERM_PRINTF_MAX;
+    for (size_t i = 0; i < range; i++)
+        term_write_char(pt, text[i]);
+
     va_end(va);
 
-    return ret;
-}
-
-//va_list version  ... callable in variadic functions
-int vterm_printf(term_t *pt, const char *fmt, va_list va) {
-    char text[TERM_PRINTF_MAX];
-    int ret;
-    int i;
-
-    ret = vsnprintf(text,sizeof(text), fmt, va);
-
-    for (i = 0; i < ret; i++)
-        term_write_char(pt, text[i]);
     return ret;
 }


### PR DESCRIPTION
Stack (content pointed to by term_t *pt) became corrupted when vsnprintf(text, sizeof(text), fmt, va) was called inside vterm_printf(term_t *pt, const char *fmt, va_list va).
It is probably not legal to pass va_list function parameter to another function taking va_list.

http://www.cplusplus.com/reference/cstdarg/va_list/
The specifics of this type depend on the particular library implementation. Objects of this type shall only be used as argument for the va_start, va_arg, va_end and va_copy macros, or functions that use them, like the variable argument functions in <cstdio> (vprintf, vscanf, vsnprintf, vsprintf and vsscanf).