### PR TITLE
FAT USB stick file sorting

### DIFF
--- a/lib/Middlewares/Third_Party/FatFs/src/ff.c
+++ b/lib/Middlewares/Third_Party/FatFs/src/ff.c
@@ -2448,7 +2448,7 @@ void get_fileinfo (		/* No return code */
 {
 	UINT i, j;
 	TCHAR c;
-	DWORD tm;
+	DWORD tm, tmc;
 #if _USE_LFN != 0
 	WCHAR w, lfv;
 	FATFS *fs = dp->obj.fs;
@@ -2529,7 +2529,9 @@ void get_fileinfo (		/* No return code */
 
 	fno->fattrib = dp->dir[DIR_Attr];				/* Attribute */
 	fno->fsize = ld_dword(dp->dir + DIR_FileSize);	/* Size */
-	tm = ld_dword(dp->dir + DIR_ModTime);			/* Timestamp */
+	tm = ld_dword(dp->dir + DIR_ModTime);			/* Modification Timestamp */
+	tmc = ld_dword(dp->dir + DIR_CrtTime);          /* Creation Timestamp */
+	tm = (tm > tmc) ? tm : tmc;
 	fno->ftime = (WORD)tm; fno->fdate = (WORD)(tm >> 16);
 }
 


### PR DESCRIPTION
A3IDES-578
Fixed file sorting when a user puts a USB stick into the Prusa MINI after adding a new G-code file. Now latest added file is correctly read and offered to print.
Technically, this fix takes the newest one from FAT's Creation time and Modification time - which should solve most of the situations a user may experience.

Kudos to @Chleba
This PR only cleans the original PR#262 from unrelated stuff.