### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The currently supported model is:
 ### Requirements
 
 - Python 3.6 or newer
+- python3-pip
 
 ### Cloning this repository
 


### PR DESCRIPTION
With missing module pip, which is not default on my system I am getting error:

/usr/bin/python3: No module named pip
Traceback (most recent call last):
  File "/home/marek/workspace/Prusa-Firmware-Buddy-Private/utils/bootstrap.py", line 228, in <module>
    sys.exit(main())
  File "/home/marek/workspace/Prusa-Firmware-Buddy-Private/utils/bootstrap.py", line 211, in main
    installed_pip_packages = get_installed_pip_packages()
  File "/home/marek/workspace/Prusa-Firmware-Buddy-Private/utils/bootstrap.py", line 128, in get_installed_pip_packages
    '--disable-pip-version-check', '--format', 'json')
  File "/home/marek/workspace/Prusa-Firmware-Buddy-Private/utils/bootstrap.py", line 106, in run
    encoding='utf-8')
  File "/usr/lib/python3.7/subprocess.py", line 487, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/bin/python3', '-m', 'pip', 'list', '--disable-pip-version-check', '--format', 'json']' returned non-zero exit status 1.
bootstrap.py failed.
