### PR TITLE
Fix wrong calibrated axis

### DIFF
--- a/src/common/sound.cpp
+++ b/src/common/sound.cpp
@@ -12,8 +12,7 @@ Sound::Sound() {
     duration = 0;      // added variable to set _duration for repeating
     repeat = 0;        // how many times is sound played
     frequency = 100.f; // frequency of sound signal (0-1000)
-    //volume = 0.00125;  // volume of sound signal (0-1)
-    volume = 0.70; // volume of sound signal (0-1)
+    volume = 0.50; // volume of sound signal (0-1)
 
     this->init();
 }
@@ -162,13 +161,13 @@ void Sound::soundCriticalAlert(int rep, uint32_t del) {
 // Sound signal every time when encoder nove
 void Sound::soundEncoderMove(int rep, uint32_t del) {
     float frq = 800.0f;
-    this->_sound(rep, frq, del, 0.40);
+    this->_sound(rep, frq, del, 0.25);
 }
 
 // Sound signal for signaling start and end of the menu or items selecting on screen
 void Sound::soundBlindAlert(int rep, uint32_t del) {
     float frq = 500.0f;
-    this->_sound(rep, frq, del, 0.40);
+    this->_sound(rep, frq, del, 0.25);
 }
 
 // Generic [_sound[ method with setting values and repeating logic

--- a/src/common/sound.cpp
+++ b/src/common/sound.cpp
@@ -12,7 +12,7 @@ Sound::Sound() {
     duration = 0;      // added variable to set _duration for repeating
     repeat = 0;        // how many times is sound played
     frequency = 100.f; // frequency of sound signal (0-1000)
-    volume = 0.50; // volume of sound signal (0-1)
+    volume = 0.50;     // volume of sound signal (0-1)
 
     this->init();
 }

--- a/src/gui/dialogs/DialogLoadUnload.cpp
+++ b/src/gui/dialogs/DialogLoadUnload.cpp
@@ -68,7 +68,7 @@ static DialogLoadUnload::States LoadUnloadFactory() {
         DialogLoadUnload::State { txt_unload,             btn(PhasesLoadUnload::RemoveFilament,   ph_txt_stop) },
         DialogLoadUnload::State { txt_push_fil,           btn(PhasesLoadUnload::UserPush,         ph_txt_cont), DialogLoadUnload::userPushEnter, DialogLoadUnload::userPushExit },
         DialogLoadUnload::State { txt_nozzle_cold,        btn(PhasesLoadUnload::NozzleTimeout,    ph_txt_reheat) },
-        DialogLoadUnload::State { txt_make_sure_inserted, btn(PhasesLoadUnload::MakeSureInserted, ph_txt_cont) },
+        DialogLoadUnload::State { txt_make_sure_inserted, btn(PhasesLoadUnload::MakeSureInserted, ph_txt_cont), DialogLoadUnload::makeSureInsertedEnter, DialogLoadUnload::makeSureInsertedExit },
         DialogLoadUnload::State { txt_inserting,          btn(PhasesLoadUnload::Inserting,        ph_txt_stop) },
         DialogLoadUnload::State { txt_is_filament_in_gear,btn(PhasesLoadUnload::IsFilamentInGear, ph_txt_yesno) },
         DialogLoadUnload::State { txt_ejecting,           btn(PhasesLoadUnload::Ejecting,         ph_txt_none) },
@@ -89,6 +89,9 @@ DialogLoadUnload::DialogLoadUnload(const char *name)
 // specified phase
 void DialogLoadUnload::userPushEnter() { Sound_Play(eSOUND_TYPE_StandardPrompt); }
 void DialogLoadUnload::userPushExit() { Sound_Stop(); }
+
+void DialogLoadUnload::makeSureInsertedEnter() { Sound_Play(eSOUND_TYPE_StandardPrompt); }
+void DialogLoadUnload::makeSureInsertedExit() { Sound_Stop(); }
 
 void DialogLoadUnload::c_draw(window_t *win) {
     IDialog *ptr = cast(win);

--- a/src/gui/dialogs/DialogLoadUnload.hpp
+++ b/src/gui/dialogs/DialogLoadUnload.hpp
@@ -13,8 +13,7 @@ public:
     // phase callbacks
     static void userPushEnter();
     static void userPushExit();
-		static void makeSureInsertedEnter();
+    static void makeSureInsertedEnter();
     static void makeSureInsertedExit();
-
 };
 #pragma pack(pop)

--- a/src/gui/dialogs/DialogLoadUnload.hpp
+++ b/src/gui/dialogs/DialogLoadUnload.hpp
@@ -13,5 +13,8 @@ public:
     // phase callbacks
     static void userPushEnter();
     static void userPushExit();
+		static void makeSureInsertedEnter();
+    static void makeSureInsertedExit();
+
 };
 #pragma pack(pop)


### PR DESCRIPTION
- after some cases we got wrong coordinates when calibration is going
- we want to fixed that in home sequence
FIX:
- set default current_position (x_home, y_home, z_home)
- set home offset for right machine coords just like G92 call
- set G92 and workplace offset by default values

BFW-872