### PR TITLE
Only mini with MINDA_BROKEN_CABLE_DETECTION should include "Z_probe.h…

### DIFF
--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -27,7 +27,9 @@
 #include "hwio_a3ides.h"
 #include "eeprom.h"
 #include "filament_sensor.h"
-#include "Z_probe.h" //get_Z_probe_endstop_hits
+#ifdef MINDA_BROKEN_CABLE_DETECTION
+    #include "Z_probe.h" //get_Z_probe_endstop_hits
+#endif
 
 #ifdef LCDSIM
     #include "lcdsim.h"


### PR DESCRIPTION
…" in marlin api.