### PR TITLE
Fix text rolling in file browser

### DIFF
--- a/src/gui/window_file_list.h
+++ b/src/gui/window_file_list.h
@@ -28,12 +28,11 @@ typedef struct _window_file_list_t {
     font_t *font;
     padding_ui8_t padding;
     txtroll_t roll;
-    uint8_t alignment;
-    uint8_t last_index;
     int count;                        // total number of files/entries in a dir
     int index;                        // selected index - cursor position within the visible items
-    char sfn_path[FILE_PATH_MAX_LEN]; // this is a Short-File-Name path where we start the file dialog
     void *ldv;                        // I'm a C-pig and I need a pointer to my LazyDirView class instance ... subject to change when this gets rewritten to C++
+    char sfn_path[FILE_PATH_MAX_LEN]; // this is a Short-File-Name path where we start the file dialog
+    uint8_t alignment;
 } window_file_list_t;
 
 // This enum value is stored to eeprom as file sort settings


### PR DESCRIPTION
There were 2 issues:
- repaint of top/bottom item was incorrect (could leave some characters from the previous item)
- text roll didn't restart when reached the end of text

BFW-979