### PR TITLE
Printing time after pause start from 0

### DIFF
--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -519,7 +519,7 @@ static void _server_print_loop(void) {
     case mpsResuming_UnparkHead:
         if (planner.movesplanned() == 0) {
             media_print_resume();
-            if(print_job_timer.isPaused())
+            if (print_job_timer.isPaused())
                 print_job_timer.start();
 #if FAN_COUNT > 0
             thermalManager.set_fan_speed(0, marlin_server.resume_fan_speed); // restore fan speed

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -519,7 +519,8 @@ static void _server_print_loop(void) {
     case mpsResuming_UnparkHead:
         if (planner.movesplanned() == 0) {
             media_print_resume();
-            print_job_timer.resume(0);
+            if(print_job_timer.isPaused())
+                print_job_timer.start();
 #if FAN_COUNT > 0
             thermalManager.set_fan_speed(0, marlin_server.resume_fan_speed); // restore fan speed
 #endif


### PR DESCRIPTION
Previous resume used stopwatch's - resume(0) and was called two times. Rawtime was always 0 in update function (screen_printing).
Now we check if timer is paused, then use start() fnc because it's not loosing it's previous time value.