### PR TITLE
[4.0.2] Fix MINI's bed max temperature limit (#224)

### DIFF
--- a/include/marlin/Configuration_A3ides_2209_MINI.h
+++ b/include/marlin/Configuration_A3ides_2209_MINI.h
@@ -393,7 +393,13 @@
 #define HEATER_3_MAXTEMP 275
 #define HEATER_4_MAXTEMP 275
 #define HEATER_5_MAXTEMP 275
-#define BED_MAXTEMP 125
+// Beware: this is the absolute temperature limit.
+// The MINI cannot normally reach 110C.
+// Thus all usage in the UI must be lowered by 10C to offer a valid temperature limit.
+// Those 10C are a safety margin used throughout the whole Marlin code
+// (without a proper #define though :( )
+#define BED_MAXTEMP 110
+#define BED_MAXTEMP_SAFETY_MARGIN 10
 #define CHAMBER_MAXTEMP 100
 
 //===========================================================================

--- a/src/gui/menu_vars.cpp
+++ b/src/gui/menu_vars.cpp
@@ -28,7 +28,9 @@ const float z_offset_max = Z_OFFSET_MAX;
 const float zoffset_fl_range[3] = { z_offset_min, z_offset_max, z_offset_step };
 const char *zoffset_fl_format = "%.3f";
 const int32_t nozzle_range[3] = { 0, (HEATER_0_MAXTEMP - 15) * 1000, 1000 };
-const int32_t heatbed_range[3] = { 0, BED_MAXTEMP * 1000, 1000 };
+// The MINI can heat up no more than 100C, for detection of thermal run away the bed is set 10C higher
+// Thus do not allow the user to set a higher bed temp in the UI here
+const int32_t heatbed_range[3] = { 0, (BED_MAXTEMP - BED_MAXTEMP_SAFETY_MARGIN) * 1000, 1000 };
 const int32_t printfan_range[3] = { 0, 255000, 1000 };
 const int32_t flowfact_range[3] = { 50000, 150000, 1000 };
 const int32_t feedrate_range[3] = { 10000, 255000, 1000 };


### PR DESCRIPTION
* Fix MINI's bed max temperature limit

* Introduce BED_MAXTEMP_SAFETY_MARGIN

* related Marlin changes