### PR TITLE
Make filebrowser remember last selected file

### DIFF
--- a/lib/WUI/wui.c
+++ b/lib/WUI/wui.c
@@ -48,7 +48,7 @@ static void update_wui_vars(void) {
     wui_vars.sd_precent_done = wui_marlin_vars->sd_percent_done;
     wui_vars.sd_printing = wui_marlin_vars->sd_printing;
     if (marlin_change_clr(MARLIN_VAR_FILENAME)) {
-        strlcpy(wui_vars.gcode_name, wui_marlin_vars->media_file_name, FILE_NAME_MAX_LEN);
+        strlcpy(wui_vars.gcode_name, wui_marlin_vars->media_LFN, FILE_NAME_MAX_LEN);
     }
 
     osMutexRelease(wui_thread_mutex_id);

--- a/src/common/cmath_ext.h
+++ b/src/common/cmath_ext.h
@@ -17,7 +17,7 @@
     _a <= _b ? _a : _b; })
 
     /// -1 = negative, 1 = positive, 0 = 0
-    #define SIGN(x) \
+    #define SIGN0(x) \
         ({ __typeof__ (x) _x = (x); \
     (_x > 0) - (_x < 0); })
 

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -170,8 +170,8 @@ void marlin_server_init(void) {
     marlin_server.mesh.xc = 4;
     marlin_server.mesh.yc = 4;
     marlin_server.update_vars = MARLIN_VAR_MSK_DEF;
-    marlin_server.vars.media_file_name = media_print_filename;
-    marlin_server.vars.media_file_path = media_print_filepath;
+    marlin_server.vars.media_LFN = media_print_filename();
+    marlin_server.vars.media_SFN_path = media_print_filepath();
 }
 
 void print_fan_spd() {

--- a/src/common/marlin_vars.c
+++ b/src/common/marlin_vars.c
@@ -111,9 +111,9 @@ variant8_t marlin_vars_get_var(marlin_vars_t *vars, uint8_t var_id) {
         case MARLIN_VAR_PRNSTATE:
             return variant8_ui8(vars->print_state);
         case MARLIN_VAR_FILENAME:
-            return variant8_pchar(vars->media_file_name, 0, 1);
+            return variant8_pchar(vars->media_LFN, 0, 1);
         case MARLIN_VAR_FILEPATH:
-            return variant8_pchar(vars->media_file_path, 0, 1);
+            return variant8_pchar(vars->media_SFN_path, 0, 1);
         case MARLIN_VAR_DTEM_NOZ:
             return variant8_flt(vars->display_nozzle);
         case MARLIN_VAR_TIMTOEND:
@@ -204,14 +204,14 @@ void marlin_vars_set_var(marlin_vars_t *vars, uint8_t var_id, variant8_t var) {
             vars->print_state = var.ui8;
             break;
         case MARLIN_VAR_FILENAME:
-            if (vars->media_file_name)
+            if (vars->media_LFN)
                 if (var.type == VARIANT8_PCHAR)
-                    strncpy(vars->media_file_name, var.pch, FILE_NAME_MAX_LEN);
+                    strncpy(vars->media_LFN, var.pch, FILE_NAME_MAX_LEN);
             break;
         case MARLIN_VAR_FILEPATH:
-            if (vars->media_file_path)
+            if (vars->media_SFN_path)
                 if (var.type == VARIANT8_PCHAR)
-                    strncpy(vars->media_file_path, var.pch, FILE_PATH_MAX_LEN);
+                    strncpy(vars->media_SFN_path, var.pch, FILE_PATH_MAX_LEN);
             break;
         case MARLIN_VAR_DTEM_NOZ:
             vars->display_nozzle = var.flt;
@@ -293,10 +293,10 @@ int marlin_vars_value_to_str(marlin_vars_t *vars, uint8_t var_id, char *str, uns
             ret = snprintf(str, size, "%u", (unsigned int)(vars->print_state));
             break;
         case MARLIN_VAR_FILENAME:
-            ret = snprintf(str, size, "%s", vars->media_file_name);
+            ret = snprintf(str, size, "%s", vars->media_LFN);
             break;
         case MARLIN_VAR_FILEPATH:
-            ret = snprintf(str, size, "%s", vars->media_file_path);
+            ret = snprintf(str, size, "%s", vars->media_SFN_path);
             break;
         case MARLIN_VAR_DTEM_NOZ:
             ret = snprintf(str, size, "%.1f", (double)(vars->display_nozzle));
@@ -381,10 +381,10 @@ int marlin_vars_str_to_value(marlin_vars_t *vars, uint8_t var_id, const char *st
             ret = sscanf(str, "%hhu", &(vars->print_state));
             break;
         case MARLIN_VAR_FILENAME:
-            ret = sscanf(str, "%s", (vars->media_file_name));
+            ret = sscanf(str, "%s", (vars->media_LFN));
             break;
         case MARLIN_VAR_FILEPATH:
-            ret = sscanf(str, "%s", (vars->media_file_path));
+            ret = sscanf(str, "%s", (vars->media_SFN_path));
             break;
         case MARLIN_VAR_DTEM_NOZ:
             ret = sscanf(str, "%f", &(vars->display_nozzle));

--- a/src/common/marlin_vars.h
+++ b/src/common/marlin_vars.h
@@ -126,8 +126,8 @@ typedef struct _marlin_vars_t {
     uint32_t print_duration;          // print_job_timer.duration() [ms]
     uint8_t media_inserted;           // media_is_inserted()
     marlin_print_state_t print_state; // marlin_server.print_state
-    char *media_file_name;            //
-    char *media_file_path;            //
+    char *media_LFN;                  // Long-File-Name of the currently selected file - a pointer to a global static buffer
+    char *media_SFN_path;             // Short-File-Name path to currently selected file - a pointer to a global static buffer
     float display_nozzle;             // nozzle temperature to display [C]
     uint32_t time_to_end;             // oProgressData.oTime2End.mGetValue() [ms]
 } marlin_vars_t;

--- a/src/common/media.cpp
+++ b/src/common/media.cpp
@@ -5,6 +5,7 @@
 #include "ff.h"
 #include "usbh_core.h"
 #include "../Marlin/src/gcode/queue.h"
+#include "cmath_ext.h"
 
 extern USBH_HandleTypeDef hUsbHostHS; // UsbHost handle
 
@@ -34,8 +35,21 @@ static void _usbhost_reenum(void) {
     }
 }
 
-char media_print_filename[MEDIA_PRINT_FILENAME_SIZE] = { 0 };
-char media_print_filepath[MEDIA_PRINT_FILEPATH_SIZE] = { 0 };
+/// File name (Long-File-Name) of the file being printed
+static char media_print_LFN[MEDIA_PRINT_FILENAME_SIZE] = { 0 };
+
+/// Absolute path to the file being printed.
+/// MUST be in Short-File-Name (DOS 8.3) notation, since
+/// the transfer buffer is ~120B long (LFN paths would run out of space easily)
+static char media_print_SFN_path[MEDIA_PRINT_FILEPATH_SIZE] = { 0 };
+
+char *media_print_filename() {
+    return media_print_LFN;
+}
+
+char *media_print_filepath() {
+    return media_print_SFN_path;
+}
 
 static media_state_t media_state = media_state_REMOVED;
 static media_error_t media_error = media_error_OK;
@@ -51,55 +65,55 @@ media_state_t media_get_state(void) {
     return media_state;
 }
 
-void media_get_sfn_path(char *sfn, const char *filepath) {
-    uint i, j, k;
-    i = j = k = 0;
-    uint sl = strlen(filepath); // length of filepath
-    FILINFO fi;
-    char tmpPath[sl] = { 0 };
-    while (i <= sl) {
-        // folder || endfile found -> begin
-        if (filepath[i] == '/' || i == sl) {
-            // file info struct with fname & altname
-            strlcpy(tmpPath, filepath, i + 1);
-            FRESULT fRes = f_stat(tmpPath, &fi);
-            if (fRes == FR_OK) {
-                // we got folder || end file info -> process
-                const char *tmpDir = fi.altname; // LFN MUST BE TURNED ON (1||2)
-                _dbg(tmpDir);
-                // FATFS flag for valid 8.3 fname - used instead of altname
-                if (tmpDir[0] == 0 && fi.fname[0] != 0) {
-                    tmpDir = fi.fname;
-                }
-                // save SFN part
-                for (j = 0; j < 12; j++) {
-                    if (tmpDir[j] == 0) {
-                        break;
-                    }
-                    sfn[k] = tmpDir[j];
-                    k++;
-                }
-                // add folder slash
-                if (i != sl) {
-                    sfn[k] = '/';
-                    k++;
-                }
-                // SFN part of path saved
-            }
+void media_get_SFN_path(char *sfn, uint32_t sfn_size, char *filepath) {
+    *sfn = 0; // init the output buffer
+    if (!*filepath)
+        return; // empty path received -> don't bother
+
+    // skip initial '/'
+    while (*filepath == '/')
+        ++filepath;
+
+    // first walk over filepath and replace all '/' with \x00
+    // that will allow for incremental traversal through the path without the need for additional buffer
+    // the '/' will be replaced back, so in fact, filepath will not be changed, but must be in RAM!
+    // Moreover, fpend will get the address of the end of filepath with this cycle
+    char *fpend = filepath;
+    for (; *fpend; ++fpend) {
+        if (*fpend == '/')
+            *fpend = 0;
+    }
+    char *tmpEnd = filepath + strlen(filepath); // up until the first \x00
+
+    // normally, I'd do this by hijacking FATfs's follow_path(), which in fact does the same
+    // but it is not in FATfs's public interface ...
+    while (filepath < fpend) {
+        *sfn = '/'; // prepare an output slash
+        FILINFO fi;
+        // LFN MUST BE TURNED ON (1||2)
+        // unfortunately, this does follow_path internally all over again
+        if (f_stat(filepath, &fi) == FR_OK) {
+            // we got folder || end file info -> process
+            // FATFS flag for valid 8.3 fname - used instead of altname
+            const char *fname = (fi.altname[0] == 0 && fi.fname[0] != 0) ? fi.fname : fi.altname;
+            _dbg(fname);
+            uint32_t chars_added = strlcpy(sfn, fname, MIN(sfn_size, 12U));
+            sfn += chars_added;
+            sfn_size -= chars_added;
         }
-        i++;
+        *tmpEnd = '/';                    // return the '/' back into filepath
+        tmpEnd = tmpEnd + strlen(tmpEnd); // iterate to the next \x00
     }
 }
 
-void media_print_start(const char *filepath) {
+void media_print_start(const char *sfnFilePath) {
     FILINFO filinfo;
     if (media_print_state == media_print_state_NONE) {
-        // get SFN path
-        media_get_sfn_path(media_print_filepath, filepath);
-        if (f_stat(media_print_filepath, &filinfo) == FR_OK) {
-            strlcpy(media_print_filename, filinfo.fname, sizeof(media_print_filename) - 1);
+        strlcpy(media_print_SFN_path, sfnFilePath, sizeof(media_print_SFN_path));
+        if (f_stat(media_print_SFN_path, &filinfo) == FR_OK) {
+            strlcpy(media_print_LFN, filinfo.fname, sizeof(media_print_LFN));
             media_print_size = filinfo.fsize;
-            if (f_open(&media_print_fil, media_print_filepath, FA_READ) == FR_OK) {
+            if (f_open(&media_print_fil, media_print_SFN_path, FA_READ) == FR_OK) {
                 media_current_position = 0;
                 media_current_line = 0;
                 media_print_state = media_print_state_PRINTING;
@@ -129,7 +143,7 @@ void media_print_pause(void) {
 
 void media_print_resume(void) {
     if (media_print_state == media_print_state_PAUSED) {
-        if (f_open(&media_print_fil, media_print_filepath, FA_READ) == FR_OK) {
+        if (f_open(&media_print_fil, media_print_SFN_path, FA_READ) == FR_OK) {
             if (f_lseek(&media_print_fil, media_current_position) == FR_OK)
                 media_print_state = media_print_state_PRINTING;
             else

--- a/src/common/media.h
+++ b/src/common/media.h
@@ -28,13 +28,17 @@ typedef enum {
 extern "C" {
 #endif //__cplusplus
 
-extern char media_print_filename[MEDIA_PRINT_FILENAME_SIZE];
-
-extern char media_print_filepath[MEDIA_PRINT_FILEPATH_SIZE];
+/// Do not use this anywhere - the accessor functions are here just because marlin_server.cpp needs the allocated buffer.
+/// @@TODO to be improved in the future
+extern char *media_print_filename();
+extern char *media_print_filepath();
 
 extern media_state_t media_get_state(void);
 
-extern void media_print_start(const char *filepath);
+/// Start printing by issuing M23 into Marlin with a file path.
+/// Copies the content of sfnFilePath into marlin_vars->media_SFN_path (aka media_print_filepath)
+/// Updates marlin_vars->media_LFN as a side-effect by opening the marlin_vars->media_SFN_path and reading its LFN
+extern void media_print_start(const char *sfnFilePath);
 
 extern void media_print_stop(void);
 
@@ -60,8 +64,11 @@ extern void media_set_removed(void);
 
 extern void media_set_error(media_error_t error);
 
-// extern void media_get_sfn_path(char *sfn, const char *filepath, char *aname);
-extern void media_get_sfn_path(char *sfn, const char *filepath);
+/// Computes short file name (SFN) path from a (potentially) long file name (LFN)
+/// path in filepath.
+/// @param sfn output buffer to store the SFN path
+/// @param filepath input LFN path, intentionally NOT const -
+extern void media_get_SFN_path(char *sfn, uint32_t sfn_size, char *filepath);
 
 #ifdef __cplusplus
 }

--- a/src/gui/guimain.c
+++ b/src/gui/guimain.c
@@ -63,8 +63,8 @@ static void _gui_loop_cb() {
     marlin_client_loop();
 }
 
-char gui_media_filename[FILE_NAME_MAX_LEN + 1];
-char gui_media_filepath[FILE_PATH_MAX_LEN + 1];
+char gui_media_LFN[FILE_NAME_MAX_LEN + 1];
+char gui_media_SFN_path[FILE_PATH_MAX_LEN + 1]; //@@TODO DR - tohle pouzit na ulozeni posledni cesty
 
 void gui_run(void) {
     if (diag_fastboot)
@@ -93,8 +93,8 @@ void gui_run(void) {
         update_firmware_screen();
 
     gui_marlin_vars = marlin_client_init();
-    gui_marlin_vars->media_file_name = gui_media_filename;
-    gui_marlin_vars->media_file_path = gui_media_filepath;
+    gui_marlin_vars->media_LFN = gui_media_LFN;
+    gui_marlin_vars->media_SFN_path = gui_media_SFN_path;
 
     marlin_client_set_event_notify(MARLIN_EVT_MSK_DEF);
     marlin_client_set_change_notify(MARLIN_VAR_MSK_DEF);

--- a/src/gui/lazyfilelist-c-api.cpp
+++ b/src/gui/lazyfilelist-c-api.cpp
@@ -3,17 +3,22 @@
 
 using LDV9 = LazyDirView<9>;
 
-extern "C" bool LDV_ChangeDir(void *LDV, bool sortByName, const char *path) {
+extern "C" bool LDV_ChangeDir(void *LDV, bool sortByName, const char *path, const char *fname) {
     LDV9 *ldv = reinterpret_cast<LDV9 *>(LDV);
     ldv->ChangeDirectory(path,
         sortByName ? LDV9::SortPolicy::BY_NAME : LDV9::SortPolicy::BY_CRMOD_DATETIME,
-        nullptr);
+        fname);
     return true;
 }
 
 extern "C" uint32_t LDV_TotalFilesCount(void *LDV) {
     LDV9 *ldv = reinterpret_cast<LDV9 *>(LDV);
     return ldv->TotalFilesCount();
+}
+
+extern "C" uint32_t LDV_WindowSize(void *LDV) {
+    LDV9 *ldv = reinterpret_cast<LDV9 *>(LDV);
+    return ldv->WindowSize();
 }
 
 extern "C" uint32_t LDV_VisibleFilesCount(void *LDV) {
@@ -31,9 +36,16 @@ extern "C" bool LDV_MoveDown(void *LDV) {
     return ldv->MoveDown();
 }
 
-extern "C" const char *LDV_FileAt(void *LDV, int index, bool *isFile) {
+extern "C" const char *LDV_LongFileNameAt(void *LDV, int index, bool *isFile) {
     LDV9 *ldv = reinterpret_cast<LDV9 *>(LDV);
-    auto i = ldv->FileNameAt(index);
+    auto i = ldv->LongFileNameAt(index);
+    *isFile = i.second == LDV9::EntryType::FILE;
+    return i.first;
+}
+
+extern "C" const char *LDV_ShortFileNameAt(void *LDV, int index, bool *isFile) {
+    LDV9 *ldv = reinterpret_cast<LDV9 *>(LDV);
+    auto i = ldv->ShortFileNameAt(index);
     *isFile = i.second == LDV9::EntryType::FILE;
     return i.first;
 }

--- a/src/gui/lazyfilelist-c-api.h
+++ b/src/gui/lazyfilelist-c-api.h
@@ -7,12 +7,14 @@
 extern "C" {
 #endif
 
-bool LDV_ChangeDir(void *LDV, bool sortByName, const char *path);
+bool LDV_ChangeDir(void *LDV, bool sortByName, const char *path, const char *fname);
 uint32_t LDV_TotalFilesCount(void *LDV);
+uint32_t LDV_WindowSize(void *LDV);
 uint32_t LDV_VisibleFilesCount(void *LDV);
 bool LDV_MoveUp(void *LDV);
 bool LDV_MoveDown(void *LDV);
-const char *LDV_FileAt(void *LDV, int index, bool *isFile);
+const char *LDV_LongFileNameAt(void *LDV, int index, bool *isFile);
+const char *LDV_ShortFileNameAt(void *LDV, int index, bool *isFile);
 void *LDV_Get(void);
 
 #ifdef __cplusplus

--- a/src/gui/lazyfilelist.h
+++ b/src/gui/lazyfilelist.h
@@ -6,6 +6,12 @@
 #include <limits.h>
 #include "file_list_defs.h"
 
+#ifndef LAZYFILELIST_UNITTEST
+    #include "../common/marlin_vars.h" // for FILE_PATH_MAX_LEN
+#else
+    #define FILE_PATH_MAX_LEN 103
+#endif
+
 /// Lazy Dir View
 /// Implements a fixed size view over a directory's content.
 ///
@@ -32,23 +38,36 @@ public:
                           ///< Expects support in FATfs - to return the most recent time stamp from both of them
     };
 
-    LazyDirView()
-        : totalFiles(0)
-        , windowStartingFrom(0) {
+    LazyDirView() {
+        Clear();
+    }
+
+    void Clear() {
+        totalFiles = 0;
+        windowStartingFrom = 0;
         std::for_each(files.begin(), files.end(), [](Entry &e) { e.Clear(); });
     }
 
     /// @param windowIndex index within the window (i.e. [0 - WINDOW_SIZE-1])
     /// @return pointer to a filename (or nullptr, if there is nothing at that index) and the type of the entry (FILE / DIR)
-    std::pair<const char *, EntryType> FileNameAt(size_t windowIndex) {
-        return std::make_pair(files[windowIndex].name, files[windowIndex].isFile ? EntryType::FILE : EntryType::DIR);
+    std::pair<const char *, EntryType> LongFileNameAt(size_t windowIndex) const {
+        return std::make_pair(files[windowIndex].lfn, files[windowIndex].isFile ? EntryType::FILE : EntryType::DIR);
+    }
+
+    /// @param windowIndex index within the window (i.e. [0 - WINDOW_SIZE-1])
+    /// @return pointer to a filename (or nullptr, if there is nothing at that index) and the type of the entry (FILE / DIR)
+    std::pair<const char *, EntryType> ShortFileNameAt(size_t windowIndex) const {
+        return std::make_pair(files[windowIndex].sfn, files[windowIndex].isFile ? EntryType::FILE : EntryType::DIR);
     }
 
     /// @return total number of files/entries in a directory
     size_t TotalFilesCount() const { return totalFiles; }
 
     /// @return number of visible files/entries in a directory supported by this instance
-    size_t VisibleFilesCount() const { return WINDOW_SIZE; }
+    size_t WindowSize() const { return WINDOW_SIZE; }
+
+    /// @return number of currently visible files in the window
+    size_t VisibleFilesCount() const { return totalFiles - windowStartingFrom; }
 
     /// Initial population of the window + sorting is a normal insert sort algorithm with one run through the directory.
     /// Much of the comparison is done in RAM while avoiding slower USB/FATFS interface as much possible.
@@ -62,16 +81,16 @@ public:
     ///                      A value of nullptr means put ".." first
     void ChangeDirectory(const char *p, SortPolicy sp = SortPolicy::BY_NAME, const char *firstDirEntry = nullptr) {
         size_t filesInWindow = 0; // number of files populated in the window - less than WINDOW_SIZE when there are less files in the dir
-        totalFiles = 0;
+        Clear();
         sortPolicy = sp;
-        strlcpy(path, p, sizeof(path));
+        strlcpy(sfnPath, p, sizeof(sfnPath));
         if (!firstDirEntry) {
             files[0].SetDirUp(); // this is always the first (zeroth) one
             windowStartingFrom = -1;
         } else {
             // find the file in the directory using pattern search
-            F_DIR_RAII_Find_One dir(path, firstDirEntry);
-            if (dir.result != FR_OK || dir.fno.fname[0] == 0) {
+            F_DIR_RAII_Find_One dir(sfnPath, firstDirEntry);
+            if (dir.result != FR_OK) {
                 // the filename was not found, discard the firstDirEntry and start from the beginning
                 // of the directory like if firstDirEntry was nullptr
                 files[0].SetDirUp();
@@ -101,31 +120,32 @@ public:
         // we now have at least one entry - either ".." or the file firstDirEntry
         ++filesInWindow;
         ++totalFiles;
-        F_DIR_RAII_Iterator dir(path);
+        F_DIR_RAII_Iterator dir(sfnPath);
         while (dir.FindNext()) {
             // Find the right stop to insert the file/entry - a normal binary search algorithm
             // Searching is done from the first (not zeroth) index, because the zeroth must be kept intact - that's the start of our window
             // Impl. detail: cannot use auto, need the write iterator (non const)
             typename decltype(files)::iterator i = std::upper_bound(files.begin() + 1, files.begin() + filesInWindow, dir.fno, LessFE);
-            if (i == files.end()) {
-                // The file entry would have been inserted outside of the window - ignore
-                // However, if it is less than the zeroth entry, we must increment windowStartsFrom
-                if (LessFE(dir.fno, files[0])) {
+            if (i != files.end()) {
+                if (i == files.begin() + 1 && LessFE(dir.fno, files[0])) {
+                    // The file entry could have been inserted outside of the window - i.e. before the first item, which is to be unmovable
+                    // However, if it is less than the zeroth entry, we must increment windowStartsFrom
                     ++windowStartingFrom;
-                }
-            } else {
-                if (strcmp(files[0].name, dir.fno.fname) != 0) {
-                    // i.e. we didn't get the same entry as the zeroth entry (which may occur when populating the window with non-null firstDirEntry)
-                    // Make place in the window by standard item rotation downwards (to the right)
-                    std::rotate(files.rbegin(), files.rbegin() + 1, std::make_reverse_iterator(i)); // resi i pripad, ze tech fajlu je zatim mene
-                    // Save the entry
-                    i->CopyFrom(dir.fno);
-                    if (filesInWindow < WINDOW_SIZE) {
-                        ++filesInWindow;
+                } else {
+                    if (strcmp(files[0].lfn, dir.fno.fname) != 0) {
+                        // i.e. we didn't get the same entry as the zeroth entry (which may occur when populating the window with non-null firstDirEntry)
+                        // Make place in the window by standard item rotation downwards (to the right)
+                        std::rotate(files.rbegin(), files.rbegin() + 1, std::make_reverse_iterator(i)); // solves also the case, when there are less files in the window
+                        // Save the entry
+                        i->CopyFrom(dir.fno);
+                        if (filesInWindow < WINDOW_SIZE) {
+                            ++filesInWindow;
+                        }
                     }
                 }
-            }
-            ++totalFiles;
+            } // if i == files.end() -> file entry would have been inserted after the end of the window - ignore
+
+            ++totalFiles; // increment total discovered file entries count
         }
     }
 
@@ -146,7 +166,7 @@ public:
             return true;
         }
 
-        F_DIR_RAII_Iterator dir(path);
+        F_DIR_RAII_Iterator dir(sfnPath);
         // prepare the item at the zeroth position according to sort policy
         files[0] = MakeFirstEntry();
         while (dir.FindNext()) {
@@ -167,7 +187,7 @@ public:
         }
         std::rotate(files.begin(), files.begin() + 1, files.end());
 
-        F_DIR_RAII_Iterator dir(path);
+        F_DIR_RAII_Iterator dir(sfnPath);
         // prepare the last item according to sort policy
         files[WINDOW_SIZE - 1] = MakeLastEntry();
         while (dir.FindNext()) {
@@ -180,25 +200,35 @@ public:
         return true;
     }
 
+#ifndef LAZYFILELIST_UNITTEST
 private:
+#endif
+    static constexpr size_t MAX_SFN = 13;
     struct Entry {
         bool isFile;
-        char name[_MAX_LFN];
+        char lfn[_MAX_LFN];
+        char sfn[MAX_SFN]; // cache the short filenames too, since they will be used in communication with Marlin
         uint16_t date, time;
         void Clear() {
             isFile = false;
-            name[0] = 0;
+            lfn[0] = 0;
+            sfn[0] = 0;
             date = time = 0;
         }
         void CopyFrom(const FILINFO &fno) {
-            strlcpy(name, fno.fname, sizeof(name));
+            strlcpy(lfn, fno.fname, sizeof(lfn));
+            if (fno.altname[0] == 0) { // the lfn is identical to sfn
+                strlcpy(sfn, lfn, sizeof(sfn));
+            } else {
+                strlcpy(sfn, fno.altname, sizeof(sfn));
+            }
             isFile = (fno.fattrib & AM_DIR) == 0;
             date = fno.fdate;
             time = fno.ftime;
         }
         void SetDirUp() {
-            name[0] = name[1] = '.';
-            name[2] = 0;
+            lfn[0] = lfn[1] = sfn[0] = sfn[1] = '.';
+            lfn[2] = sfn[2] = 0;
             isFile = false;
             date = time = UINT16_MAX;
         }
@@ -208,7 +238,7 @@ private:
     size_t totalFiles;                    ///< total number of entries in the directory
     int windowStartingFrom;               ///< from which entry index the window starts (e.g. from the 3rd file in dir).
                                           ///< intentionally int, because -1 means ".."
-    char path[F_MAXPATHNAMELENGTH];       ///< current directory path - @@TODO this may not be enough - needs checking
+    char sfnPath[FILE_PATH_MAX_LEN];      ///< current directory path - @@TODO this may not be enough - needs checking
     SortPolicy sortPolicy;                ///< sort policy set in ChangeDirectory - @@TODO probably not needed at runtime
 
     /// Current selected sort policy compare functions
@@ -224,8 +254,25 @@ private:
         DIR dp;
         FILINFO fno;
         int result;
-        F_DIR_RAII_Find_One(const char *path, const char *pattern) {
-            result = f_findfirst(&dp, &fno, path, pattern);
+        F_DIR_RAII_Find_One(const char *sfnPath, const char *sfn) {
+            // this would have been easy if the f_findfirst was working with SFN
+            //result = f_findfirst(&dp, &fno, path, pattern);
+            // the following code was modified from FATfs
+            result = FR_NO_FILE;
+            if ((result = f_opendir(&dp, sfnPath)) == FR_OK) {
+                for (;;) {
+                    result = f_readdir(&dp, &fno); // get a directory item
+                    if (result != FR_OK || !fno.fname[0]) {
+                        result = FR_NO_FILE; // make sure we report some meaningful error (unlike FATfs)
+                        break;
+                    }
+                    // select appropriate file name
+                    const char *fname = fno.altname[0] ? fno.altname : fno.fname;
+                    if (!strcmp(sfn, fname)) {
+                        break; // found the SFN searched for
+                    }
+                }
+            }
         }
         ~F_DIR_RAII_Find_One() {
             f_closedir(&dp);
@@ -305,25 +352,25 @@ private:
     // Using std::tie to avoid errors in comparison of a heterogenous sequence of components
     static bool LessByFNameEF(const Entry &e, const FILINFO &fno) {
         string_view_light fnoName(fno.fname);
-        string_view_light eName(e.name);
+        string_view_light eName(e.lfn);
         bool fnoIsFile = (fno.fattrib & AM_DIR) == 0;
         return std::tie(e.isFile, eName) < std::tie(fnoIsFile, fnoName);
     }
     static bool LessByFNameFE(const FILINFO &fno, const Entry &e) {
         string_view_light fnoName(fno.fname);
-        string_view_light eName(e.name);
+        string_view_light eName(e.lfn);
         bool fnoIsFile = (fno.fattrib & AM_DIR) == 0;
         return std::tie(fnoIsFile, fnoName) < std::tie(e.isFile, eName);
     }
 
     static Entry MakeFirstEntryByFName() {
-        static const Entry e = { false, "", 0U, 0U };
+        static const Entry e = { false, "", "", 0U, 0U };
         return e;
     }
     static Entry MakeLastEntryByFName() {
-        Entry e = { true, "", 0xffff, 0xffff };
-        std::fill(e.name, e.name + sizeof(e.name) - 1, 0xff);
-        e.name[sizeof(e.name) - 1] = 0;
+        Entry e = { true, "", "", 0xffff, 0xffff };
+        std::fill(e.lfn, e.lfn + sizeof(e.lfn) - 1, 0xff);
+        e.lfn[sizeof(e.lfn) - 1] = 0;
         return e;
     }
     // This may look confusing - from the sorting perspective, the higher time stamp (the more recent one)
@@ -336,24 +383,28 @@ private:
         // beware - multiple files may have identical time stamps!
         // In such case, the file name is the only unique identifier and thus must be included in the comparison
         string_view_light fnoName(fno.fname);
-        string_view_light eName(e.name);
+        string_view_light eName(e.lfn);
         return std::tie(fnoIsDir, fno.fdate, fno.ftime, fnoName) < std::tie(eIsDir, e.date, e.time, eName);
     }
     static bool LessByTimeFE(const FILINFO &fno, const Entry &e) {
         bool fnoIsDir = (fno.fattrib & AM_DIR) != 0;
         bool eIsDir = !e.isFile;
         string_view_light fnoName(fno.fname);
-        string_view_light eName(e.name);
+        string_view_light eName(e.lfn);
         return std::tie(eIsDir, e.date, e.time, eName) < std::tie(fnoIsDir, fno.fdate, fno.ftime, fnoName);
     }
     static Entry MakeFirstEntryByTime() {
-        Entry e = { false, "", 0xffff, 0xffff };
-        std::fill(e.name, e.name + sizeof(e.name) - 1, 0xff);
-        e.name[sizeof(e.name) - 1] = 0;
+        Entry e = { false, "", "", 0xffff, 0xffff };
+        std::fill(e.lfn, e.lfn + sizeof(e.lfn) - 1, 0xff);
+        e.lfn[sizeof(e.lfn) - 1] = 0;
+        // since the sfn is not used for comparison anywhere in LazyDirView,
+        // its initialization may be skipped here to save some code
+        //        std::fill(e.sfn, e.sfn + sizeof(e.sfn) - 1, 0xff);
+        //        e.sfn[sizeof(e.sfn) - 1] = 0;
         return e;
     }
     static Entry MakeLastEntryByTime() {
-        static const Entry e = { true, "", 0U, 0U };
+        static const Entry e = { true, "", "", 0U, 0U };
         return e;
     }
 };

--- a/src/gui/screen_filebrowser.cpp
+++ b/src/gui/screen_filebrowser.cpp
@@ -40,8 +40,10 @@ typedef struct
 // Default value could be rewrite from eeprom settings
 static WF_Sort_t screen_filebrowser_sort = WF_SORT_BY_TIME;
 
-static const char *filters[] = { "*.gcode", "*.gco", "*.g" };
-static const size_t filt_cnt = sizeof(filters) / sizeof(const char *);
+/// To save first/top visible item in the file browser
+/// This is something else than the selected file for print
+/// This is used to restore the content of the browser into previous state including the layout
+static char firstVisibleSFN[13] = "";
 
 static void screen_filebrowser_init(screen_t *screen) {
     // TODO: load screen_filebrowser_sort from eeprom
@@ -59,11 +61,22 @@ static void screen_filebrowser_init(screen_t *screen) {
     p_window_header_set_icon(&(pd->header), IDR_PNG_filescreen_icon_folder);
     p_window_header_set_text(&(pd->header), "SELECT FILE");
 
+    window_file_list_t *filelist = &(pd->w_filelist);
+
     id = window_create_ptr(WINDOW_CLS_FILE_LIST, root,
         rect_ui16(10, 32, 220, 278),
-        &(pd->w_filelist));
-    window_file_list_load(&(pd->w_filelist), screen_filebrowser_sort);
-    window_file_set_item_index(&(pd->w_filelist), 1);
+        filelist);
+
+    // initialize the directory (and selected file) from marlin_vars
+    marlin_vars_t *vars = marlin_vars();
+    // here the strncpy is meant to be - need the rest of the buffer zeroed
+    strncpy(filelist->sfn_path, vars->media_SFN_path, sizeof(filelist->sfn_path));
+    // cut by the filename to retain only the directory path
+    char *c = strrchr(filelist->sfn_path, '/');
+    *c = 0; // even if we didn't find the '/', c will point to valid memory
+    // Moreover - the next characters after c contain the filename, which I want to start my cursor at!
+    window_file_list_load(filelist, screen_filebrowser_sort, c + 1, firstVisibleSFN);
+    // window_file_set_item_index(filelist, 1); // this is automagically done in the window file list
     window_set_capture(id); // hack for do not change capture
     window_set_focus(id);   // hack for do not change capture
 }
@@ -85,9 +98,11 @@ static void on_print_preview_action(print_preview_action_t action) {
     }
 }
 
-static int screen_filebrowser_event(screen_t *screen, window_t *window,
-    uint8_t event, void *param) {
+static int screen_filebrowser_event(screen_t *screen, window_t *window, uint8_t event, void *param) {
+    marlin_vars_t *vars = marlin_vars();
     if (marlin_event_clr(MARLIN_EVT_MediaRemoved)) { // close screen when media removed
+        vars->media_SFN_path[0] = 0;
+        firstVisibleSFN[0] = 0; // clear the last top item
         screen_close();
         return 1;
     }
@@ -100,62 +115,69 @@ static int screen_filebrowser_event(screen_t *screen, window_t *window,
         return 0;
     }
 
-    bool currentIsFile;
-    // displayed text - can be a 8.3 DOS name or a LFN
-    const char *currentFName = window_file_current_fname(filelist, &currentIsFile);
+    static const char dirUp[] = "..";
+    static const char slash[] = "/";
 
-    //there must be fname, not altname
-    if (!strcmp(currentFName, "..") && !strcmp(filelist->altpath, "/")) {
+    bool currentIsFile;
+    const char *currentSFN = window_file_current_SFN(filelist, &currentIsFile);
+
+    if (!strcmp(currentSFN, dirUp) && !strcmp(filelist->sfn_path, slash)) {
+        vars->media_SFN_path[0] = 0;
+        firstVisibleSFN[0] = 0; // clear the last top item
         screen_close();
         return 1;
     }
 
-    size_t altPathLen = strlen(filelist->altpath);
-    if ((altPathLen + strlen(currentFName) + 1) >= MAXPATHNAMELENGTH) {
+    size_t sfnPathLen = strlen(filelist->sfn_path);
+    if ((sfnPathLen + strlen(currentSFN) + 1) >= MAXPATHNAMELENGTH) {
         LOG_ERROR("path too long");
         return 0;
     }
-    if (!currentIsFile) {                 // directory selected
-        if (strcmp(currentFName, "..")) { // not same -> not ..
-            // append the dir name at the end of altPath
-            if (filelist->altpath[altPathLen - 1] != '/') {
-                filelist->altpath[altPathLen++] = '/';
+    if (!currentIsFile) {                // directory selected
+        if (strcmp(currentSFN, dirUp)) { // not same -> not ..
+            // append the dir name at the end of sfnPath
+            if (filelist->sfn_path[sfnPathLen - 1] != slash[0]) {
+                filelist->sfn_path[sfnPathLen++] = slash[0];
             }
-            strcpy(filelist->altpath + altPathLen, currentFName);
+            strcpy(filelist->sfn_path + sfnPathLen, currentSFN);
         } else {
-            char *last = strrchr(filelist->altpath, '/');
-            if (last == filelist->altpath) {
-                strcpy(last, "/"); // reached top level dir
+            char *last = strrchr(filelist->sfn_path, slash[0]);
+            if (last == filelist->sfn_path) {
+                // reached top level dir - ensure it only contains a slash
+                filelist->sfn_path[0] = slash[0];
+                filelist->sfn_path[1] = 0;
             } else {
                 *last = '\0'; // truncate the string after the last "/"
             }
         }
-        window_file_list_load(filelist, screen_filebrowser_sort);
-        window_set_text(pd->header.win.id, strrchr(filelist->altpath, '/'));
+        window_file_list_load(filelist, screen_filebrowser_sort, nullptr, nullptr);
+
+        // @@TODO we want to print the LFN of the dir name, which is very hard to do right now
+        // However, the text is not visible on the screen yet...
+        window_set_text(pd->header.win.id, strrchr(filelist->sfn_path, '/'));
+
     } else { // print the file
-
-        marlin_vars_t *vars = marlin_vars();
-
-        if (vars->media_file_name && vars->media_file_path) {
-
+        if (vars->media_LFN && vars->media_SFN_path) {
             int written;
-            if (!strcmp(filelist->altpath, "/"))
-                written = snprintf(vars->media_file_path, FILE_PATH_MAX_LEN,
-                    "/%s", currentFName);
-            else
-                written = snprintf(vars->media_file_path, FILE_PATH_MAX_LEN,
-                    "%s/%s", filelist->altpath, currentFName);
-
+            if (!strcmp(filelist->sfn_path, slash)) {
+                written = snprintf(vars->media_SFN_path, FILE_PATH_MAX_LEN, "/%s", currentSFN);
+            } else {
+                written = snprintf(vars->media_SFN_path, FILE_PATH_MAX_LEN, "%s/%s", filelist->sfn_path, currentSFN);
+            }
             if (written < 0 || written >= (int)FILE_PATH_MAX_LEN) {
                 LOG_ERROR("failed to prepare file path for print");
                 return 0;
             }
 
-            strcpy(vars->media_file_name, currentFName);
+            // displayed text - can be a 8.3 DOS name or a LFN
+            const char *currentLFN = window_file_current_LFN(filelist, &currentIsFile);
+            strcpy(vars->media_LFN, currentLFN);
+            // save the top browser item
+            strcpy(firstVisibleSFN, window_file_list_top_item_SFN(filelist));
 
             screen_print_preview_set_on_action(on_print_preview_action);
-            screen_print_preview_set_gcode_filepath(vars->media_file_path);
-            screen_print_preview_set_gcode_filename(vars->media_file_name);
+            screen_print_preview_set_gcode_filepath(vars->media_SFN_path);
+            screen_print_preview_set_gcode_filename(vars->media_LFN);
             screen_open(get_scr_print_preview()->id);
 
             return 1;

--- a/src/gui/screen_home.cpp
+++ b/src/gui/screen_home.cpp
@@ -172,14 +172,14 @@ int screen_home_event(screen_t *screen, window_t *window, uint8_t event, void *p
         // we are using marlin variables for filename and filepath buffers
         marlin_vars_t *vars = marlin_vars();
         //check if the variables filename and filepath allocated
-        if (vars->media_file_name && vars->media_file_name) {
+        if (vars->media_LFN && vars->media_LFN) {
             if (find_latest_gcode(
-                    vars->media_file_path,
+                    vars->media_SFN_path,
                     FILE_PATH_MAX_LEN,
-                    vars->media_file_name,
+                    vars->media_LFN,
                     FILE_NAME_MAX_LEN)) {
-                screen_print_preview_set_gcode_filepath(vars->media_file_path);
-                screen_print_preview_set_gcode_filename(vars->media_file_name);
+                screen_print_preview_set_gcode_filepath(vars->media_SFN_path);
+                screen_print_preview_set_gcode_filename(vars->media_LFN);
                 screen_print_preview_set_on_action(on_print_preview_action);
                 screen_open(get_scr_print_preview()->id);
             }

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -429,6 +429,21 @@ static void update_remaining_time(screen_t *screen, time_t rawtime) {
 
     window_set_text(pw->w_etime_value.win.id, array.data());
 }
+static void update_print_duration(screen_t *screen, time_t rawtime) {
+    pw->w_time_value.color_text = COLOR_VALUE_VALID;
+    auto &array = pw->text_time;
+    const struct tm *timeinfo = localtime(&rawtime);
+    if (timeinfo->tm_yday) {
+        snprintf(array.data(), array.size(), "%id %2ih", timeinfo->tm_yday, timeinfo->tm_hour);
+    } else if (timeinfo->tm_hour) {
+        snprintf(array.data(), array.size(), "%ih %2im", timeinfo->tm_hour, timeinfo->tm_min);
+    } else if (timeinfo->tm_min) {
+        snprintf(array.data(), array.size(), "%im %2is", timeinfo->tm_min, timeinfo->tm_sec);
+    } else {
+        snprintf(array.data(), array.size(), "%is", timeinfo->tm_sec);
+    }
+    window_set_text(pw->w_time_value.win.id, array.data());
+}
 
 static void screen_printing_reprint(screen_t *screen) {
     print_begin(marlin_vars()->media_SFN_path);

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -430,22 +430,6 @@ static void update_remaining_time(screen_t *screen, time_t rawtime) {
     window_set_text(pw->w_etime_value.win.id, array.data());
 }
 
-static void update_print_duration(screen_t *screen, time_t rawtime) {
-    pw->w_time_value.color_text = COLOR_VALUE_VALID;
-    auto &array = pw->text_time;
-    const struct tm *timeinfo = localtime(&rawtime);
-    if (timeinfo->tm_yday) {
-        snprintf(array.data(), array.size(), "%id %2ih", timeinfo->tm_yday, timeinfo->tm_hour);
-    } else if (timeinfo->tm_hour) {
-        snprintf(array.data(), array.size(), "%ih %2im", timeinfo->tm_hour, timeinfo->tm_min);
-    } else if (timeinfo->tm_min) {
-        snprintf(array.data(), array.size(), "%im %2is", timeinfo->tm_min, timeinfo->tm_sec);
-    } else {
-        snprintf(array.data(), array.size(), "%is", timeinfo->tm_sec);
-    }
-    window_set_text(pw->w_time_value.win.id, array.data());
-}
-
 static void screen_printing_reprint(screen_t *screen) {
     print_begin(marlin_vars()->media_SFN_path);
     window_set_text(pw->w_etime_label.win.id, PSTR("Remaining Time")); // !!! "screen_printing_init()" is not invoked !!!

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -173,7 +173,7 @@ void screen_printing_init(screen_t *screen) {
     pw->w_filename.font = resource_font(IDR_FNT_BIG);
     window_set_padding(id, padding_ui8(0, 0, 0, 0));
     window_set_alignment(id, ALIGN_LEFT_BOTTOM);
-    window_set_text(id, vars->media_file_name ? vars->media_file_name : "");
+    window_set_text(id, vars->media_LFN ? vars->media_LFN : "");
 
     id = window_create_ptr(WINDOW_CLS_PROGRESS, root,
         rect_ui16(10, 70, 220, 50),
@@ -447,7 +447,7 @@ static void update_print_duration(screen_t *screen, time_t rawtime) {
 }
 
 static void screen_printing_reprint(screen_t *screen) {
-    print_begin(marlin_vars()->media_file_path);
+    print_begin(marlin_vars()->media_SFN_path);
     window_set_text(pw->w_etime_label.win.id, PSTR("Remaining Time")); // !!! "screen_printing_init()" is not invoked !!!
 
     window_set_text(pw->w_labels[BUTTON_STOP].win.id, printing_labels[iid_stop]);

--- a/src/gui/window_file_list.c
+++ b/src/gui/window_file_list.c
@@ -20,6 +20,10 @@ int16_t WINDOW_CLS_FILE_LIST = 0;
 void window_file_list_inc(window_file_list_t *window, int dif);
 void window_file_list_dec(window_file_list_t *window, int dif);
 
+bool window_file_list_path_is_root(const char *path) {
+    return (path[0] == 0 || strcmp(path, "/") == 0);
+}
+
 void window_file_list_load(window_file_list_t *window, WF_Sort_t sort, const char *sfnAtCursor, const char *topSFN) {
     if (!LDV_ChangeDir(window->ldv, sort == WF_SORT_BY_NAME, window->sfn_path, topSFN)) {
         _dbg("LDV_ChangeDir error");
@@ -106,8 +110,8 @@ void window_file_list_draw(window_file_list_t *window) {
 
         // special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
         // and will get a nice house-like icon
-        static const char home[] = "Home";                                             // @@TODO reuse from elsewhere ...
-        if (i == 0 && strcmp(item, "..") == 0 && strcmp(window->sfn_path, "/") == 0) { // @@TODO clean up, this is probably unnecessarily complex
+        static const char home[] = "Home";                                                          // @@TODO reuse from elsewhere ...
+        if (i == 0 && strcmp(item, "..") == 0 && window_file_list_path_is_root(window->sfn_path)) { // @@TODO clean up, this is probably unnecessarily complex
             id_icon = IDR_PNG_filescreen_icon_home;
             item = home;
         }

--- a/src/gui/window_file_list.c
+++ b/src/gui/window_file_list.c
@@ -10,25 +10,42 @@
 #include "gui.h"
 #include "config.h"
 #include "fatfs.h"
-//#include "usb_host.h"
 #include "dbg.h"
 #include "lazyfilelist-c-api.h"
 #include "sound_C_wrapper.h"
-
-//extern ApplicationTypeDef Appli_state;
+#include "../common/cmath_ext.h"
 
 int16_t WINDOW_CLS_FILE_LIST = 0;
 
 void window_file_list_inc(window_file_list_t *window, int dif);
 void window_file_list_dec(window_file_list_t *window, int dif);
 
-void window_file_list_load(window_file_list_t *window, WF_Sort_t sort) {
-    if (!LDV_ChangeDir(window->ldv, sort == WF_SORT_BY_NAME, window->altpath)) {
+void window_file_list_load(window_file_list_t *window, WF_Sort_t sort, const char *sfnAtCursor, const char *topSFN) {
+    if (!LDV_ChangeDir(window->ldv, sort == WF_SORT_BY_NAME, window->sfn_path, topSFN)) {
         _dbg("LDV_ChangeDir error");
     }
 
     window->count = LDV_TotalFilesCount(window->ldv);
-    window->index = 0;
+
+    bool tmp;
+    if (!topSFN) {
+        // we didn't get any requirements about the top item
+        window->index = window->count > 1 ? 1 : 0; // just avoid highlighting ".." if there is at least one file in the dir
+    } else {
+        if (sfnAtCursor[0] == 0) { // empty file name to start with
+            window->index = 1;
+        } else {
+            // try to find the sfn to be highlighted
+            for (window->index = 0; window->index < LDV_VisibleFilesCount(window->ldv); ++window->index) {
+                if (!strcmp(sfnAtCursor, LDV_ShortFileNameAt(window->ldv, window->index, &tmp))) {
+                    break;
+                }
+            }
+            if (window->index == LDV_VisibleFilesCount(window->ldv)) {
+                window->index = window->count > 1 ? 1 : 0; // just avoid highlighting ".." if there is at least one file in the dir
+            }
+        }
+    }
     _window_invalidate((window_t *)window);
 }
 
@@ -39,8 +56,17 @@ void window_file_set_item_index(window_file_list_t *window, int index) {
     }
 }
 
-const char *window_file_current_fname(window_file_list_t *window, bool *isFile) {
-    return LDV_FileAt(window->ldv, window->index, isFile);
+const char *window_file_current_LFN(window_file_list_t *window, bool *isFile) {
+    return LDV_LongFileNameAt(window->ldv, window->index, isFile);
+}
+
+const char *window_file_current_SFN(window_file_list_t *window, bool *isFile) {
+    return LDV_ShortFileNameAt(window->ldv, window->index, isFile);
+}
+
+const char *window_file_list_top_item_SFN(window_file_list_t *window) {
+    bool tmp;
+    return LDV_ShortFileNameAt(window->ldv, 0, &tmp);
 }
 
 void window_file_list_init(window_file_list_t *window) {
@@ -51,7 +77,7 @@ void window_file_list_init(window_file_list_t *window) {
     window->alignment = ALIGN_LEFT_CENTER;
     window->win.flg |= WINDOW_FLG_ENABLED;
 
-    strcpy(window->altpath, "/");
+    strcpy(window->sfn_path, "/");
 
     // it is still the same address every time, no harm assigning it again.
     // Will be removed when this file gets converted to c++ (and cleaned)
@@ -64,11 +90,14 @@ void window_file_list_draw(window_file_list_t *window) {
     int item_height = window->font->h + window->padding.top + window->padding.bottom;
     rect_ui16_t rc_win = window->win.rect;
 
-    int visible_count = rc_win.h / item_height;
+    int visible_slots = rc_win.h / item_height;
+    int ldv_visible_files = LDV_VisibleFilesCount(window->ldv);
+    int maxi = MIN(MIN(visible_slots, ldv_visible_files), window->count);
+
     int i;
-    for (i = 0; i < visible_count && i < window->count; i++) {
+    for (i = 0; i < maxi; i++) {
         bool isFile = true;
-        const char *item = LDV_FileAt(window->ldv, i, &isFile);
+        const char *item = LDV_LongFileNameAt(window->ldv, i, &isFile);
         if (!item) {
             // this should normally not happen, visible_count shall limit indices to valid items only
             continue; // ... but getting ready for the unexpected
@@ -77,8 +106,8 @@ void window_file_list_draw(window_file_list_t *window) {
 
         // special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
         // and will get a nice house-like icon
-        static const char home[] = "Home";                                            // @@TODO reuse from elsewhere ...
-        if (i == 0 && strcmp(item, "..") == 0 && strcmp(window->altpath, "/") == 0) { // @@TODO clean up, this is probably unnecessarily complex
+        static const char home[] = "Home";                                             // @@TODO reuse from elsewhere ...
+        if (i == 0 && strcmp(item, "..") == 0 && strcmp(window->sfn_path, "/") == 0) { // @@TODO clean up, this is probably unnecessarily complex
             id_icon = IDR_PNG_filescreen_icon_home;
             item = home;
         }
@@ -145,7 +174,7 @@ void window_file_list_event(window_file_list_t *window, uint8_t event, void *par
 
 void window_file_list_inc(window_file_list_t *window, int dif) {
     bool repaint = false;
-    if (window->index >= LDV_VisibleFilesCount(window->ldv) - 1) {
+    if (window->index >= LDV_WindowSize(window->ldv) - 1) {
         Sound_Play(eSOUND_TYPE_BlindAlert);
         repaint = LDV_MoveDown(window->ldv);
     } else {

--- a/src/gui/window_file_list.h
+++ b/src/gui/window_file_list.h
@@ -12,6 +12,7 @@
 #include "ff.h"
 #include <stdbool.h>
 #include "file_list_defs.h"
+#include "../common/marlin_vars.h" // for FILE_PATH_MAX_LEN
 
 typedef struct _window_file_list_t window_file_list_t;
 
@@ -29,10 +30,10 @@ typedef struct _window_file_list_t {
     font_t *font;
     padding_ui8_t padding;
     uint8_t alignment;
-    int count;                              // total number of files/entries in a dir
-    int index;                              // selected index - cursor position within the visible items
-    char altpath[F_MAXPATHNAMELENGTH - 12]; // this is a path where we start the file dialog
-    void *ldv;                              // I'm a C-pig and I need a pointer to my LazyDirView class instance ... subject to change when this gets rewritten to C++
+    int count;                        // total number of files/entries in a dir
+    int index;                        // selected index - cursor position within the visible items
+    char sfn_path[FILE_PATH_MAX_LEN]; // this is a Short-File-Name path where we start the file dialog
+    void *ldv;                        // I'm a C-pig and I need a pointer to my LazyDirView class instance ... subject to change when this gets rewritten to C++
 } window_file_list_t;
 
 #pragma pack(pop)
@@ -52,11 +53,13 @@ extern int16_t WINDOW_CLS_FILE_LIST;
 
 extern const window_class_file_list_t window_class_file_list;
 
-extern void window_file_list_load(window_file_list_t *window, WF_Sort_t sort);
+extern void window_file_list_load(window_file_list_t *window, WF_Sort_t sort, const char *sfnAtCursor, const char *topSFN);
 
 extern void window_file_set_item_index(window_file_list_t *window, int index);
 
-extern const char *window_file_current_fname(window_file_list_t *window, bool *isFile);
+extern const char *window_file_list_top_item_SFN(window_file_list_t *window);
+extern const char *window_file_current_LFN(window_file_list_t *window, bool *isFile);
+extern const char *window_file_current_SFN(window_file_list_t *window, bool *isFile);
 
 #ifdef __cplusplus
 }

--- a/src/gui/window_file_list.h
+++ b/src/gui/window_file_list.h
@@ -61,6 +61,9 @@ extern const char *window_file_list_top_item_SFN(window_file_list_t *window);
 extern const char *window_file_current_LFN(window_file_list_t *window, bool *isFile);
 extern const char *window_file_current_SFN(window_file_list_t *window, bool *isFile);
 
+/// @return true if path is either empty or contains just a "/"
+extern bool window_file_list_path_is_root(const char *path);
+
 #ifdef __cplusplus
 }
 #endif //__cplusplus


### PR DESCRIPTION
- file browser engine now works on short file name (SFN) paths everywhere
- variables holding SFN or LFN strings have been renamed throughout the whole FW accordingly
- file browser now remembers the last selected file and can restore its view to identical state as it was before entering the print preview screen (including scroll and cursor position)
- lazy file list improved and made unit-test-ready (unit test will be committed shortly)
- cmath-ext: #define SIGN(x) -> SIGN0 to avoid clash with Marlin

BFW-795
BFW-802