### PR TITLE
Code safety: sprintf->snprintf + static const char [] + proper USB VID/PID

### DIFF
--- a/src/common/bsod.c
+++ b/src/common/bsod.c
@@ -197,7 +197,7 @@ void _bsod(const char *fmt, const char *file_name, int line_number, ...) {
     __disable_irq(); //disable irq
 
     char tskName[configMAX_TASK_NAME_LEN];
-    strncpy(tskName, pxCurrentTCB->pcTaskName, configMAX_TASK_NAME_LEN);
+    strlcpy(tskName, pxCurrentTCB->pcTaskName, configMAX_TASK_NAME_LEN);
     StackType_t *pTopOfStack = (StackType_t *)pxCurrentTCB->pxTopOfStack;
     StackType_t *pBotOfStack = pxCurrentTCB->pxStack;
 

--- a/src/common/eeprom.c
+++ b/src/common/eeprom.c
@@ -157,43 +157,44 @@ void eeprom_dump(void) {
     char line[64];
     for (i = 0; i < 128; i++) // 128 lines = 2048 bytes
     {
-        sprintf(line, "%04x", i * 16);
+        sprintf(line, "%04x", i * 16); //@@TODO make safer with snprintf
         for (j = 0; j < 16; j++) {
             b = st25dv64k_user_read(j + i * 16);
-            sprintf(line + 4 + j * 3, " %02x", b);
+            sprintf(line + 4 + j * 3, " %02x", b); //@@TODO make safer with snprintf
         }
         _dbg("%s", line);
     }
 }
 
-int eeprom_var_sprintf(char *str, uint8_t id, variant8_t var) {
+int eeprom_var_sprintf(char *str, uint32_t str_size, uint8_t id, variant8_t var) {
     switch (id) {
     case EEVAR_VERSION:
-        return sprintf(str, "%u", (unsigned int)var.ui16);
+        return snprintf(str, str_size, "%u", (unsigned int)var.ui16);
     case EEVAR_FILAMENT_TYPE:
-        return sprintf(str, "%u", (unsigned int)var.ui8);
+        return snprintf(str, str_size, "%u", (unsigned int)var.ui8);
     case EEVAR_FILAMENT_COLOR:
-        return sprintf(str, "0x%08lx", (unsigned long)var.ui32);
+        return snprintf(str, str_size, "0x%08lx", (unsigned long)var.ui32);
     case EEVAR_UNUSED_1:
-        return sprintf(str, "%.4f", (double)var.flt);
+        return snprintf(str, str_size, "%.4f", (double)var.flt);
     case EEVAR_UNUSED_2:
-        return sprintf(str, "%.1f", (double)var.flt);
+        return snprintf(str, str_size, "%.1f", (double)var.flt);
     case EEVAR_UNUSED_3:
-        return sprintf(str, "%.1f", (double)var.flt);
+        return snprintf(str, str_size, "%.1f", (double)var.flt);
     case EEVAR_RUN_SELFTEST:
     case EEVAR_RUN_XYZCALIB:
     case EEVAR_RUN_FIRSTLAY:
     case EEVAR_FSENSOR_ENABLED:
-        return sprintf(str, "%u", (unsigned int)var.ui8);
+        return snprintf(str, str_size, "%u", (unsigned int)var.ui8);
     }
     return 0;
 }
 
 void eeprom_print_vars(void) {
     uint8_t id;
-    char text[16];
+    static const uint32_t text_size = 16;
+    char text[text_size];
     for (id = 0; id < EE_VAR_CNT; id++) {
-        eeprom_var_sprintf(text, id, eeprom_get_var(id));
+        eeprom_var_sprintf(text, text_size, id, eeprom_get_var(id));
         _dbg("%s=%s", eeprom_var_name[id], text);
     }
 }
@@ -208,7 +209,7 @@ void eeprom_clear(void) {
 int8_t eeprom_test_PUT(const unsigned int bytes) {
 
     unsigned int i;
-    char line[16] = "abcdefghijklmno";
+    static const char line[16] = "abcdefghijklmno";
     char line2[16];
     uint8_t size = sizeof(line);
     unsigned int count = bytes / 16;

--- a/src/common/eeprom.c
+++ b/src/common/eeprom.c
@@ -166,7 +166,7 @@ void eeprom_dump(void) {
     }
 }
 
-int eeprom_var_sprintf(char *str, uint32_t str_size, uint8_t id, variant8_t var) {
+int eeprom_var_snprintf(char *str, uint32_t str_size, uint8_t id, variant8_t var) {
     switch (id) {
     case EEVAR_VERSION:
         return snprintf(str, str_size, "%u", (unsigned int)var.ui16);
@@ -194,7 +194,7 @@ void eeprom_print_vars(void) {
     static const uint32_t text_size = 16;
     char text[text_size];
     for (id = 0; id < EE_VAR_CNT; id++) {
-        eeprom_var_sprintf(text, text_size, id, eeprom_get_var(id));
+        eeprom_var_snprintf(text, text_size, id, eeprom_get_var(id));
         _dbg("%s=%s", eeprom_var_name[id], text);
     }
 }

--- a/src/common/hwio_a3ides_2209_02.c
+++ b/src/common/hwio_a3ides_2209_02.c
@@ -568,19 +568,19 @@ void hwio_arduino_error(int err, uint32_t pin32) {
     char text[text_size];
     if ((err == HWIO_ERR_UNINI_DIG_WR) && (pin32 == PIN_BEEPER))
         return; //ignore BEEPER write
-    strcat(text, "HWIO error\n");
+    strncat(text, "HWIO error\n", text_size);
     switch (err) {
     case HWIO_ERR_UNINI_DIG_RD:
     case HWIO_ERR_UNINI_DIG_WR:
     case HWIO_ERR_UNINI_ANA_RD:
     case HWIO_ERR_UNINI_ANA_WR:
-        strcat(text, "uninitialized\n");
+        strncat(text, "uninitialized\n", text_size);
         break;
     case HWIO_ERR_UNDEF_DIG_RD:
     case HWIO_ERR_UNDEF_DIG_WR:
     case HWIO_ERR_UNDEF_ANA_RD:
     case HWIO_ERR_UNDEF_ANA_WR:
-        strcat(text, "undefined\n");
+        strncat(text, "undefined\n", text_size);
         break;
     }
     uint32_t text_current_len = strlen(text);
@@ -590,13 +590,13 @@ void hwio_arduino_error(int err, uint32_t pin32) {
     case HWIO_ERR_UNINI_DIG_WR:
     case HWIO_ERR_UNDEF_DIG_RD:
     case HWIO_ERR_UNDEF_DIG_WR:
-        strcat(text, "digital ");
+        strncat(text, "digital ", text_size);
         break;
     case HWIO_ERR_UNINI_ANA_RD:
     case HWIO_ERR_UNINI_ANA_WR:
     case HWIO_ERR_UNDEF_ANA_RD:
     case HWIO_ERR_UNDEF_ANA_WR:
-        strcat(text, "analog ");
+        strncat(text, "analog ", text_size);
         break;
     }
     switch (err) {
@@ -604,15 +604,16 @@ void hwio_arduino_error(int err, uint32_t pin32) {
     case HWIO_ERR_UNDEF_DIG_RD:
     case HWIO_ERR_UNINI_ANA_RD:
     case HWIO_ERR_UNDEF_ANA_RD:
-        strcat(text, "read");
+        strncat(text, "read", text_size);
         break;
     case HWIO_ERR_UNINI_DIG_WR:
     case HWIO_ERR_UNDEF_DIG_WR:
     case HWIO_ERR_UNINI_ANA_WR:
     case HWIO_ERR_UNDEF_ANA_WR:
-        strcat(text, "write");
+        strncat(text, "write", text_size);
         break;
     }
+    text[text_size - 1] = 0;
     bsod(text);
 }
 

--- a/src/common/hwio_a3ides_2209_02.c
+++ b/src/common/hwio_a3ides_2209_02.c
@@ -564,7 +564,8 @@ uint8_t adc_seq2idx(uint8_t seq) {
 // Arduino digital/analog read/write error handler
 
 void hwio_arduino_error(int err, uint32_t pin32) {
-    char text[64];
+    static const uint32_t text_size = 64;
+    char text[text_size];
     if ((err == HWIO_ERR_UNINI_DIG_WR) && (pin32 == PIN_BEEPER))
         return; //ignore BEEPER write
     strcat(text, "HWIO error\n");
@@ -582,7 +583,8 @@ void hwio_arduino_error(int err, uint32_t pin32) {
         strcat(text, "undefined\n");
         break;
     }
-    sprintf(text + strlen(text), "pin #%u (0x%02x)\n", (int)pin32, (uint8_t)pin32);
+    uint32_t text_current_len = strlen(text);
+    snprintf(text + text_current_len, text_size - text_current_len, "pin #%u (0x%02x)\n", (int)pin32, (uint8_t)pin32);
     switch (err) {
     case HWIO_ERR_UNINI_DIG_RD:
     case HWIO_ERR_UNINI_DIG_WR:

--- a/src/common/hwio_a3ides_2209_02.c
+++ b/src/common/hwio_a3ides_2209_02.c
@@ -568,19 +568,19 @@ void hwio_arduino_error(int err, uint32_t pin32) {
     char text[text_size];
     if ((err == HWIO_ERR_UNINI_DIG_WR) && (pin32 == PIN_BEEPER))
         return; //ignore BEEPER write
-    strncat(text, "HWIO error\n", text_size);
+    strlcat(text, "HWIO error\n", text_size);
     switch (err) {
     case HWIO_ERR_UNINI_DIG_RD:
     case HWIO_ERR_UNINI_DIG_WR:
     case HWIO_ERR_UNINI_ANA_RD:
     case HWIO_ERR_UNINI_ANA_WR:
-        strncat(text, "uninitialized\n", text_size);
+        strlcat(text, "uninitialized\n", text_size);
         break;
     case HWIO_ERR_UNDEF_DIG_RD:
     case HWIO_ERR_UNDEF_DIG_WR:
     case HWIO_ERR_UNDEF_ANA_RD:
     case HWIO_ERR_UNDEF_ANA_WR:
-        strncat(text, "undefined\n", text_size);
+        strlcat(text, "undefined\n", text_size);
         break;
     }
     uint32_t text_current_len = strlen(text);
@@ -590,13 +590,13 @@ void hwio_arduino_error(int err, uint32_t pin32) {
     case HWIO_ERR_UNINI_DIG_WR:
     case HWIO_ERR_UNDEF_DIG_RD:
     case HWIO_ERR_UNDEF_DIG_WR:
-        strncat(text, "digital ", text_size);
+        strlcat(text, "digital ", text_size);
         break;
     case HWIO_ERR_UNINI_ANA_RD:
     case HWIO_ERR_UNINI_ANA_WR:
     case HWIO_ERR_UNDEF_ANA_RD:
     case HWIO_ERR_UNDEF_ANA_WR:
-        strncat(text, "analog ", text_size);
+        strlcat(text, "analog ", text_size);
         break;
     }
     switch (err) {
@@ -604,16 +604,15 @@ void hwio_arduino_error(int err, uint32_t pin32) {
     case HWIO_ERR_UNDEF_DIG_RD:
     case HWIO_ERR_UNINI_ANA_RD:
     case HWIO_ERR_UNDEF_ANA_RD:
-        strncat(text, "read", text_size);
+        strlcat(text, "read", text_size);
         break;
     case HWIO_ERR_UNINI_DIG_WR:
     case HWIO_ERR_UNDEF_DIG_WR:
     case HWIO_ERR_UNINI_ANA_WR:
     case HWIO_ERR_UNDEF_ANA_WR:
-        strncat(text, "write", text_size);
+        strlcat(text, "write", text_size);
         break;
     }
-    text[text_size - 1] = 0;
     bsod(text);
 }
 

--- a/src/common/marlin_client.c
+++ b/src/common/marlin_client.c
@@ -201,12 +201,13 @@ int marlin_wait_motion(uint32_t timeout) {
 }
 
 void marlin_gcode(const char *gcode) {
-    char request[MARLIN_MAX_REQUEST];
     marlin_client_t *client = _client_ptr();
     if (client == 0)
         return;
-    strcpy(request, "!g ");
-    strcat(request, gcode);
+    char request[MARLIN_MAX_REQUEST] = "!g ";
+//    strcpy(request, "!g ");
+    strncat(request, gcode, MARLIN_MAX_REQUEST - 3);
+    request[MARLIN_MAX_REQUEST-1] = 0; // safety, strncat does not add a \0 if buffer limit is reached
     _send_request_to_server(client->id, request);
     _wait_ack_from_server(client->id);
 }

--- a/src/common/marlin_client.c
+++ b/src/common/marlin_client.c
@@ -205,9 +205,7 @@ void marlin_gcode(const char *gcode) {
     if (client == 0)
         return;
     char request[MARLIN_MAX_REQUEST] = "!g ";
-//    strcpy(request, "!g ");
-    strncat(request, gcode, MARLIN_MAX_REQUEST - 3);
-    request[MARLIN_MAX_REQUEST-1] = 0; // safety, strncat does not add a \0 if buffer limit is reached
+    strlcat(request + 3, gcode, MARLIN_MAX_REQUEST - 3);
     _send_request_to_server(client->id, request);
     _wait_ack_from_server(client->id);
 }
@@ -217,7 +215,6 @@ int marlin_gcode_printf(const char *format, ...) {
     marlin_client_t *client = _client_ptr();
     if (client == 0)
         return 0;
-    // strcpy(request, "!g ");
     char request[MARLIN_MAX_REQUEST] = "!g ";
     va_list ap;
     va_start(ap, format);

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -1127,14 +1127,16 @@ void host_response_handler(const uint8_t response) {
 
 void host_action_prompt_begin(const char *const pstr, const bool eol) {
     DBG_HOST("host_action_prompt_begin '%s' %d", pstr, (int)eol);
-    strcpy(host_prompt, pstr);
+    strncpy(host_prompt, pstr, HOST_PROMPT_LEN_MAX);
+    host_prompt[HOST_PROMPT_LEN_MAX-1] = 0;
     host_prompt_buttons = 0;
 }
 
 void host_action_prompt_button(const char *const pstr) {
     DBG_HOST("host_action_prompt_button '%s'", pstr);
     if (host_prompt_buttons < HOST_BUTTON_CNT_MAX) {
-        strcpy(host_prompt_button[host_prompt_buttons], pstr);
+        strncpy(host_prompt_button[host_prompt_buttons], pstr, HOST_PROMPT_LEN_MAX);
+        host_prompt_button[host_prompt_buttons][HOST_PROMPT_LEN_MAX-1] = 0;
         host_prompt_buttons++;
     }
 }

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -109,20 +109,18 @@ void _add_status_msg(const char *const popup_msg) {
     char message[MSG_MAX_LENGTH];
     size_t str_size = strlen(popup_msg);
     if (str_size >= MSG_MAX_LENGTH - 1) {
-        strncpy(message, popup_msg, MSG_MAX_LENGTH - 1); // popup_msg is not always null-terminated...
-        message[MSG_MAX_LENGTH - 1] = '\0';
+        strlcpy(message, popup_msg, MSG_MAX_LENGTH); // popup_msg is not always null-terminated but strlcpy should solve it
     } else {
-        strncpy(message, popup_msg, str_size);
-        message[str_size] = '\0';
+        strlcpy(message, popup_msg, str_size);
     }
 
     for (uint8_t i = msg_stack.count; i; i--) {
         if (i == MSG_STACK_SIZE)
             i--; // last place of the limited stack will be always overwritten
-        strncpy(msg_stack.msg_data[i], msg_stack.msg_data[i - 1], MSG_MAX_LENGTH);
+        strlcpy(msg_stack.msg_data[i], msg_stack.msg_data[i - 1], MSG_MAX_LENGTH);
     }
 
-    strncpy(msg_stack.msg_data[0], message, MSG_MAX_LENGTH);
+    strlcpy(msg_stack.msg_data[0], message, MSG_MAX_LENGTH);
 
     if (msg_stack.count < MSG_STACK_SIZE)
         msg_stack.count++;
@@ -1127,16 +1125,14 @@ void host_response_handler(const uint8_t response) {
 
 void host_action_prompt_begin(const char *const pstr, const bool eol) {
     DBG_HOST("host_action_prompt_begin '%s' %d", pstr, (int)eol);
-    strncpy(host_prompt, pstr, HOST_PROMPT_LEN_MAX);
-    host_prompt[HOST_PROMPT_LEN_MAX-1] = 0;
+    strlcpy(host_prompt, pstr, HOST_PROMPT_LEN_MAX);
     host_prompt_buttons = 0;
 }
 
 void host_action_prompt_button(const char *const pstr) {
     DBG_HOST("host_action_prompt_button '%s'", pstr);
     if (host_prompt_buttons < HOST_BUTTON_CNT_MAX) {
-        strncpy(host_prompt_button[host_prompt_buttons], pstr, HOST_PROMPT_LEN_MAX);
-        host_prompt_button[host_prompt_buttons][HOST_PROMPT_LEN_MAX-1] = 0;
+        strlcpy(host_prompt_button[host_prompt_buttons], pstr, HOST_PROMPT_LEN_MAX);
         host_prompt_buttons++;
     }
 }

--- a/src/common/marlin_vars.c
+++ b/src/common/marlin_vars.c
@@ -180,71 +180,71 @@ void marlin_vars_set_var(marlin_vars_t *vars, uint8_t var_id, variant8_t var) {
         }
 }
 
-void marlin_vars_value_to_str(marlin_vars_t *vars, uint8_t var_id, char *str) {
+void marlin_vars_value_to_str(marlin_vars_t *vars, uint8_t var_id, char *str, uint32_t str_size) {
     if (vars)
         switch (var_id) {
         case MARLIN_VAR_MOTION:
-            sprintf(str, "%u", (unsigned int)(vars->motion));
+            snprintf(str, str_size, "%u", (unsigned int)(vars->motion));
             break;
         case MARLIN_VAR_GQUEUE:
-            sprintf(str, "%u", (unsigned int)(vars->gqueue));
+            snprintf(str, str_size, "%u", (unsigned int)(vars->gqueue));
             break;
         case MARLIN_VAR_PQUEUE:
-            sprintf(str, "%u", (unsigned int)(vars->pqueue));
+            snprintf(str, str_size, "%u", (unsigned int)(vars->pqueue));
             break;
         case MARLIN_VAR_IPOS_X:
         case MARLIN_VAR_IPOS_Y:
         case MARLIN_VAR_IPOS_Z:
         case MARLIN_VAR_IPOS_E:
-            sprintf(str, "%li", (long int)vars->ipos[var_id - MARLIN_VAR_IPOS_X]);
+            snprintf(str, str_size, "%li", (long int)vars->ipos[var_id - MARLIN_VAR_IPOS_X]);
             break;
         case MARLIN_VAR_POS_X:
         case MARLIN_VAR_POS_Y:
         case MARLIN_VAR_POS_Z:
         case MARLIN_VAR_POS_E:
-            sprintf(str, "%.3f", (double)(vars->pos[var_id - MARLIN_VAR_POS_X]));
+            snprintf(str, str_size, "%.3f", (double)(vars->pos[var_id - MARLIN_VAR_POS_X]));
             break;
         case MARLIN_VAR_TEMP_NOZ:
-            sprintf(str, "%.1f", (double)(vars->temp_nozzle));
+            snprintf(str, str_size, "%.1f", (double)(vars->temp_nozzle));
             break;
         case MARLIN_VAR_TEMP_BED:
-            sprintf(str, "%.1f", (double)(vars->temp_bed));
+            snprintf(str, str_size, "%.1f", (double)(vars->temp_bed));
             break;
         case MARLIN_VAR_TTEM_NOZ:
-            sprintf(str, "%.1f", (double)(vars->target_nozzle));
+            snprintf(str, str_size, "%.1f", (double)(vars->target_nozzle));
             break;
         case MARLIN_VAR_TTEM_BED:
-            sprintf(str, "%.1f", (double)(vars->target_bed));
+            snprintf(str, str_size, "%.1f", (double)(vars->target_bed));
             break;
         case MARLIN_VAR_Z_OFFSET:
-            sprintf(str, "%.4f", (double)(vars->z_offset));
+            snprintf(str, str_size, "%.4f", (double)(vars->z_offset));
             break;
         case MARLIN_VAR_FANSPEED:
-            sprintf(str, "%u", (unsigned int)(vars->fan_speed));
+            snprintf(str, str_size, "%u", (unsigned int)(vars->fan_speed));
             break;
         case MARLIN_VAR_PRNSPEED:
-            sprintf(str, "%u", (unsigned int)(vars->print_speed));
+            snprintf(str, str_size, "%u", (unsigned int)(vars->print_speed));
             break;
         case MARLIN_VAR_FLOWFACT:
-            sprintf(str, "%u", (unsigned int)(vars->flow_factor));
+            snprintf(str, str_size, "%u", (unsigned int)(vars->flow_factor));
             break;
         case MARLIN_VAR_WAITHEAT:
-            sprintf(str, "%u", (unsigned int)(vars->wait_heat));
+            snprintf(str, str_size, "%u", (unsigned int)(vars->wait_heat));
             break;
         case MARLIN_VAR_WAITUSER:
-            sprintf(str, "%u", (unsigned int)(vars->wait_user));
+            snprintf(str, str_size, "%u", (unsigned int)(vars->wait_user));
             break;
         case MARLIN_VAR_SD_PRINT:
-            sprintf(str, "%u", (unsigned int)(vars->sd_printing));
+            snprintf(str, str_size, "%u", (unsigned int)(vars->sd_printing));
             break;
         case MARLIN_VAR_SD_PDONE:
-            sprintf(str, "%u", (unsigned int)(vars->sd_percent_done));
+            snprintf(str, str_size, "%u", (unsigned int)(vars->sd_percent_done));
             break;
         case MARLIN_VAR_DURATION:
-            sprintf(str, "%lu", (long unsigned int)(vars->print_duration));
+            snprintf(str, str_size, "%lu", (long unsigned int)(vars->print_duration));
             break;
         default:
-            sprintf(str, "???");
+            snprintf(str, str_size, "???");
         }
 }
 

--- a/src/common/marlin_vars.c
+++ b/src/common/marlin_vars.c
@@ -181,7 +181,7 @@ void marlin_vars_set_var(marlin_vars_t *vars, uint8_t var_id, variant8_t var) {
 }
 
 void marlin_vars_value_to_str(marlin_vars_t *vars, uint8_t var_id, char *str, uint32_t str_size) {
-    if (vars)
+    if (vars) {
         switch (var_id) {
         case MARLIN_VAR_MOTION:
             snprintf(str, str_size, "%u", (unsigned int)(vars->motion));
@@ -246,6 +246,12 @@ void marlin_vars_value_to_str(marlin_vars_t *vars, uint8_t var_id, char *str, ui
         default:
             snprintf(str, str_size, "???");
         }
+    } else {
+        // in a rare case when vars is nullptr, at least properly write "empty" string to str
+        // of course only when the str pointer is valid and some non-zero size was set
+        if( str && str_size )
+            str[0] = 0;
+    }
 }
 
 int marlin_vars_str_to_value(marlin_vars_t *vars, uint8_t var_id, const char *str) {

--- a/src/common/marlin_vars.h
+++ b/src/common/marlin_vars.h
@@ -146,7 +146,7 @@ extern variant8_t marlin_vars_get_var(marlin_vars_t *vars, uint8_t var_id);
 extern void marlin_vars_set_var(marlin_vars_t *vars, uint8_t var_id, variant8_t var);
 
 // format variable to string
-extern void marlin_vars_value_to_str(marlin_vars_t *vars, uint8_t var_id, char *str);
+extern void marlin_vars_value_to_str(marlin_vars_t *vars, uint8_t var_id, char *str, uint32_t str_size);
 
 // parse variable from string, returns sscanf result (1 = ok)
 extern int marlin_vars_str_to_value(marlin_vars_t *vars, uint8_t var_id, const char *str);

--- a/src/common/menu_support.cpp
+++ b/src/common/menu_support.cpp
@@ -25,7 +25,7 @@ void menu_support() {
     int ver_min = (FW_VERSION - 100 * ver_maj) / 10;
     int ver_sub = FW_VERSION % 10;
     const char *stages[] = { "pre-alpha", "alpha", "beta", "RC", "final" };
-    sprintf(version, " %d.%d.%d %s", ver_maj, ver_min, ver_sub, (char *)stages[FW_STAGENR]);
+    snprintf(version, " %d.%d.%d %s", ver_maj, ver_min, ver_sub, (char *)stages[FW_STAGENR]);
     #if (PRINTER_TYPE == PRINTER_PRUSA_MINI)
     const char *printer = "MINI";
     #else

--- a/src/common/menu_support.cpp
+++ b/src/common/menu_support.cpp
@@ -19,13 +19,15 @@ void menu_support() {
     #else
     STATIC_ITEM_P("Marlin - A3ides ????");
     #endif
-    char version[32];
-    char build[32];
+    static const uint32_t version_size = 32;
+    static const uint32_t build_size = 32;
+    char version[version_size];
+    char build[build_size];
     int ver_maj = FW_VERSION / 100;
     int ver_min = (FW_VERSION - 100 * ver_maj) / 10;
     int ver_sub = FW_VERSION % 10;
     const char *stages[] = { "pre-alpha", "alpha", "beta", "RC", "final" };
-    snprintf(version, " %d.%d.%d %s", ver_maj, ver_min, ver_sub, (char *)stages[FW_STAGENR]);
+    snprintf(version, version_size, " %d.%d.%d %s", ver_maj, ver_min, ver_sub, (char *)stages[FW_STAGENR]);
     #if (PRINTER_TYPE == PRINTER_PRUSA_MINI)
     const char *printer = "MINI";
     #else
@@ -34,7 +36,7 @@ void menu_support() {
     #ifdef _DEBUG
     sprintf(build, " %d%s (DEBUG_%s)", version_build_nr, (char *)FW_BUILDSX, printer);
     #else //_DEBUG
-    sprintf(build, " %d%s (%s)", version_build_nr, (char *)FW_BUILDSX, printer);
+    snprintf(build, build_size, " %d%s (%s)", version_build_nr, (char *)FW_BUILDSX, printer);
     #endif //_DEBUG
     STATIC_ITEM_P("version:            ");
     STATIC_ITEM(version);

--- a/src/common/st25dv64k.c
+++ b/src/common/st25dv64k.c
@@ -116,8 +116,8 @@ void st25dv64k_user_read_bytes(uint16_t address, void *pdata, uint8_t size) {
     st25dv64k_unlock();
 }
 
-void st25dv64k_user_write_bytes(uint16_t address, void *pdata, uint8_t size) {
-    uint8_t *p = (uint8_t *)pdata;
+void st25dv64k_user_write_bytes(uint16_t address, const void *pdata, uint8_t size) {
+    const uint8_t *p = (const uint8_t *)pdata;
     uint8_t _out[6];
     uint8_t block_size;
     st25dv64k_lock();

--- a/src/common/st25dv64k.h
+++ b/src/common/st25dv64k.h
@@ -17,7 +17,7 @@ extern void st25dv64k_user_write(uint16_t address, uint8_t data);
 
 extern void st25dv64k_user_read_bytes(uint16_t address, void *pdata, uint8_t size);
 
-extern void st25dv64k_user_write_bytes(uint16_t address, void *pdata, uint8_t size);
+extern void st25dv64k_user_write_bytes(uint16_t address, const void *pdata, uint8_t size);
 
 extern uint8_t st25dv64k_rd_cfg(uint16_t address);
 

--- a/src/common/uartslave.c
+++ b/src/common/uartslave.c
@@ -127,10 +127,11 @@ void uartslave_cycle(uartslave_t *pslave) {
 }
 
 int uartslave_printf(uartslave_t *pslave, const char *fmt, ...) {
-    char text[32];
+    static const uint32_t text_size = 32;
+    char text[text_size];
     va_list va;
     va_start(va, fmt);
-    int len = vsprintf(text, fmt, va);
+    int len = vsnprintf(text, text_size, fmt, va);
     va_end(va);
     HAL_StatusTypeDef ret = HAL_UART_Transmit(pslave->prxbuff->phuart, (uint8_t *)text, len, HAL_MAX_DELAY);
     if (ret == HAL_OK)

--- a/src/gui/dialogs/window_dlg_popup.c
+++ b/src/gui/dialogs/window_dlg_popup.c
@@ -70,8 +70,7 @@ void gui_pop_up(void) {
 
     int16_t id_capture = window_capture();
     int16_t id = window_create_ptr(WINDOW_CLS_DLG_POPUP, 0, rect_ui16(0, 32, 240, 120), &dlg);
-    strncpy(dlg.text, msg_stack.msg_data[0], MSG_MAX_LENGTH);
-    dlg.text[MSG_MAX_LENGTH - 1] = '\0';
+    strlcpy(dlg.text, msg_stack.msg_data[0], MSG_MAX_LENGTH);
     window_1 = (window_t *)&dlg;
     gui_invalidate();
     window_set_capture(id);

--- a/src/gui/dialogs/window_dlg_preheat.c
+++ b/src/gui/dialogs/window_dlg_preheat.c
@@ -30,10 +30,10 @@ void window_list_filament_item_forced_cb(window_list_t *pwindow_list, uint16_t i
     const char **pptext, uint16_t *pid_icon) {
     if (index <= pwindow_list->count) {
         *pptext = filaments[index + FILAMENT_PLA].long_name;
-    } else
+    } else {
         static const char indexError[] = "Index ERROR";
         *pptext = indexError;
-
+    }
     *pid_icon = 0;
 }
 

--- a/src/gui/dialogs/window_dlg_preheat.c
+++ b/src/gui/dialogs/window_dlg_preheat.c
@@ -31,7 +31,8 @@ void window_list_filament_item_forced_cb(window_list_t *pwindow_list, uint16_t i
     if (index <= pwindow_list->count) {
         *pptext = filaments[index + FILAMENT_PLA].long_name;
     } else
-        *pptext = "Index ERROR";
+        static const char indexError[] = "Index ERROR";
+        *pptext = indexError;
 
     *pid_icon = 0;
 }
@@ -39,7 +40,8 @@ void window_list_filament_item_forced_cb(window_list_t *pwindow_list, uint16_t i
 void window_list_filament_item_cb(window_list_t *pwindow_list, uint16_t index,
     const char **pptext, uint16_t *pid_icon) {
     if (index == 0) {
-        *pptext = "Return";
+        static const char ret[] = "Return";
+        *pptext = ret;
         *pid_icon = IDR_PNG_filescreen_icon_up_folder;
     } else {
         window_list_filament_item_forced_cb(pwindow_list, index - 1, pptext, pid_icon);

--- a/src/gui/dialogs/window_dlg_statemachine.c
+++ b/src/gui/dialogs/window_dlg_statemachine.c
@@ -108,7 +108,11 @@ void _window_dlg_statemachine_draw_frame(window_dlg_statemachine_t *window) {
 void progress_draw(rect_ui16_t win_rect, font_t *font, color_t color_back,
     color_t color_text, padding_ui8_t padding, uint8_t progress) {
     rect_ui16_t rc_pro = win_rect; //must copy it
-    char text[16];
+    // why 16 bytes for "0%" - "100%"? Thats just 5 bytes instead of 16
+    // Save stack, guys!
+    // @@TODO duplicit code for printing percentage!
+    static const uint32_t text_size = 5;//16;
+    char text[text_size];
     rc_pro.x += 10;
     rc_pro.w -= 20;
     rc_pro.h = 16;
@@ -123,7 +127,7 @@ void progress_draw(rect_ui16_t win_rect, font_t *font, color_t color_back,
     rc_pro.w = win_rect.w - 120;
     rc_pro.x = win_rect.x + 60;
     rc_pro.h = 30;
-    sprintf(text, "%d%%", progress);
+    snprintf(text, text_size, "%d%%", progress);
     render_text_align(rc_pro, text, font, color_back, color_text, padding, ALIGN_CENTER);
 }
 

--- a/src/gui/dialogs/window_dlg_wait.c
+++ b/src/gui/dialogs/window_dlg_wait.c
@@ -101,7 +101,10 @@ void window_dlg_wait_draw(window_dlg_wait_t *window) {
             rect_ui16_t rc_pro = rc;
             rc_pro.x = 10;
             rc_pro.w -= 20;
-            char text[16];
+            // why 16 bytes for "0%" - "100%"? Thats just 5 bytes instead of 16
+            // Save stack, guys!
+            static const uint32_t text_size = 5;//16;
+            char text[text_size];
             rc_pro.h = 16;
             rc_pro.y += 120;
             uint16_t w = rc_pro.w;
@@ -114,7 +117,7 @@ void window_dlg_wait_draw(window_dlg_wait_t *window) {
             rc_pro.w = rc.w - 120;
             rc_pro.x = rc.x + 60;
             rc_pro.h = 30;
-            sprintf(text, "%d%%", window->progress);
+            snprintf(text, text_size, "%d%%", window->progress);
             render_text_align(rc_pro, text, window->font_title, window->color_back, window->color_text, window->padding, ALIGN_CENTER);
             window->flags &= 0x7FFF;
         }

--- a/src/gui/screen_lan_settings.c
+++ b/src/gui/screen_lan_settings.c
@@ -80,12 +80,12 @@ static void _addrs_to_str(char *param_str, uint8_t flg) {
             ip4_addr_str, ip4_msk_str, ip4_gw_str, param_str);
 }
 
-static void _parse_MAC_addr(char *mac_addr_str) {
+static void _parse_MAC_addr(char *mac_addr_str, uint32_t mac_addr_str_size) {
     volatile uint8_t mac_addr[] = { 0, 0, 0, 0, 0, 0 };
     for (uint8_t i = 0; i < MAC_ADDR_SIZE; i++)
         mac_addr[i] = *(volatile uint8_t *)(MAC_ADDR_START + i);
 
-    sprintf(mac_addr_str, "%x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+    snprintf(mac_addr_str, mac_addr_str_size, "%x:%x:%x:%x:%x:%x", mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
 }
 
 static void screen_lan_settings_init(screen_t *screen) {
@@ -124,15 +124,16 @@ static void screen_lan_settings_init(screen_t *screen) {
 #endif //STATIC_SAVE_LOAD_CONFIG
     //============== DECLARE VARIABLES ================
 
-    plan_str = (char *)gui_malloc(150 * sizeof(char));
+    static const uint32_t plan_str_size = 150;
+    plan_str = (char *)gui_malloc(plan_str_size * sizeof(char));
 
     //============= FILL VARIABLES ============
 
-    _parse_MAC_addr(plsd->mac_addr_str);
+    _parse_MAC_addr(plsd->mac_addr_str, sizeof(plsd->mac_addr_str));
 
     if (_get_ip4_addrs()) {
         config.lan_ip4_addr.addr = config.lan_ip4_msk.addr = config.lan_ip4_gw.addr = 0;
-        sprintf(plan_str, "IPv4 Address:\n    0.0.0.0\nIPv4 Netmask:\n    0.0.0.0\nIPv4 Gateway:\n    0.0.0.0\nMAC Address:\n    %s",
+        snprintf(plan_str, plan_str_size, "IPv4 Address:\n    0.0.0.0\nIPv4 Netmask:\n    0.0.0.0\nIPv4 Gateway:\n    0.0.0.0\nMAC Address:\n    %s",
             plsd->mac_addr_str);
     } else {
         _addrs_to_str(plsd->mac_addr_str, 0); //0 means parsing to screen text

--- a/src/gui/screen_lan_settings.c
+++ b/src/gui/screen_lan_settings.c
@@ -129,6 +129,7 @@ static void screen_lan_settings_init(screen_t *screen) {
 
     //============= FILL VARIABLES ============
 
+    _Static_assert( sizeof(plsd->mac_addr_str) >= 18, "mac_addr_str is too short" ); // gcc-specific c-style static assert
     _parse_MAC_addr(plsd->mac_addr_str, sizeof(plsd->mac_addr_str));
 
     if (_get_ip4_addrs()) {

--- a/src/gui/screen_lan_settings.c
+++ b/src/gui/screen_lan_settings.c
@@ -69,9 +69,9 @@ static uint8_t _get_ip4_addrs(void) {
 
 static void _addrs_to_str(char *param_str, uint8_t flg) {
     static char ip4_addr_str[IP4_ADDR_STR_SIZE], ip4_msk_str[IP4_ADDR_STR_SIZE], ip4_gw_str[IP4_ADDR_STR_SIZE];
-    strncpy(ip4_addr_str, ip4addr_ntoa(&(config.lan_ip4_addr)), IP4_ADDR_STR_SIZE);
-    strncpy(ip4_msk_str, ip4addr_ntoa(&(config.lan_ip4_msk)), IP4_ADDR_STR_SIZE);
-    strncpy(ip4_gw_str, ip4addr_ntoa(&(config.lan_ip4_gw)), IP4_ADDR_STR_SIZE);
+    strlcpy(ip4_addr_str, ip4addr_ntoa(&(config.lan_ip4_addr)), IP4_ADDR_STR_SIZE);
+    strlcpy(ip4_msk_str, ip4addr_ntoa(&(config.lan_ip4_msk)), IP4_ADDR_STR_SIZE);
+    strlcpy(ip4_gw_str, ip4addr_ntoa(&(config.lan_ip4_gw)), IP4_ADDR_STR_SIZE);
 
     if (flg)
         snprintf(param_str, MAX_INI_SIZE, "[lan_ip4]\naddress=%s\nmask=%s\ngateway=%s", ip4_addr_str, ip4_msk_str, ip4_gw_str);

--- a/src/gui/screen_menu_preheat.cpp
+++ b/src/gui/screen_menu_preheat.cpp
@@ -33,7 +33,7 @@ void screen_menu_preheat_init(screen_t *screen) {
         strncpy((char *)psmd->items[i].item.label, filaments[i].name,
             strlen(filaments[i].name));
         sprintf((char *)psmd->items[i].item.label + 9, "%d/%d",
-            filaments[i].nozzle, filaments[i].heatbed);
+            filaments[i].nozzle, filaments[i].heatbed); //@@TODO very dangerous - the size of "label" is unknown here
     }
 
     if (!menu_preheat_type) {

--- a/src/gui/screen_menu_preheat.cpp
+++ b/src/gui/screen_menu_preheat.cpp
@@ -30,7 +30,7 @@ void screen_menu_preheat_init(screen_t *screen) {
 
     for (size_t i = 1; i < FILAMENTS_END; i++) {
         memset((char *)psmd->items[i].item.label, ' ', sizeof(char) * 15);
-        strncpy((char *)psmd->items[i].item.label, filaments[i].name,
+        strlcpy((char *)psmd->items[i].item.label, filaments[i].name,
             strlen(filaments[i].name));
         sprintf((char *)psmd->items[i].item.label + 9, "%d/%d",
             filaments[i].nozzle, filaments[i].heatbed); //@@TODO very dangerous - the size of "label" is unknown here

--- a/src/gui/screen_messages.c
+++ b/src/gui/screen_messages.c
@@ -48,7 +48,7 @@ void _msg_stack_del(uint8_t del_index) { // del_index = < 0 ; MSG_STACK_SIZE - 1
 
     // when we delete from last spot of the limited stack [MSG_STACK_SIZE - 1], no swapping is needed, for cycle won't start
     for (uint8_t i = del_index; i + 1 < msg_stack.count; i++)
-        strncpy(msg_stack.msg_data[i], msg_stack.msg_data[i + 1], MSG_MAX_LENGTH);
+        strlcpy(msg_stack.msg_data[i], msg_stack.msg_data[i + 1], MSG_MAX_LENGTH);
     msg_stack.count--;
 }
 

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -193,20 +193,20 @@ struct pduration_t : duration_t {
     pduration_t(uint32_t const &seconds)
         : duration_t(seconds) {}
 
-    void to_string(char *buffer) const {
+    void to_string(char *buffer, uint32_t buffer_size) const {
         int d = this->day(),
             h = this->hour() % 24,
             m = this->minute() % 60,
             s = this->second() % 60;
 
         if (d) {
-            sprintf(buffer, "%3id %2ih %2im", d, h, m);
+            snprintf(buffer, buffer_size, "%3id %2ih %2im", d, h, m);
         } else if (h) {
-            sprintf(buffer, "     %2ih %2im", h, m);
+            snprintf(buffer, buffer_size, "     %2ih %2im", h, m);
         } else if (m) {
-            sprintf(buffer, "     %2im %2is", m, s);
+            snprintf(buffer, buffer_size, "     %2im %2is", m, s);
         } else {
-            sprintf(buffer, "         %2is", s);
+            snprintf(buffer, buffer_size, "         %2is", s);
         }
     }
 };
@@ -607,7 +607,7 @@ void screen_printing_update_progress(screen_t *screen) {
     //const pduration_t e_time(ExtUI::getProgress_seconds_elapsed());
 
     const pduration_t e_time(marlin_vars()->print_duration);
-    e_time.to_string(pw->text_time);
+    e_time.to_string(pw->text_time, sizeof(pw->text_time) );
     window_set_text(pw->w_time_value.win.id, pw->text_time);
     //_dbg("#.. progress / p :: %d t0: %d ?: %d\r",oProgressData.oPercentDirectControl.mGetValue(),oProgressData.oPercentDirectControl.nTime,oProgressData.oPercentDirectControl.mIsActual(print_job_timer.duration()));
     //_dbg("#.. progress / P :: %d t0: %d ?: %d\r",oProgressData.oPercentDone.mGetValue(),oProgressData.oPercentDone.nTime,oProgressData.oPercentDone.mIsActual(print_job_timer.duration()));

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -217,8 +217,8 @@ void screen_printing_init(screen_t *screen) {
     marlin_error_clr(MARLIN_ERR_ProbingFailed);
     int16_t id;
 
-    strcpy(pw->text_time, "0m");
-    strcpy(pw->text_filament, "999m");
+    strncpy(pw->text_time, "0m", sizeof(pw->text_time)); pw->text_time[sizeof(pw->text_time)-1] = 0;
+    strncpy(pw->text_filament, "999m", sizeof(pw->text_filament)); pw->text_filament[ sizeof(pw->text_filament)-1] = 0;
 
     int16_t root = window_create_ptr(WINDOW_CLS_FRAME, -1,
         rect_ui16(0, 0, 0, 0),
@@ -567,7 +567,7 @@ static void screen_printing_update_remaining_time_progress(screen_t *screen) {
         //_dbg(".progress: %d\r",nPercent);
     } else {
         nPercent = marlin_vars()->sd_percent_done;
-        strcpy_P(pw->text_etime, PSTR("N/A"));
+        strncpy(pw->text_etime, "N/A", sizeof(pw->text_etime)); pw->text_etime[sizeof(pw->text_etime)-1] = 0;
         pw->w_etime_value.color_text = COLOR_VALUE_VALID;
         pw->w_progress.color_text = COLOR_VALUE_INVALID;
         //_dbg(".progress: %d ???\r",nPercent);

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -217,8 +217,8 @@ void screen_printing_init(screen_t *screen) {
     marlin_error_clr(MARLIN_ERR_ProbingFailed);
     int16_t id;
 
-    strncpy(pw->text_time, "0m", sizeof(pw->text_time)); pw->text_time[sizeof(pw->text_time)-1] = 0;
-    strncpy(pw->text_filament, "999m", sizeof(pw->text_filament)); pw->text_filament[ sizeof(pw->text_filament)-1] = 0;
+    strlcpy(pw->text_time, "0m", sizeof(pw->text_time));
+    strlcpy(pw->text_filament, "999m", sizeof(pw->text_filament));
 
     int16_t root = window_create_ptr(WINDOW_CLS_FRAME, -1,
         rect_ui16(0, 0, 0, 0),
@@ -567,7 +567,7 @@ static void screen_printing_update_remaining_time_progress(screen_t *screen) {
         //_dbg(".progress: %d\r",nPercent);
     } else {
         nPercent = marlin_vars()->sd_percent_done;
-        strncpy(pw->text_etime, "N/A", sizeof(pw->text_etime)); pw->text_etime[sizeof(pw->text_etime)-1] = 0;
+        strlcpy(pw->text_etime, "N/A", sizeof(pw->text_etime));
         pw->w_etime_value.color_text = COLOR_VALUE_VALID;
         pw->w_progress.color_text = COLOR_VALUE_INVALID;
         //_dbg(".progress: %d ???\r",nPercent);

--- a/src/gui/status_footer.cpp
+++ b/src/gui/status_footer.cpp
@@ -184,7 +184,7 @@ void status_footer_update_temperatures(status_footer_t *footer,
     } else if (!heating_nozzle && actual_nozzle != footer->nozzle) {
         footer->nozzle = actual_nozzle;
     }
-    sprintf(footer->text_nozzle, "%.0f/%.0f\177C", (double)actual_nozzle, (double)target_nozzle);
+    snprintf(footer->text_nozzle, sizeof(footer->text_nozzle), "%.0f/%.0f\177C", (double)actual_nozzle, (double)target_nozzle);
     window_set_text(footer->wt_nozzle.win.id, footer->text_nozzle);
 
     if (heating_heatbed && target_heatbed != footer->heatbed) {
@@ -192,13 +192,13 @@ void status_footer_update_temperatures(status_footer_t *footer,
     } else if (!heating_heatbed && actual_heatbed != footer->heatbed) {
         footer->heatbed = actual_heatbed;
     }
-    sprintf(footer->text_heatbed, "%.0f/%.0f\177C", (double)actual_heatbed, (double)target_heatbed);
+    snprintf(footer->text_heatbed, sizeof(footer->text_heatbed), "%.0f/%.0f\177C", (double)actual_heatbed, (double)target_heatbed);
     window_set_text(footer->wt_heatbed.win.id, footer->text_heatbed);
 
 #ifdef LCD_HEATBREAK_TO_FILAMENT
     float actual_heatbreak = thermalManager.degHeatbreak();
     //float actual_heatbreak = analogRead(6);
-    sprintf(footer->text_heatbreak, "%.0f\177C", (double)actual_heatbreak);
+    snprintf(footer->text_heatbreak, sizeof(footer->text_heatbreak), "%.0f\177C", (double)actual_heatbreak);
     window_set_text(footer->wt_filament.win.id, footer->text_heatbreak);
 #endif //LCD_HEATBREAK_TO_FILAMENT
 }
@@ -212,7 +212,7 @@ void status_footer_update_feedrate(status_footer_t *footer) {
 }
 
 void status_footer_update_z_axis(status_footer_t *footer) {
-    sprintf(footer->text_z_axis, "%.2f", (double)current_position[2]);
+    snprintf(footer->text_z_axis, sizeof(footer->text_z_axis), "%.2f", (double)current_position[2]);
     window_set_text(footer->wt_z_axis.win.id, footer->text_z_axis);
 }
 

--- a/src/gui/test/screen_test_disp_mem.c
+++ b/src/gui/test/screen_test_disp_mem.c
@@ -96,12 +96,14 @@ static int8_t isInverted_actual = -1;
 static int8_t isBrightness_ena_last = -1;
 static int8_t isBrightness_ena_actual = -1;
 
+static const char window_list_indexError[] = "Index ERROR";
+
 void window_list_spi_item(window_list_t *pwindow_list, uint16_t index,
     const char **pptext, uint16_t *pid_icon) {
     if (index < opt_spi_sz)
         *pptext = (char *)opt_spi[index];
     else
-        *pptext = "Index ERROR";
+        *pptext = window_list_indexError;
     *pid_icon = 0;
 }
 
@@ -110,7 +112,7 @@ void window_list_modes_item(window_list_t *pwindow_list, uint16_t index,
     if (index < modes_sz)
         *pptext = (char *)modes[index];
     else
-        *pptext = "Index ERROR";
+        *pptext = window_list_indexError;
     *pid_icon = 0;
 }
 
@@ -119,7 +121,7 @@ void window_list_inversions_item(window_list_t *pwindow_list, uint16_t index,
     if (index < inversions_sz)
         *pptext = (char *)inversions[index];
     else
-        *pptext = "Index ERROR";
+        *pptext = window_list_indexError;
     *pid_icon = 0;
 }
 
@@ -128,7 +130,7 @@ void window_list_bright_enas_item(window_list_t *pwindow_list, uint16_t index,
     if (index < bright_enas_sz)
         *pptext = (char *)bright_enas[index];
     else
-        *pptext = "Index ERROR";
+        *pptext = window_list_indexError;
     *pid_icon = 0;
 }
 

--- a/src/gui/wizard/wizard_ui.c
+++ b/src/gui/wizard/wizard_ui.c
@@ -28,10 +28,14 @@ void wizard_update_test_icon(int16_t win_id, uint8_t state) {
 // messagebox with custom buttons (NEXT and DONE), optionaly icon and rectangle
 int wizard_msgbox_ex(const char *text, uint16_t flags, uint16_t id_icon, rect_ui16_t rc) {
     const char *custom_btn = 0;
-    if ((flags & MSGBOX_MSK_BTN) == MSGBOX_BTN_NEXT)
-        custom_btn = "NEXT";
-    else if ((flags & MSGBOX_MSK_BTN) == MSGBOX_BTN_DONE)
-        custom_btn = "DONE";
+    if ((flags & MSGBOX_MSK_BTN) == MSGBOX_BTN_NEXT){
+        static const char next[] = "NEXT";
+        custom_btn = next;
+    } else if ((flags & MSGBOX_MSK_BTN) == MSGBOX_BTN_DONE){
+        static const char done[] = "DONE";
+        custom_btn = done;
+    }
+
     if (custom_btn) {
         flags = (flags & ~MSGBOX_MSK_BTN) | MSGBOX_BTN_CUSTOM1;
         return gui_msgbox_ex(0, text, flags | MSGBOX_ICO_CUSTOM, rc, id_icon, &custom_btn);

--- a/src/guiapi/src/window_menu.c
+++ b/src/guiapi/src/window_menu.c
@@ -45,18 +45,23 @@ void window_menu_init(window_menu_t *window) {
 void window_menu_done(window_menu_t *window) {
 }
 
-void window_menu_calculate_spin(WI_SPIN_t *item, char *value) {
+void window_menu_calculate_spin(WI_SPIN_t *item, char *value, uint32_t value_size) {
+    static const char fmt3f[] = "%.3f";
+    static const char fmt2f[] = "%.2f";
+    static const char fmt1f[] = "%.1f";
+    static const char fmtf[] = "%.f";
+
     const char *format;
 
     if (item->range[WIO_STEP] < 10)
-        format = "%.3f";
+        format = fmt3f;
     else if (item->range[WIO_STEP] < 100)
-        format = "%.2f";
+        format = fmt2f;
     else if (item->range[WIO_STEP] < 1000)
-        format = "%.1f";
+        format = fmt1f;
     else
-        format = "%.f";
-    sprintf(value, format, item->value * 0.001);
+        format = fmtf;
+    snprintf(value, value_size, format, item->value * 0.001);
 }
 
 void _window_menu_draw_value(window_menu_t *window, const char *value,
@@ -117,9 +122,9 @@ void window_menu_draw(window_menu_t *window) {
             case WI_SPIN_FL: {
                 char value[20] = { '\0' };
                 if (item->type & WI_SPIN_FL)
-                    sprintf(value, item->wi_spin_fl.prt_format, (double)item->wi_spin_fl.value);
+                    snprintf(value, sizeof(value), item->wi_spin_fl.prt_format, (double)item->wi_spin_fl.value);
                 else
-                    window_menu_calculate_spin(&(item->wi_spin), value);
+                    window_menu_calculate_spin(&(item->wi_spin), value, sizeof(value));
 
                 _window_menu_draw_value(window, value, &rc, color_option, color_back);
             } break;

--- a/src/guiapi/src/window_numb.c
+++ b/src/guiapi/src/window_numb.c
@@ -9,7 +9,8 @@ void window_numb_init(window_numb_t *window) {
     window->color_text = gui_defaults.color_text;
     window->font = gui_defaults.font;
     window->value = 0;
-    window->format = "%.0f";
+    static const char format[] = "%.0f";
+    window->format = format;
     window->padding = gui_defaults.padding;
     window->alignment = gui_defaults.alignment;
 }
@@ -22,9 +23,9 @@ void window_numb_draw(window_numb_t *window) {
             clr_text = COLOR_ORANGE;
         char text[WINDOW_NUMB_MAX_TEXT];
         if (window->win.flg & WINDOW_FLG_NUMB_FLOAT2INT) {
-            sprintf(text, window->format, (int)(window->value));
+            snprintf(text, sizeof(text), window->format, (int)(window->value));
         } else {
-            sprintf(text, window->format, (double)window->value);
+            snprintf(text, sizeof(text), window->format, (double)window->value);
         }
 
         render_text_align(window->win.rect,

--- a/src/guiapi/src/window_progress.c
+++ b/src/guiapi/src/window_progress.c
@@ -12,7 +12,8 @@ void window_progress_init(window_progress_t *window) {
     window->padding = gui_defaults.padding;
     window->alignment = ALIGN_CENTER;
     window->height_progress = 8;
-    window->format = "%.0f%%";
+    static const char format0f[] = "%.0f%%";
+    window->format = format0f;
     window->value = 0;
     window->min = 0;
     window->max = 100;
@@ -22,7 +23,7 @@ void window_progress_draw(window_progress_t *window) {
     if (((window->win.flg & (WINDOW_FLG_INVALID | WINDOW_FLG_VISIBLE)) == (WINDOW_FLG_INVALID | WINDOW_FLG_VISIBLE))) {
         rect_ui16_t rc = window->win.rect;
         char text[WINDOW_PROGRESS_MAX_TEXT];
-        sprintf(text, window->format, (double)window->value);
+        snprintf(text, sizeof(text), window->format, (double)window->value);
         int progress_w = (int)(rc.w * (window->value - window->min) / (window->max - window->min));
         rc.h = window->height_progress;
 

--- a/src/usbd_desc.c
+++ b/src/usbd_desc.c
@@ -321,18 +321,12 @@ uint8_t *USBD_FS_SerialStrDescriptor(USBD_SpeedTypeDef speed, uint16_t *length) 
     // Anyway, we want to return our serial number from OTP.
     // The OTP contains the serial number without the first four characters "CZPX" (total 15 chars, zero terminated).
     // And since it is already zero-terminated, we can convert the serial number into a unicode string and return it.
-    // The source address should be normally const uint8_t *, but the function's signature is without const (which is wrong in fact).
-#ifdef _DEBUG
-    // This is here just for the case of old dev boards which do not have anything in the OTP memory.
-    // Normal boards, which went through normal manufacturing process, have ALWAYS a set serial number terminated with \0
-    uint8_t tmp[16];
-    memcpy(tmp, (/*const*/ uint8_t *)OTP_SERIAL_NUMBER_ADDR, 16);
-    tmp[15] = 0; // to be sure...
+    // Additionally, it is required to print the serial number the same way as the MK3 does -> we must add CZPX to the beginning
+    uint8_t tmp[OTP_SERIAL_NUMBER_SIZE + 4] = "CZPX";
+    memcpy(tmp + 4, (const uint8_t *)OTP_SERIAL_NUMBER_ADDR, OTP_SERIAL_NUMBER_SIZE);
+    tmp[OTP_SERIAL_NUMBER_SIZE + 4 - 1] = 0; // proper string termination in case there is something wrong with the OTP data
 
     USBD_GetString(tmp, USBD_StrDesc, length);
-#else
-    USBD_GetString((/*const*/ uint8_t *)OTP_SERIAL_NUMBER_ADDR, USBD_StrDesc, length);
-#endif
     return USBD_StrDesc;
 }
 


### PR DESCRIPTION
- replace `sprintf `with `snprintf `where possible
- force using `static const char [] = ""` when assigning these strings into some pointers, which reference these strings beyond their scope of definition
- there are still a few spots to be fixed/improved, marked with `@@TODO`

Originally this branch was made for setting proper USB VID/PID and device strings
A3IDES-770