### PR TITLE
Hack draw rect A3IDES-666

### DIFF
--- a/src/guiapi/src/st7789v.c
+++ b/src/guiapi/src/st7789v.c
@@ -487,6 +487,7 @@ void st7789v_draw_rect(rect_ui16_t rc, color_t clr) {
     st7789v_draw_line(pt1, pt2, clr);
     st7789v_draw_line(pt2, pt3, clr);
     st7789v_draw_line(pt3, pt, clr);
+    st7789v_set_pixel(pt2, clr); //hack, drawline is broken
 }
 
 void st7789v_fill_rect(rect_ui16_t rc, color_t clr) {


### PR DESCRIPTION
Draw rect does not draw 1 pixel.
Problem is in draw line, but it is used in many places i code (with wrong values).
So fix would not be trivial. Will be fixed in future A3IDES-665.

Quick hack is just draw that pixel.