### PR TITLE
Add automatic .dfu generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set(GENERATE_BBF
     )
 set(GENERATE_DFU
     "NO"
-    CACHE BOOL "Whether a .dfu file should be generated."
+    CACHE BOOL "Whether a .dfu file should be generated. Implies GENERATE_BBF."
     )
 set(SIGNING_KEY
     ""
@@ -88,6 +88,11 @@ foreach(OPTION "PRINTER" "MOTHERBOARD" "BOOTLOADER")
     message(FATAL_ERROR "Invalid ${OPTION} ${${OPTION}}: Valid values are ${${OPTION}_VALID_OPTS}")
   endif()
 endforeach()
+
+# in order to generate DFU file for bootloader, we need a BFU
+if(GENERATE_DFU AND BOOTLOADER)
+  set(GENERATE_BBF "YES")
+endif()
 
 # Resolve BUILD_NUMBER and PROJECT_VERSION_* variables
 resolve_version_variables()
@@ -362,16 +367,17 @@ if(GENERATE_DFU)
       get_dependency_directory("bootloader-${printer_low}" bootloader_dir)
       set(bootloader_input "0x08000000:${bootloader_dir}/bootloader.bin")
     endif()
+    set(firmware_input "0x08020000:${CMAKE_BINARY_DIR}/firmware.bbf")
   else()
-    set(firmware_addr "0x08000000")
+    set(firmware_input "0x08000000:${CMAKE_BINARY_DIR}/firmware.bin")
   endif()
 
   create_dfu(
     TARGET
     firmware
     INPUT
-    "${firmware_addr}:${CMAKE_CURRENT_BINARY_DIR}/firmware.bin"
     "${bootloader_input}"
+    "${firmware_input}"
     OUTPUT
     "${CMAKE_CURRENT_BINARY_DIR}/firmware.dfu"
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,10 @@ set(GENERATE_BBF
     "NO"
     CACHE STRING "Whether a .bbf version should be generated."
     )
+set(GENERATE_DFU
+    "NO"
+    CACHE BOOL "Whether a .dfu file should be generated."
+    )
 set(SIGNING_KEY
     ""
     CACHE FILEPATH "Path to a PEM EC private key to be used to sign the firmware."
@@ -347,6 +351,30 @@ if(GENERATE_BBF)
     )
 elseif(SIGNING_KEY)
   message(WARNING "SIGNING_KEY specified but BBF generation is not enabled.")
+endif()
+
+# generate .dfu version if requested
+if(GENERATE_DFU)
+  if(BOOTLOADER)
+    set(firmware_addr "0x08020000")
+    if(BOOTLOADER STREQUAL "YES")
+      string(TOLOWER ${PRINTER} printer_low)
+      get_dependency_directory("bootloader-${printer_low}" bootloader_dir)
+      set(bootloader_input "0x08000000:${bootloader_dir}/bootloader.bin")
+    endif()
+  else()
+    set(firmware_addr "0x08000000")
+  endif()
+
+  create_dfu(
+    TARGET
+    firmware
+    INPUT
+    "${firmware_addr}:${CMAKE_CURRENT_BINARY_DIR}/firmware.bin"
+    "${bootloader_input}"
+    OUTPUT
+    "${CMAKE_CURRENT_BINARY_DIR}/firmware.dfu"
+    )
 endif()
 
 target_include_directories(

--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -59,7 +59,11 @@ dependencies = {
             'Windows': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/clang-format-9.0.0-noext-win.zip',
             'Darwin': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/clang-format-9.0.0-darwin.zip',
         }
-    }
+    },
+    'bootloader-mini': {
+        'version': '1.0.0',
+        'url': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/bootloader-mini-1.0.0.zip',
+    },
 }
 pip_dependencies = ['ecdsa']
 # yapf: enable
@@ -134,8 +138,10 @@ def install_dependency(dependency):
     specs = dependencies[dependency]
     installation_directory = directory_for_dependency(dependency,
                                                       specs['version'])
-    download_and_unzip(url=specs['url'][platform.system()],
-                       directory=installation_directory)
+    url = specs['url']
+    if isinstance(url, dict):
+        url = url[platform.system()]
+    download_and_unzip(url=url, directory=installation_directory)
     fix_executable_permissions(dependency, installation_directory)
 
 

--- a/utils/build.py
+++ b/utils/build.py
@@ -126,6 +126,7 @@ class FirmwareBuildConfiguration(BuildConfiguration):
                  build_type: BuildType,
                  toolchain: Path = None,
                  generator: str = None,
+                 generate_dfu: bool = False,
                  generate_bbf: bool = False,
                  signing_key: Path = None,
                  version_suffix: str = None,
@@ -137,6 +138,7 @@ class FirmwareBuildConfiguration(BuildConfiguration):
         self.toolchain = toolchain or FirmwareBuildConfiguration.default_toolchain(
         )
         self.generator = generator
+        self.generate_dfu = generate_dfu
         self.generate_bbf = generate_bbf
         self.signing_key = signing_key
         self.version_suffix = version_suffix
@@ -165,6 +167,7 @@ class FirmwareBuildConfiguration(BuildConfiguration):
             ('PRINTER', 'STRING', self.printer.value),
             ('BOOTLOADER', 'STRING', self.bootloader.value),
             ('GENERATE_BBF', 'STRING', str(generate_bbf).upper()),
+            ('GENERATE_DFU', 'BOOL', 'ON' if self.generate_dfu else 'OFF'),
             ('SIGNING_KEY', 'FILEPATH', str(signing_key_flg)),
             ('CMAKE_TOOLCHAIN_FILE', 'FILEPATH', str(self.toolchain)),
             ('CMAKE_BUILD_TYPE', 'STRING', self.build_type.value.title()),
@@ -291,8 +294,8 @@ def build(configuration: BuildConfiguration,
                                        check=False)
         build_returncode = build_process.returncode
         products.extend(
-            build_dir / fname
-            for fname in ['firmware', 'firmware.bin', 'firmware.bbf']
+            build_dir / fname for fname in
+            ['firmware', 'firmware.bin', 'firmware.bbf', 'firmware.dfu']
             if (build_dir / fname).exists())
     else:
         build_returncode = None
@@ -545,6 +548,11 @@ def main():
               ' Use --signing-key to specify a private key to be used for signing.')
     )
     parser.add_argument(
+        '--generate-dfu',
+        action='store_true',
+        help='Generate .dfu versions of the firmware.'
+    )
+    parser.add_argument(
         '--host-tools',
         action='store_true',
         help=('Build host tools (png2font and others). '
@@ -592,6 +600,7 @@ def main():
             printer=printer,
             bootloader=bootloader,
             build_type=build_type,
+            generate_dfu=args.generate_dfu,
             generate_bbf=args.generate_bbf,
             signing_key=args.signing_key,
             version_suffix=args.version_suffix,

--- a/utils/dfu.py
+++ b/utils/dfu.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+import sys
+import argparse
+import struct
+import zlib
+from typing import List
+from pathlib import Path
+
+
+class DfuImage:
+    def __init__(self, address, data):
+        self.address = address
+        self.data = data
+
+
+class DfuTarget:
+    def __init__(self, images: List[DfuImage], name='Generic Target'):
+        self.images = images
+        self.name = name
+
+
+def compute_crc(data):
+    return 0xFFFFFFFF & -zlib.crc32(data) - 1
+
+
+def dfu_file_create_prefix(*, dfu_file_size, targets_count) -> bytes:
+    return struct.pack('<5sBIB', b'DfuSe', 0x01, dfu_file_size, targets_count)
+
+
+def dfu_file_create_target(target: DfuTarget) -> bytes:
+    images_data = bytes()
+    for image in target.images:
+        images_data += struct.pack('<II', image.address, len(image.data))
+        images_data += image.data
+    target_prefix = struct.pack('<6sBI255s2I', b'Target', 0, 1,
+                                target.name.encode('utf-8'), len(images_data),
+                                len(target.images))
+    return target_prefix + images_data
+
+
+def dfu_file_append_suffix(data,
+                           *,
+                           bcd_device=0x0000,
+                           id_product=0x0000,
+                           id_vendor=0x0000) -> bytes:
+    data += struct.pack('<HHHH3sB', bcd_device, id_product, id_vendor, 0x011A,
+                        b'UFD', 16)
+    data += struct.pack('<I', compute_crc(data))
+    return data
+
+
+def dfu_file_create(path, id_product, id_vendor, targets: List[DfuTarget]):
+    targets_data = bytes()
+    for target in targets:
+        targets_data += dfu_file_create_target(target)
+    prefix_data = dfu_file_create_prefix(dfu_file_size=len(targets_data) + 11,
+                                         targets_count=len(targets))
+    data = prefix_data + targets_data
+    data = dfu_file_append_suffix(data,
+                                  id_product=id_product,
+                                  id_vendor=id_vendor)
+    with open(path, 'wb') as f:
+        f.write(data)
+
+
+def device_id_spec(arg):
+    return tuple(map(lambda s: int(s, 0) & 0xffff, arg.split(':', 1)))
+
+
+def input_file_spec(arg):
+    address, filepath = arg.split(':', 1)
+    return int(address, 0), Path(filepath)
+
+
+def create_cmd(args):
+    images = []
+    for infile in args.input_files:
+        with open(infile[1], 'rb') as f:
+            images.append(DfuImage(infile[0], f.read()))
+    dfu_file_create(path=args.dfu_file,
+                    id_product=args.device[0],
+                    id_vendor=args.device[1],
+                    targets=[DfuTarget(images=images)])
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    # yapf: disable
+    parser_create = subparsers.add_parser('create', help='create a dfu file')
+    parser_create.add_argument(
+        '--device', type=device_id_spec, default='0x0000:0x0483')
+    parser_create.add_argument(
+        'input_files', nargs='+', type=input_file_spec,
+        help='Input binary files and their addresses, eg. "0x0:./firmware.bin"')
+    parser_create.add_argument(
+        'dfu_file', type=Path,
+        help='Path where the output file should be saved')
+    parser_create.set_defaults(func=create_cmd)
+    # yapf: enable
+    args = parser.parse_args(argv[1:])
+    try:
+        args.func(args)
+    except AttributeError:
+        parser.parse_args(['--help'])
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/utils/dfu.py
+++ b/utils/dfu.py
@@ -74,9 +74,14 @@ def input_file_spec(arg):
 
 def create_cmd(args):
     images = []
+    # load input files
     for infile in args.input_files:
         with open(infile[1], 'rb') as f:
-            images.append(DfuImage(infile[0], f.read()))
+            data = f.read()
+            if infile[1].suffix == '.bbf':
+                data = data[64:]  # skip signature in .bbf files
+            images.append(DfuImage(infile[0], data))
+    # create dfu files
     dfu_file_create(path=args.dfu_file,
                     id_product=args.device[0],
                     id_vendor=args.device[1],

--- a/utils/holly/build-pr.jenkins
+++ b/utils/holly/build-pr.jenkins
@@ -14,6 +14,7 @@ pipeline {
                     def configurations = [
                         [printer: "mini", build_type: "release", bootloader: "no"],
                         [printer: "mini", build_type: "release", bootloader: "empty"],
+                        [printer: "mini", build_type: "release", bootloader: "yes"],
                     ]
 
                     // prepare version suffix
@@ -44,6 +45,7 @@ pipeline {
                                     --build-type ${config.build_type} \
                                     --bootloader ${config.bootloader} \
                                     --generate-bbf \
+                                    --generate-dfu \
                                     --no-store-output \
                                     --version-suffix=${full_suffix} \
                                     --version-suffix-short=${short_suffix}


### PR DESCRIPTION
- adds `dfu.py` script, which can generate a `.dfu` file from given `.bin` files
- adds precompiled bootloader as a dependency
- introduces new `GENERATE_DFU` and `--generate-dfu` options for CMake and `build.py`, respectively
- when compiling with `--bootloader yes --generate-dfu` (`-DBOOTLOADER=YES -DGENERATE_DFU=YES`), it automatically merges the firmware and bootloader into a single `firmware.dfu` file