### PR TITLE
Remove pngview.c from build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,7 +513,6 @@ if(GUI)
             src/gui/resource.c
             src/gui/window_file_list.c
             src/gui/lazyfilelist-c-api.cpp
-            src/gui/pngview.c
             src/gui/wizard/selftest_temp.c
             src/gui/window_temp_graph.c
             src/gui/screen_menu_settings.cpp


### PR DESCRIPTION
The file of pngview.c is an auxiliary code for an image viewer based on the Buddy board.
It is not used in the FW anywhere. Removing it saves 2KB of statically allocated RAM.