### PR TITLE
BUG - removing USB on printing screen

### DIFF
--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -346,7 +346,7 @@ int screen_printing_event(screen_t *screen, window_t *window, uint8_t event, voi
     if (marlin_vars()->sd_percent_done != pw->last_sd_percent_done)
         update_progress(screen, marlin_vars()->sd_percent_done, marlin_vars()->print_speed);
 
-    if (p_window_header_event_clr(&(pw->header), MARLIN_EVT_MediaRemoved)) {
+    if (p_window_header_event_clr(&(pw->header), MARLIN_EVT_MediaRemoved) && get_state(screen) == printing_state_t::PRINTED) {
         screen_close();
     }
 


### PR DESCRIPTION
When user remove USB stick in the middle of printing, then printing is paused. Last fix of removing USB when printing is done or stopped did not checked printing state (PRINTED), so media_removed event returned user to home screen instead of just paused print.
This is fix for that.