### PR TITLE
BFW-800 timestamp in printing screen

### DIFF
--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -23,6 +23,14 @@
 #define MAX_TIME_STR_SIZE 12  // length of time string hh:mm:ss (12 for warning-free compilation)
 #define MAX_DATE_STR_SIZE 14  // length of date string dd:mm:yyyy (13 for warning-free compilation)
 
+#define TIME_STR_SECS   0x01 // flag bit for stringifying seconds
+#define TIME_STR_MINS   0x02 // flag bit for stringifying minutes
+#define TIME_STR_HOURS  0x04 // flag bit for stringifying hours
+#define TIME_STR_DAYS   0x08 // flag bit for stringifying days
+#define TIME_STR_MONTHS 0x10 // flag bit for stringifying months
+#define TIME_STR_YEARS  0x20 // flag bit for stringifying years
+#define TIME_STR_ALL    (TIME_STR_SECS | TIME_STR_MINS | TIME_STR_HOURS | TIME_STR_DAYS | TIME_STR_MONTHS | TIME_STR_YEARS)
+
 #define ETHVAR_MSK(n_id) ((uint32_t)1 << (n_id))
 #define ETHVAR_STATIC_LAN_ADDRS \
     (ETHVAR_MSK(ETHVAR_LAN_ADDR_IP4) | ETHVAR_MSK(ETHVAR_LAN_MSK_IP4) | ETHVAR_MSK(ETHVAR_LAN_GW_IP4))
@@ -227,16 +235,18 @@ uint32_t sntp_get_system_time(timestamp_t *system_time);
 ******************************************************************************/
 void sntp_set_system_time(uint32_t sec);
 
-/*!****************************************************************************
+/*!***********************************************************************************
 * \brief Parses system time info into a destination string
 *
 * \param [out] dest - destination structure with strings for time and date
 *
 * \param [in] timestamp - system time aquired from device's time storage/clock
 *
+* \param [in] flag - stores flag bits, that decides what to stringify (TIME_STR_xxxx)
+*
 * \retval 1 if time is initialized by sntp, else 0
-*****************************************************************************/
-uint32_t stringify_timestamp(time_str_t *dest, timestamp_t *timestamp);
+*************************************************************************************/
+uint32_t stringify_timestamp(time_str_t *dest, timestamp_t *timestamp, uint8_t flag);
 
 /*!********************************************************************************
 * \brief Updates timestamp from its epoch_secs value

--- a/src/common/wui_api.c
+++ b/src/common/wui_api.c
@@ -314,23 +314,23 @@ uint32_t stringify_timestamp(time_str_t *dest, timestamp_t *timestamp, uint8_t f
         }
 
         // DATE PARSING
-        if (flag & TIME_STR_DAYS) {
-            snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d.", timestamp->date.d);
+        if (flag & TIME_STR_YEARS) {
+            snprintf(dest->date, MAX_DATE_STR_SIZE, "%d", timestamp->date.y);
         }
         if (flag & TIME_STR_MONTHS) {
             uint8_t length = strlen(dest->date);
             if (length > 0) {
-                snprintf(dest->date + length, MAX_DATE_STR_SIZE - length, "%02d.", timestamp->date.m);
+                snprintf(dest->date + length, MAX_DATE_STR_SIZE - length, "-%02d", timestamp->date.m);
             } else {
-                snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d.", timestamp->date.m);
+                snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d", timestamp->date.m);
             }
         }
-        if (flag & TIME_STR_YEARS) {
+        if (flag & TIME_STR_DAYS) {
             uint8_t length = strlen(dest->date);
             if (length > 0) {
-                snprintf(dest->date + length, MAX_DATE_STR_SIZE - length, "%d", timestamp->date.y);
+                snprintf(dest->date + length, MAX_DATE_STR_SIZE - length, "-%02d", timestamp->date.d);
             } else {
-                snprintf(dest->date, MAX_DATE_STR_SIZE, "%d", timestamp->date.y);
+                snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d", timestamp->date.d);
             }
         }
         return 1;

--- a/src/common/wui_api.c
+++ b/src/common/wui_api.c
@@ -286,10 +286,53 @@ void sntp_set_system_time(uint32_t sec) {
     sntp_time_init = true;
 }
 
-uint32_t stringify_timestamp(time_str_t *dest, timestamp_t *timestamp) {
+uint32_t stringify_timestamp(time_str_t *dest, timestamp_t *timestamp, uint8_t flag) {
     if (sntp_time_init) {
-        snprintf(dest->time, MAX_TIME_STR_SIZE, "%02d:%02d:%02d", timestamp->time.h, timestamp->time.m, timestamp->time.s);
-        snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d.%02d.%d", timestamp->date.d, timestamp->date.m, timestamp->date.y);
+
+        dest->time[0] = 0;
+        dest->date[0] = 0;
+
+        // TIME PARSING
+        if (flag & TIME_STR_HOURS) {
+            snprintf(dest->time, MAX_TIME_STR_SIZE, "%02d", timestamp->time.h);
+        }
+        if (flag & TIME_STR_MINS) {
+            uint8_t length = strlen(dest->time);
+            if (length > 0) {
+                snprintf(dest->time + length, MAX_TIME_STR_SIZE - length, ":%02d", timestamp->time.m);
+            } else {
+                snprintf(dest->time, MAX_TIME_STR_SIZE, "%02d", timestamp->time.m);
+            }
+        }
+        if (flag & TIME_STR_SECS) {
+            uint8_t length = strlen(dest->time);
+            if (length > 0) {
+                snprintf(dest->time + length, MAX_TIME_STR_SIZE - length, ":%02d", timestamp->time.s);
+            } else {
+                snprintf(dest->time, MAX_TIME_STR_SIZE, "%02d", timestamp->time.s);
+            }
+        }
+
+        // DATE PARSING
+        if (flag & TIME_STR_DAYS) {
+            snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d", timestamp->date.d);
+        }
+        if (flag & TIME_STR_MONTHS) {
+            uint8_t length = strlen(dest->date);
+            if (length > 0) {
+                snprintf(dest->date + length, MAX_DATE_STR_SIZE - length, ".%02d", timestamp->date.m);
+            } else {
+                snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d", timestamp->date.m);
+            }
+        }
+        if (flag & TIME_STR_YEARS) {
+            uint8_t length = strlen(dest->date);
+            if (length > 0) {
+                snprintf(dest->date + length, MAX_DATE_STR_SIZE - length, ".%d", timestamp->date.y);
+            } else {
+                snprintf(dest->date, MAX_DATE_STR_SIZE, "%d", timestamp->date.y);
+            }
+        }
         return 1;
     } else {
         strlcpy(dest->time, "N/A", MAX_TIME_STR_SIZE);

--- a/src/common/wui_api.c
+++ b/src/common/wui_api.c
@@ -315,20 +315,20 @@ uint32_t stringify_timestamp(time_str_t *dest, timestamp_t *timestamp, uint8_t f
 
         // DATE PARSING
         if (flag & TIME_STR_DAYS) {
-            snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d", timestamp->date.d);
+            snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d.", timestamp->date.d);
         }
         if (flag & TIME_STR_MONTHS) {
             uint8_t length = strlen(dest->date);
             if (length > 0) {
-                snprintf(dest->date + length, MAX_DATE_STR_SIZE - length, ".%02d", timestamp->date.m);
+                snprintf(dest->date + length, MAX_DATE_STR_SIZE - length, "%02d.", timestamp->date.m);
             } else {
-                snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d", timestamp->date.m);
+                snprintf(dest->date, MAX_DATE_STR_SIZE, "%02d.", timestamp->date.m);
             }
         }
         if (flag & TIME_STR_YEARS) {
             uint8_t length = strlen(dest->date);
             if (length > 0) {
-                snprintf(dest->date + length, MAX_DATE_STR_SIZE - length, ".%d", timestamp->date.y);
+                snprintf(dest->date + length, MAX_DATE_STR_SIZE - length, "%d", timestamp->date.y);
             } else {
                 snprintf(dest->date, MAX_DATE_STR_SIZE, "%d", timestamp->date.y);
             }

--- a/src/gui/screen_menu_filament.cpp
+++ b/src/gui/screen_menu_filament.cpp
@@ -126,7 +126,7 @@ int screen_menu_filament_event(screen_t *screen, window_t *window, uint8_t event
     switch ((int)param) {
     case MI_LOAD:
         p_window_header_set_text(&(psmd->header), "LOAD FILAMENT");
-        if (gui_dlg_load() == DLG_OK) {                                                            //user can pres return
+        if (gui_dlg_load() == DLG_OK) {                                                            //user can press return
             DialogHandler::WaitUntilClosed(ClientFSM::Load_unload, uint8_t(LoadUnloadMode::Load)); //opens dialog if it is not already openned
             setPreheatTemp();
         }
@@ -134,7 +134,7 @@ int screen_menu_filament_event(screen_t *screen, window_t *window, uint8_t event
         break;
     case MI_UNLOAD:
         p_window_header_set_text(&(psmd->header), "UNLOAD FILAM.");
-        if (gui_dlg_unload() == DLG_OK) {                                                            //user can pres return
+        if (gui_dlg_unload() == DLG_OK) {                                                            //user can press return
             DialogHandler::WaitUntilClosed(ClientFSM::Load_unload, uint8_t(LoadUnloadMode::Unload)); //opens dialog if it is not already openned
         }
         p_window_header_set_text(&(psmd->header), "FILAMENT");
@@ -143,7 +143,7 @@ int screen_menu_filament_event(screen_t *screen, window_t *window, uint8_t event
         p_window_header_set_text(&(psmd->header), "CHANGE FILAM.");
         if (gui_dlg_unload() == DLG_OK) {                                                              //"CHANGE FILAM." is active only when filament is known so preheat is autoselected and should always return DLG_OK, better to check it anyway
             DialogHandler::WaitUntilClosed(ClientFSM::Load_unload, uint8_t(LoadUnloadMode::Unload));   //opens dialog if it is not already openned
-            if (gui_dlg_load() == DLG_OK) {                                                            //user can pres return
+            if (gui_dlg_load() == DLG_OK) {                                                            //user can press return
                 DialogHandler::WaitUntilClosed(ClientFSM::Load_unload, uint8_t(LoadUnloadMode::Load)); //opens dialog if it is not already openned
                 setPreheatTemp();
             } else {

--- a/src/gui/screen_menu_settings.cpp
+++ b/src/gui/screen_menu_settings.cpp
@@ -12,6 +12,7 @@
 #ifdef BUDDY_ENABLE_ETHERNET
     #include "screen_lan_settings.h"
     #include "menu_vars.h"
+    #include "wui_api.h"
 #endif //BUDDY_ENABLE_ETHERNET
 #include "screen_menu_fw_update.h"
 #include "filament_sensor.h"
@@ -240,6 +241,11 @@ int screen_menu_settings_event(screen_t *screen, window_t *window, uint8_t event
         case MI_TIMEZONE: {
             int8_t time_zone = (int8_t)(psmd->items[MI_TIMEZONE].item.wi_spin.value / 1000);
             eeprom_set_var(EEVAR_TIMEZONE, variant8_i8(time_zone));
+            timestamp_t now;
+            if (sntp_get_system_time(&now)) {
+                now.epoch_secs += (time_zone * 3600);
+                sntp_set_system_time(now.epoch_secs);
+            }
             break;
         }
         }

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -457,9 +457,10 @@ static void update_end_timestamp(screen_t *screen, timestamp_t *now) {
         pw->w_etime_value.color_text = COLOR_VALUE_VALID;
     }
 
+    static const uint32_t full_day_in_seconds = 86400;
     timestamp_t print_end, tommorow;
     print_end.epoch_secs = now->epoch_secs + (marlin_vars()->time_to_end / 1000);
-    tommorow.epoch_secs = now->epoch_secs += 86400; // now + one full day
+    tommorow.epoch_secs = now->epoch_secs += full_day_in_seconds;
     update_timestamp_from_epoch_secs(&tommorow);
     update_timestamp_from_epoch_secs(&print_end);
 

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -190,7 +190,7 @@ void screen_printing_init(screen_t *screen) {
     pw->w_etime_label.font = resource_font(IDR_FNT_SMALL);
     window_set_alignment(id, ALIGN_RIGHT_BOTTOM);
     window_set_padding(id, padding_ui8(0, 2, 0, 2));
-    window_set_text(id, "End Timestamp");
+    window_set_text(id, "Print will end at");
 
     id = window_create_ptr(WINDOW_CLS_TEXT, root,
         rect_ui16(30, 148, 201, 20),
@@ -433,13 +433,15 @@ static void update_end_timestamp(screen_t *screen) {
     update_timestamp_from_epoch_secs(&end);
 
     time_str_t time_str;
-    stringify_timestamp(&time_str, &end);
 
     if (now.date.d == end.date.d) {
+        stringify_timestamp(&time_str, &end, TIME_STR_HOURS | TIME_STR_MINS);
         snprintf(array.data(), MAX_END_TIMESTAMP_SIZE, "Today at %s", time_str.time);
     } else if (now.date.d + 1 == end.date.d) {
+        stringify_timestamp(&time_str, &end, TIME_STR_HOURS | TIME_STR_MINS);
         snprintf(array.data(), MAX_END_TIMESTAMP_SIZE, "Tommorow at %s", time_str.time);
     } else {
+        stringify_timestamp(&time_str, &end, TIME_STR_HOURS | TIME_STR_MINS | TIME_STR_DAYS | TIME_STR_MONTHS);
         snprintf(array.data(), MAX_END_TIMESTAMP_SIZE, "%s at %s", time_str.date, time_str.time);
     }
 

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -25,7 +25,7 @@
 #define BUTTON_STOP  2
 
 #define POPUP_MSG_DUR_MS       5000
-#define MAX_END_TIMESTAMP_SIZE (MAX_DATE_STR_SIZE + MAX_TIME_STR_SIZE + 4) // "dd.mm.yyyy at hh:mm:ss" + safty measures for 3digit where 2 digits should be
+#define MAX_END_TIMESTAMP_SIZE (MAX_DATE_STR_SIZE + MAX_TIME_STR_SIZE + 5) // "dd.mm.yyyy at hh:mm:ss" + safty measures for 3digit where 2 digits should be
 
 #pragma pack(push)
 #pragma pack(1)
@@ -106,7 +106,8 @@ typedef struct
     uint8_t last_sd_percent_done;
 
     std::array<char, 9> text_time;
-    std::array<char, MAX_DATE_STR_SIZE + MAX_TIME_STR_SIZE + 2> text_etime;
+    std::array<char, MAX_END_TIMESTAMP_SIZE> text_etime;
+    std::array<char, 15> label_etime;  // "Remaining Time" or "Print will end"
     std::array<char, 5> text_filament; // 999m\0 | 1.2m\0
 
     window_text_t w_message; //Messages from onStatusChanged()
@@ -135,7 +136,8 @@ static void screen_printing_reprint(screen_t *screen);
 //static void mesh_err_stop_print(screen_t *screen); //todo use it
 static void change_print_state(screen_t *screen);
 static void update_progress(screen_t *screen, uint8_t percent, uint16_t print_speed);
-static void update_end_timestamp(screen_t *screen);
+static void update_remaining_time(screen_t *screen, time_t rawtime);
+static void update_end_timestamp(screen_t *screen, timestamp_t *now);
 static void update_print_duration(screen_t *screen, time_t print_duration);
 
 screen_t screen_printing = {
@@ -190,7 +192,8 @@ void screen_printing_init(screen_t *screen) {
     pw->w_etime_label.font = resource_font(IDR_FNT_SMALL);
     window_set_alignment(id, ALIGN_RIGHT_BOTTOM);
     window_set_padding(id, padding_ui8(0, 2, 0, 2));
-    window_set_text(id, "Print will end at");
+    strlcpy(pw->label_etime.data(), "Remaining Time", 15);
+    window_set_text(id, pw->label_etime.data());
 
     id = window_create_ptr(WINDOW_CLS_TEXT, root,
         rect_ui16(30, 148, 201, 20),
@@ -328,8 +331,19 @@ int screen_printing_event(screen_t *screen, window_t *window, uint8_t event, voi
 
     if (marlin_vars()->print_duration != pw->last_print_duration)
         update_print_duration(screen, marlin_vars()->print_duration);
-    if (marlin_vars()->time_to_end != pw->last_time_to_end)
-        update_end_timestamp(screen);
+    if (marlin_vars()->time_to_end != pw->last_time_to_end) {
+        timestamp_t now;
+        if (sntp_get_system_time(&now)) {
+            strlcpy(pw->label_etime.data(), "Print will end", 15);
+            window_set_text(pw->w_etime_label.win.id, pw->label_etime.data());
+            update_end_timestamp(screen, &now);
+        } else {
+            strlcpy(pw->label_etime.data(), "Remaining Time", 15);
+            window_set_text(pw->w_etime_label.win.id, pw->label_etime.data());
+            update_remaining_time(screen, marlin_vars()->time_to_end);
+        }
+        pw->last_time_to_end = marlin_vars()->time_to_end;
+    }
     if (marlin_vars()->sd_percent_done != pw->last_sd_percent_done)
         update_progress(screen, marlin_vars()->sd_percent_done, marlin_vars()->print_speed);
 
@@ -412,37 +426,53 @@ static void update_progress(screen_t *screen, uint8_t percent, uint16_t print_sp
     window_set_value(pw->w_progress.win.id, percent);
 }
 
-static void update_end_timestamp(screen_t *screen) {
+static void update_remaining_time(screen_t *screen, time_t rawtime) {
+    pw->w_etime_value.color_text = rawtime != time_t(-1) ? COLOR_VALUE_VALID : COLOR_VALUE_INVALID;
+    auto &array = pw->text_etime;
+    if (rawtime != time_t(-1)) {
+        const struct tm *timeinfo = localtime(&rawtime);
+        //standard would be:
+        //strftime(array.data(), array.size(), "%jd %Hh", timeinfo);
+        if (timeinfo->tm_yday) {
+            snprintf(array.data(), array.size(), "%id %2ih", timeinfo->tm_yday, timeinfo->tm_hour);
+        } else if (timeinfo->tm_hour) {
+            snprintf(array.data(), array.size(), "%ih %2im", timeinfo->tm_hour, timeinfo->tm_min);
+        } else {
+            snprintf(array.data(), array.size(), "%im", timeinfo->tm_min);
+        }
+    } else
+        strlcpy(array.data(), "N/A", array.size());
 
-    pw->last_time_to_end = marlin_vars()->time_to_end;
+    window_set_text(pw->w_etime_value.win.id, array.data());
+}
+
+static void update_end_timestamp(screen_t *screen, timestamp_t *timestamp) {
 
     auto &array = pw->text_etime;
-    timestamp_t now, end;
-    sntp_get_system_time(&now);
+    char qmark[2] = "";
 
-    if (marlin_vars()->time_to_end == TIME_TO_END_INVALID || now.epoch_secs == 0) {
+    if (marlin_vars()->time_to_end == TIME_TO_END_INVALID) {
         pw->w_etime_value.color_text = COLOR_VALUE_INVALID;
-        strlcpy(array.data(), "N/A", MAX_END_TIMESTAMP_SIZE);
-        window_set_text(pw->w_etime_value.win.id, array.data());
-        return;
+        strlcpy(qmark, "?", 2);
     } else {
         pw->w_etime_value.color_text = COLOR_VALUE_VALID;
     }
 
-    end.epoch_secs = now.epoch_secs + (marlin_vars()->time_to_end / 1000);
-    update_timestamp_from_epoch_secs(&end);
+    uint8_t today = timestamp->date.d;
+    timestamp->epoch_secs += (marlin_vars()->time_to_end / 1000);
+    update_timestamp_from_epoch_secs(timestamp);
 
     time_str_t time_str;
 
-    if (now.date.d == end.date.d) {
-        stringify_timestamp(&time_str, &end, TIME_STR_HOURS | TIME_STR_MINS);
-        snprintf(array.data(), MAX_END_TIMESTAMP_SIZE, "Today at %s", time_str.time);
-    } else if (now.date.d + 1 == end.date.d) {
-        stringify_timestamp(&time_str, &end, TIME_STR_HOURS | TIME_STR_MINS);
-        snprintf(array.data(), MAX_END_TIMESTAMP_SIZE, "Tommorow at %s", time_str.time);
+    if (today == timestamp->date.d) {
+        stringify_timestamp(&time_str, timestamp, TIME_STR_HOURS | TIME_STR_MINS);
+        snprintf(array.data(), MAX_END_TIMESTAMP_SIZE, "Today at %s%s", time_str.time, qmark);
+    } else if (today + 1 == timestamp->date.d) {
+        stringify_timestamp(&time_str, timestamp, TIME_STR_HOURS | TIME_STR_MINS);
+        snprintf(array.data(), MAX_END_TIMESTAMP_SIZE, "Tommorow at %s%s", time_str.time, qmark);
     } else {
-        stringify_timestamp(&time_str, &end, TIME_STR_HOURS | TIME_STR_MINS | TIME_STR_DAYS | TIME_STR_MONTHS);
-        snprintf(array.data(), MAX_END_TIMESTAMP_SIZE, "%s at %s", time_str.date, time_str.time);
+        stringify_timestamp(&time_str, timestamp, TIME_STR_HOURS | TIME_STR_MINS | TIME_STR_DAYS | TIME_STR_MONTHS);
+        snprintf(array.data(), MAX_END_TIMESTAMP_SIZE, "%s at %s%s", time_str.date, time_str.time, qmark);
     }
 
     window_set_text(pw->w_etime_value.win.id, array.data());


### PR DESCRIPTION
Change displayed time format from Remaining time to print end timestamp. Description in JIRA task.

additional changes:
In screen_menu_settings.cpp > When timezone is changed and sntp is already initialized, it sets up time immidiately.