### PR TITLE
Build all stages even if first fails

### DIFF
--- a/utils/holly/build-pr.jenkins
+++ b/utils/holly/build-pr.jenkins
@@ -55,18 +55,20 @@ pipeline {
                     // create the build stages
                     configurations.each { config ->
                         stage("Build - ${config.printer},${config.build_type},${config.bootloader}boot") {
-                            sh """
-                                python utils/build.py \
-                                    --printer ${config.printer} \
-                                    --build-type ${config.build_type} \
-                                    --bootloader ${config.bootloader} \
-                                    --generate-bbf \
-                                    --generate-dfu \
-                                    --no-store-output \
-                                    --version-suffix=${full_suffix} \
-                                    --version-suffix-short=${short_suffix} \
-                                    -DCUSTOM_COMPILE_OPTIONS:STRING=-Werror
-                            """
+                            catchError{
+                                sh """
+                                    python utils/build.py \
+                                        --printer ${config.printer} \
+                                        --build-type ${config.build_type} \
+                                        --bootloader ${config.bootloader} \
+                                        --generate-bbf \
+                                        --generate-dfu \
+                                        --no-store-output \
+                                        --version-suffix=${full_suffix} \
+                                        --version-suffix-short=${short_suffix} \
+                                        -DCUSTOM_COMPILE_OPTIONS:STRING=-Werror
+                                """
+                            }
                         }
                     }
                 }

--- a/utils/holly/build-pr.jenkins
+++ b/utils/holly/build-pr.jenkins
@@ -55,7 +55,7 @@ pipeline {
                     // create the build stages
                     configurations.each { config ->
                         stage("Build - ${config.printer},${config.build_type},${config.bootloader}boot") {
-                            catchError{
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                                 sh """
                                     python utils/build.py \
                                         --printer ${config.printer} \


### PR DESCRIPTION
Build remaining stages after failed stage. This allows to observe which variants are failing.

buildResult: 'FAILURE' is redundant here, as catchError marks build as failed anyway, I left it there for clarity.
stageResult: 'FAILURE' is needed here, otherwise stage is marked as Passed.