### PR TITLE
Load dialog BSOD

### DIFF
--- a/src/gui/dialogs/DialogRadioButton.hpp
+++ b/src/gui/dialogs/DialogRadioButton.hpp
@@ -9,6 +9,8 @@ using PhaseTexts = std::array<const char *, MAX_RESPONSES>;
 //responses are counted and stored into btn_count
 //if there is more labels than buttons, "additional buttons" are not acessible
 //if there is less labels than buttons, "remaining buttons" have no labels
+#pragma pack(push)
+#pragma pack(1)
 class RadioButton {
 public:
     struct Window {
@@ -46,3 +48,4 @@ public:
     Response Click() const; //click returns response to be send, 0 buttons will return Response::_none
     bool IsEnabled() const;
 };
+#pragma pack(pop)


### PR DESCRIPTION
BFW-741
There was an BSOD in release in optimalized code accessing an static array
 "illegal unaligned load or store"

Pragma pack in radiobutton fixed it