### PR TITLE
Clear menu timeout, when dialog is up

### DIFF
--- a/src/guiapi/include/gui.h
+++ b/src/guiapi/include/gui.h
@@ -63,6 +63,8 @@ extern void gui_redraw(void);
 extern uint8_t gui_get_nesting(void);
 extern void gui_loop(void);
 
+extern void gui_reset_menu_timer();
+
 extern int gui_msgbox_ex(const char *title, const char *text, uint16_t flags, rect_ui16_t rect, uint16_t id_icon, const char **buttons);
 
 extern int gui_msgbox(const char *text, uint16_t flags);

--- a/src/guiapi/src/gui.c
+++ b/src/guiapi/src/gui.c
@@ -107,14 +107,7 @@ void gui_loop(void) {
             else if (dif < 0)
                 screen_dispatch_event(window_capture_ptr, WINDOW_EVENT_ENC_DN, (void *)-dif);
             gui_jogwheel_encoder = jogwheel_encoder;
-
-            //=======MENU_TIMEOUT=========
-            if (menu_timeout_enabled == 1) {
-                if (gui_get_menu_timeout_id() >= 0)
-                    gui_timer_reset(gui_get_menu_timeout_id());
-                else
-                    gui_timer_create_timeout((uint32_t)MENU_TIMEOUT_MS, (int16_t)-1);
-            }
+            gui_reset_menu_timer();
         }
         if (!jogwheel_button_down ^ !gui_jogwheel_button_down) {
             if (gui_jogwheel_button_down)
@@ -122,14 +115,7 @@ void gui_loop(void) {
             else
                 screen_dispatch_event(window_capture_ptr, WINDOW_EVENT_BTN_DN, 0);
             gui_jogwheel_button_down = jogwheel_button_down;
-
-            //=======MENU_TIMEOUT=========
-            if (menu_timeout_enabled == 1) {
-                if (gui_get_menu_timeout_id() >= 0)
-                    gui_timer_reset(gui_get_menu_timeout_id());
-                else
-                    gui_timer_create_timeout((uint32_t)MENU_TIMEOUT_MS, (int16_t)-1);
-            }
+            gui_reset_menu_timer();
         }
     }
 
@@ -153,6 +139,21 @@ void gui_loop(void) {
         screen_dispatch_event(0, WINDOW_EVENT_LOOP, 0);
     }
     --guiloop_nesting;
+
+    // -- reset menu timer when we're in dialog
+    if (guiloop_nesting > 0) {
+        gui_reset_menu_timer();
+    }
+}
+
+void gui_reset_menu_timer() {
+    if (menu_timeout_enabled) {
+        if (gui_get_menu_timeout_id() >= 0) {
+            gui_timer_reset(gui_get_menu_timeout_id());
+        } else {
+            gui_timer_create_timeout((uint32_t)MENU_TIMEOUT_MS, (int16_t)-1);
+        }
+    }
 }
 
 /// Creates message box with provided informations

--- a/src/guiapi/src/screen_close_multiple.cpp
+++ b/src/guiapi/src/screen_close_multiple.cpp
@@ -12,7 +12,8 @@ static screen_t *const timeout_blacklist[] = {
     get_scr_printing_serial(),
     get_scr_menu_tune(),
     get_scr_wizard(),
-    get_scr_print_preview()
+    get_scr_print_preview(),
+		get_scr_menu_filament()
 #ifdef PIDCALIBRATION
         ,
     get_scr_PID()


### PR DESCRIPTION
GUI menu timer expired when dialog is visible, so after dialog is closed, timer is 0 and GUI close all screens and go to HOME.
Now we're checking is gui is nested more than once and in that case gui menu timer is reset.
BFW-951