### PR TITLE
Remove the waiting to the exact temperature

### DIFF
--- a/src/marlin_stubs/pause/pause.cpp
+++ b/src/marlin_stubs/pause/pause.cpp
@@ -126,6 +126,8 @@ static bool ensure_safe_temperature(const PauseMode mode=PAUSE_MODE_SAME) {
     UNUSED(mode);
   #endif
 
+  if(mode == PAUSE_MODE_LOAD_FILAMENT || mode == PAUSE_MODE_UNLOAD_FILAMENT)
+    return true;
   return thermalManager.wait_for_hotend(active_extruder);
 }
 


### PR DESCRIPTION
Remove the waiting to the exact temperature. Now enable load / unload at +/- 10 degrees celsius.