### PR TITLE
SFN path format into a filebrowser

### DIFF
--- a/src/common/media.cpp
+++ b/src/common/media.cpp
@@ -94,8 +94,9 @@ void media_get_sfn_path(char *sfn, const char *filepath) {
 void media_print_start(const char *filepath) {
     FILINFO filinfo;
     if (media_print_state == media_print_state_NONE) {
+        strlcpy(media_print_filepath, filepath, sizeof(media_print_filepath) - 1);
         // get SFN path
-        media_get_sfn_path(media_print_filepath, filepath);
+        // media_get_sfn_path(media_print_filepath, filepath);
         if (f_stat(media_print_filepath, &filinfo) == FR_OK) {
             strlcpy(media_print_filename, filinfo.fname, sizeof(media_print_filename) - 1);
             media_print_size = filinfo.fsize;

--- a/src/common/media.cpp
+++ b/src/common/media.cpp
@@ -51,52 +51,10 @@ media_state_t media_get_state(void) {
     return media_state;
 }
 
-void media_get_sfn_path(char *sfn, const char *filepath) {
-    uint i, j, k;
-    i = j = k = 0;
-    uint sl = strlen(filepath); // length of filepath
-    FILINFO fi;
-    char tmpPath[sl] = { 0 };
-    while (i <= sl) {
-        // folder || endfile found -> begin
-        if (filepath[i] == '/' || i == sl) {
-            // file info struct with fname & altname
-            strlcpy(tmpPath, filepath, i + 1);
-            FRESULT fRes = f_stat(tmpPath, &fi);
-            if (fRes == FR_OK) {
-                // we got folder || end file info -> process
-                const char *tmpDir = fi.altname; // LFN MUST BE TURNED ON (1||2)
-                _dbg(tmpDir);
-                // FATFS flag for valid 8.3 fname - used instead of altname
-                if (tmpDir[0] == 0 && fi.fname[0] != 0) {
-                    tmpDir = fi.fname;
-                }
-                // save SFN part
-                for (j = 0; j < 12; j++) {
-                    if (tmpDir[j] == 0) {
-                        break;
-                    }
-                    sfn[k] = tmpDir[j];
-                    k++;
-                }
-                // add folder slash
-                if (i != sl) {
-                    sfn[k] = '/';
-                    k++;
-                }
-                // SFN part of path saved
-            }
-        }
-        i++;
-    }
-}
-
 void media_print_start(const char *filepath) {
     FILINFO filinfo;
     if (media_print_state == media_print_state_NONE) {
         strlcpy(media_print_filepath, filepath, sizeof(media_print_filepath) - 1);
-        // get SFN path
-        // media_get_sfn_path(media_print_filepath, filepath);
         if (f_stat(media_print_filepath, &filinfo) == FR_OK) {
             strlcpy(media_print_filename, filinfo.fname, sizeof(media_print_filename) - 1);
             media_print_size = filinfo.fsize;

--- a/src/common/media.h
+++ b/src/common/media.h
@@ -60,9 +60,6 @@ extern void media_set_removed(void);
 
 extern void media_set_error(media_error_t error);
 
-// extern void media_get_sfn_path(char *sfn, const char *filepath, char *aname);
-extern void media_get_sfn_path(char *sfn, const char *filepath);
-
 #ifdef __cplusplus
 }
 #endif //__cplusplus

--- a/src/gui/screen_filebrowser.cpp
+++ b/src/gui/screen_filebrowser.cpp
@@ -190,6 +190,7 @@ static int screen_filebrowser_event(screen_t *screen, window_t *window,
 
             if (written < 0 || written >= (int)FILE_PATH_MAX_LEN) {
                 LOG_ERROR("failed to prepare file path for print");
+                gui_msgbox_prompt("File is nested too deep.", MSGBOX_BTN_OK | MSGBOX_ICO_INFO);
                 return 0;
             }
 

--- a/src/gui/screen_filebrowser.cpp
+++ b/src/gui/screen_filebrowser.cpp
@@ -125,6 +125,7 @@ void get_sfn_path(char *sfn, const char *filepath) {
         i++;
     }
 }
+
 static int screen_filebrowser_event(screen_t *screen, window_t *window,
     uint8_t event, void *param) {
     if (marlin_event_clr(MARLIN_EVT_MediaRemoved)) { // close screen when media removed
@@ -177,22 +178,20 @@ static int screen_filebrowser_event(screen_t *screen, window_t *window,
         marlin_vars_t *vars = marlin_vars();
 
         if (vars->media_file_name && vars->media_file_path) {
-            char tmpFilePath[FILE_PATH_MAX_LEN] = { 0 };
             int written;
             if (!strcmp(filelist->altpath, "/"))
-                written = snprintf(tmpFilePath, FILE_PATH_MAX_LEN,
-                    "/%s", currentFName);
+                written = sprintf(vars->media_file_path, "/%s", currentFName);
             else
-                written = snprintf(tmpFilePath, FILE_PATH_MAX_LEN,
-                    "/%s/%s", filelist->altpath, currentFName);
+                written = sprintf(vars->media_file_path, "%s/%s", filelist->altpath, currentFName);
+
+            char tmpFilePath[FILE_PATH_MAX_LEN] = { 0 };
+            get_sfn_path(tmpFilePath, vars->media_file_path);
+            written = snprintf(vars->media_file_path, FILE_PATH_MAX_LEN, "%s", tmpFilePath);
 
             if (written < 0 || written >= (int)FILE_PATH_MAX_LEN) {
                 LOG_ERROR("failed to prepare file path for print");
                 return 0;
             }
-
-            memset(vars->media_file_path, 0, FILE_PATH_MAX_LEN);
-            get_sfn_path(vars->media_file_path, tmpFilePath);
 
             strcpy(vars->media_file_name, currentFName);
 

--- a/src/gui/screen_filebrowser.cpp
+++ b/src/gui/screen_filebrowser.cpp
@@ -191,6 +191,7 @@ static int screen_filebrowser_event(screen_t *screen, window_t *window,
                 return 0;
             }
 
+            memset(vars->media_file_path, 0, FILE_PATH_MAX_LEN);
             get_sfn_path(vars->media_file_path, tmpFilePath);
 
             strcpy(vars->media_file_name, currentFName);


### PR DESCRIPTION
Moved getting SFN path into a filebrowser, because that's where is stored into a marlin_vars request when start printing. Media.cpp is getting path variable from there - so previous solution (BFW-468) was not effective for deeper nested files because of length.

BFW-795