### PR TITLE
Get LFN from SFN path correctly + fix "Printing time"

### DIFF
--- a/src/common/media.cpp
+++ b/src/common/media.cpp
@@ -106,13 +106,69 @@ void media_get_SFN_path(char *sfn, uint32_t sfn_size, char *filepath) {
     }
 }
 
+/// This is a workaround for a nasty edge case of FATfs's f_stat,
+/// which doesn't return a LFN when given a full SFN path.
+/// @@TODO may be an updated FATfs solves this
+/// The complexity of this code is comparable to original f_stat, may be a bit faster
+/// It just opens a directory, finds the right SFN and fills the fno structure with the LFN, which is what we want.
+/// Refactored from LazyDirView::F_DIR_RAII_Find_One
+class f_stat_LFN {
+public:
+    /// beware, this assumes a full path which includes at least one slash.
+    /// Also, the sfnPath must not be a const ptr, since we are abusing the complete path
+    /// to break it IN PLACE into the separate path and the separate filename.
+    /// This is fixed at the end of the function, so the sfnPath doesn't change from the outside perspective.
+    f_stat_LFN(char *sfnPath) {
+        char *sfn = strchr(sfnPath, '/');
+        char *returnSlash = sfn;
+        *returnSlash = 0; //
+        ++sfn;
+        result = FR_NO_FILE;
+        if ((result = f_opendir(&dp, sfnPath)) == FR_OK) {
+            for (;;) {
+                result = f_readdir(&dp, &fno); // get a directory item
+                if (result != FR_OK || !fno.fname[0]) {
+                    result = FR_NO_FILE; // make sure we report some meaningful error (unlike FATfs)
+                    break;
+                }
+                // select appropriate file name
+                const char *fname = fno.altname[0] ? fno.altname : fno.fname;
+                if (!strcmp(sfn, fname)) {
+                    break; // found the SFN searched for
+                }
+            }
+        }
+        *returnSlash = '/';
+    }
+    ~f_stat_LFN() {
+        f_closedir(&dp);
+    }
+    /// @returns true if the search for the filename was successfull
+    inline bool Success() const { return result == FR_OK; }
+    /// @returns the file size of the searched for. It is only valid if the search was successful
+    inline unsigned int FSize() const { return fno.fsize; }
+    /// @returns pointer to the LFN of the file searched for.
+    /// It is only valid if the search was successful and while the f_stat_LFN exists.
+    inline const char *LFName() const { return fno.fname; }
+
+private:
+    DIR dp;
+    FILINFO fno;
+    int result;
+};
+
 void media_print_start(const char *sfnFilePath) {
-    FILINFO filinfo;
     if (media_print_state == media_print_state_NONE) {
         strlcpy(media_print_SFN_path, sfnFilePath, sizeof(media_print_SFN_path));
-        if (f_stat(media_print_SFN_path, &filinfo) == FR_OK) {
-            strlcpy(media_print_LFN, filinfo.fname, sizeof(media_print_LFN));
-            media_print_size = filinfo.fsize;
+        // Beware - f_stat returns a SFN filename, when the input path is SFN
+        // which is a nasty surprise. Therefore there is an alternative way of looking
+        // for the file, which has the same results (and a bit lower code complexity)
+        // An updated version of FATfs may solve the problem, therefore the original line of code is left here as a comment
+        // if (f_stat(media_print_SFN_path, &filinfo) == FR_OK) {
+        f_stat_LFN fo(media_print_SFN_path);
+        if (fo.Success() == FR_OK) {
+            strlcpy(media_print_LFN, fo.LFName(), sizeof(media_print_LFN));
+            media_print_size = fo.FSize(); //filinfo.fsize;
             if (f_open(&media_print_fil, media_print_SFN_path, FA_READ) == FR_OK) {
                 media_current_position = 0;
                 media_current_line = 0;
@@ -121,6 +177,7 @@ void media_print_start(const char *sfnFilePath) {
         }
     }
 }
+// #pragma GCC pop_options
 
 void media_print_stop(void) {
     if ((media_print_state == media_print_state_PRINTING) || (media_print_state == media_print_state_PAUSED)) {

--- a/src/common/media.cpp
+++ b/src/common/media.cpp
@@ -177,7 +177,6 @@ void media_print_start(const char *sfnFilePath) {
         }
     }
 }
-// #pragma GCC pop_options
 
 void media_print_stop(void) {
     if ((media_print_state == media_print_state_PRINTING) || (media_print_state == media_print_state_PAUSED)) {

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -205,7 +205,7 @@ void screen_printing_init(screen_t *screen) {
     pw->w_time_label.font = resource_font(IDR_FNT_SMALL);
     window_set_alignment(id, ALIGN_RIGHT_BOTTOM);
     window_set_padding(id, padding_ui8(0, 2, 0, 2));
-    window_set_text(id, "");
+    window_set_text(id, _("Printing time"));
 
     id = window_create_ptr(WINDOW_CLS_TEXT, root,
         rect_ui16(10, 148, 101, 20),


### PR DESCRIPTION
- Get LFN from SFN path correctly (avoid an f_stat bug).
- Return label "Printing time" where it was before.

BFW-972
BFW-973