### PR TITLE
WUI - Release fixes and improvments

### DIFF
--- a/lib/WUI/ethernetif.c
+++ b/lib/WUI/ethernetif.c
@@ -61,6 +61,7 @@
 /* Within 'USER CODE' section, code will be kept by default at each generation */
 /* USER CODE BEGIN 0 */
 #include "lwip/netifapi.h"
+#include "wui_api.h"
 #include "otp.h"
 #include <stdbool.h>
 /* USER CODE END 0 */
@@ -208,31 +209,15 @@ void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth) {
 }
 
 /* USER CODE BEGIN 4 */
-void ethernetif_link(const void *arg) {
+uint32_t ethernetif_link(const void *arg) {
     struct netif *netif = (struct netif *)arg;
-    uint8_t eth_link;
     uint32_t phyreg = 0U;
-    static bool wait = false;
+    uint32_t eth_link;
 
     HAL_ETH_ReadPHYRegister(&heth, PHY_BSR, &phyreg);
     eth_link = (phyreg & PHY_LINKED_STATUS) == PHY_LINKED_STATUS ? 1 : 0;
 
-    if (wait) {
-        if (netif_is_link_up(netif) || !eth_link) {
-            wait = false;
-        }
-    }
-
-    if (eth_link != netif_is_link_up(netif)) {
-        if (eth_link) {
-            if (!wait) {
-                netifapi_netif_set_link_up(netif); // thread safe variant
-                wait = true;
-            }
-        } else {
-            netifapi_netif_set_link_down(netif);
-        }
-    }
+    return eth_link;
 }
 
 /* USER CODE END 4 */

--- a/lib/WUI/ethernetif.c
+++ b/lib/WUI/ethernetif.c
@@ -210,14 +210,10 @@ void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth) {
 
 /* USER CODE BEGIN 4 */
 uint32_t ethernetif_link(const void *arg) {
-    struct netif *netif = (struct netif *)arg;
     uint32_t phyreg = 0U;
-    uint32_t eth_link;
 
     HAL_ETH_ReadPHYRegister(&heth, PHY_BSR, &phyreg);
-    eth_link = (phyreg & PHY_LINKED_STATUS) == PHY_LINKED_STATUS ? 1 : 0;
-
-    return eth_link;
+    return (phyreg & PHY_LINKED_STATUS) == PHY_LINKED_STATUS ? 1 : 0;
 }
 
 /* USER CODE END 4 */

--- a/lib/WUI/ethernetif.h
+++ b/lib/WUI/ethernetif.h
@@ -65,7 +65,7 @@ err_t ethernetif_init(struct netif *netif);
 void ethernetif_input(void const *argument);
 void ethernetif_update_config(struct netif *netif);
 void ethernetif_notify_conn_changed(struct netif *netif);
-void ethernetif_link(const void *arg);
+uint32_t ethernetif_link(const void *arg);
 
 u32_t sys_jiffies(void);
 u32_t sys_now(void);

--- a/lib/WUI/lwip.c
+++ b/lib/WUI/lwip.c
@@ -88,8 +88,7 @@ void netif_link_callback(struct netif *eth) {
         }
     } else {
         if (IS_LAN_DHCP(ethconfig.lan.flag)) {
-            dhcp_release(eth);
-            dhcp_stop(eth);
+            dhcp_release_and_stop(eth);
         }
         netif_set_down(eth);
     }

--- a/lib/WUI/lwip.c
+++ b/lib/WUI/lwip.c
@@ -129,7 +129,7 @@ void MX_LWIP_Init(void) {
     netif_set_link_callback(&eth0, netif_link_callback);
 
     // ETH force reset
-    if (eth0.flags & NETIF_FLAG_LINK_UP) {
+    if (eth0.flags & NETIF_FLAG_LINK_UP && IS_LAN_ON(ethconfig.lan.flag)) {
         eth0.flags &= ~NETIF_FLAG_LINK_UP;
         netifapi_netif_set_link_up(&eth0);
     } else {

--- a/lib/WUI/lwip.c
+++ b/lib/WUI/lwip.c
@@ -58,6 +58,7 @@
 #include "lwip.h"
 #include "lwip/init.h"
 #include "lwip/netif.h"
+#include "netifapi.h"
 
 #include <string.h>
 
@@ -79,26 +80,18 @@ void netif_link_callback(struct netif *eth) {
     if (netif_is_link_up(eth)) {
         if (IS_LAN_ON(ethconfig.lan.flag)) {
             netif_set_up(eth);
-        }
-    } else {
-        netif_set_down(eth);
-    }
-}
-
-void netif_status_callback(struct netif *eth) {
-    ETH_config_t ethconfig;
-    ethconfig.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
-    load_eth_params(&ethconfig);
-    if (netif_is_up(eth)) {
-        if (IS_LAN_DHCP(ethconfig.lan.flag)) {
-            dhcp_start(eth);
-        } else {
-            dhcp_inform(eth);
+            if (IS_LAN_DHCP(ethconfig.lan.flag)) {
+                dhcp_start(eth);
+            } else {
+                dhcp_inform(eth);
+            }
         }
     } else {
         if (IS_LAN_DHCP(ethconfig.lan.flag)) {
+            dhcp_release(eth);
             dhcp_stop(eth);
         }
+        netif_set_down(eth);
     }
 }
 
@@ -122,7 +115,8 @@ void MX_LWIP_Init(void) {
     ETH_config_t ethconfig;
     ethconfig.var_mask = ETHVAR_STATIC_LAN_ADDRS | ETHVAR_MSK(ETHVAR_LAN_FLAGS) | ETHVAR_MSK(ETHVAR_HOSTNAME);
     load_eth_params(&ethconfig);
-    eth0.hostname = ethconfig.hostname;
+    strlcpy(eth_hostname, ethconfig.hostname, ETH_HOSTNAME_LEN + 1);
+    eth0.hostname = eth_hostname;
     /* This won't execute until user loads static lan settings at least once (default is DHCP) */
     if (IS_LAN_STATIC(ethconfig.lan.flag)) {
 
@@ -132,20 +126,17 @@ void MX_LWIP_Init(void) {
 
         netif_set_addr(&eth0, &ipaddr, &netmask, &gw);
     }
-    if (IS_LAN_ON(ethconfig.lan.flag) && netif_is_link_up(&eth0)) {
-        /* When the netif is fully configured and switched on this function must be called */
-        netif_set_up(&eth0);
-        if (IS_LAN_DHCP(ethconfig.lan.flag)) {
-            /* Start DHCP negotiation for a network interface (IPv4) */
-            dhcp_start(&eth0);
-        }
-    } else {
-        /* When the netif link is down or software lan switch is off, this function must be called */
-        netif_set_down(&eth0);
-    }
     /* Setting necessary callbacks after initial setup */
     netif_set_link_callback(&eth0, netif_link_callback);
-    netif_set_status_callback(&eth0, netif_status_callback);
+
+    // ETH force reset
+    if (eth0.flags & NETIF_FLAG_LINK_UP) {
+        eth0.flags &= ~NETIF_FLAG_LINK_UP;
+        netifapi_netif_set_link_up(&eth0);
+    } else {
+        eth0.flags |= NETIF_FLAG_LINK_UP;
+        netifapi_netif_set_link_down(&eth0);
+    }
 }
 
 /* MINI LwIP interface functions --------------------------------------------*/

--- a/lib/WUI/lwipopts.h
+++ b/lib/WUI/lwipopts.h
@@ -146,7 +146,6 @@ extern "C" {
     #define LWIP_NETIF_API             1 // enable LWIP_NETIF_API==1: Support netif api (in netifapi.c)
     #define LWIP_NETIF_LINK_CALLBACK   1 //LWIP_NETIF_LINK_CALLBACK==1: Support a callback function from an interface
     #define LWIP_HTTPD_DYNAMIC_HEADERS 1
-    #define LWIP_NETIF_STATUS_CALLBACK 1
     #define LWIP_NETIF_HOSTNAME        1
     #define LWIP_HTTPD_SUPPORT_POST    1
     #ifdef WUI_HOST_NAME

--- a/lib/WUI/netif_settings.c
+++ b/lib/WUI/netif_settings.c
@@ -64,14 +64,16 @@ void eth_status_step(ETH_config_t *config, uint32_t eth_link) {
 }
 
 void turn_off_LAN(ETH_config_t *config) {
+    TURN_LAN_OFF(config->lan.flag);
+    save_eth_params(config);
     if (eth_status == ETH_NETIF_UP) {
         netifapi_netif_set_link_down(&eth0);
     }
-    TURN_LAN_OFF(config->lan.flag);
 }
 
 void turn_on_LAN(ETH_config_t *config) {
     TURN_LAN_ON(config->lan.flag);
+    save_eth_params(config);
     if (eth_status != ETH_UNLINKED) {
         netifapi_netif_set_link_up(&eth0);
     }

--- a/lib/WUI/wui.c
+++ b/lib/WUI/wui.c
@@ -91,7 +91,9 @@ void update_state_variables_step(void) {
     config.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
     load_eth_params(&config);
 
-    eth_status_step(&config);
+    uint32_t eth_link = ethernetif_link(&eth0); // handles Ethernet link plug/un-plug events
+
+    eth_status_step(&config, eth_link);
     sntp_client_step();
 }
 
@@ -114,17 +116,16 @@ void StartWebServerTask(void const *argument) {
     if (wui_marlin_vars) {
         wui_marlin_vars->media_LFN = wui_media_LFN;
     }
-    // get settings from ini file
-    ETH_config_t config;
-    load_ini_params(&config);
     // LwIP related initalizations
     MX_LWIP_Init();
     http_server_init();
+    // get settings from ini file
+    ETH_config_t config;
+    load_ini_params(&config);
 
     for (;;) {
 
-        ethernetif_link(&eth0); // handles Ethernet link plug/un-plug events
-        wui_queue_cycle();      // checks for commands to WUI
+        wui_queue_cycle(); // checks for commands to WUI
         update_state_variables_step();
 
         if (wui_marlin_vars) {

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -162,8 +162,10 @@ void get_addrs_from_dhcp(ETH_config_t *config);
 * \brief Checks and sets ethernet status
 *
 * \param [in] config - structure that stores currnet ethernet configurations
+*
+* \param [in] eth_link - stores whether ehternet is pluged, 0 otherwise
 ************************************************************************************/
-void eth_status_step(ETH_config_t *config);
+void eth_status_step(ETH_config_t *config, uint32_t eth_link);
 
 /*!****************************************************************************
 * \brief Turns software switch of ETH netif to OFF

--- a/src/common/wui_api.c
+++ b/src/common/wui_api.c
@@ -203,14 +203,14 @@ uint32_t set_loaded_eth_params(ETH_config_t *config) {
 
     // Aquire lan flags before load
     uint8_t prev_lan_flag = config->lan.flag;
+    uint32_t save_mask = config->var_mask;
+    config->var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
+    load_eth_params(config);
+    config->var_mask = save_mask;
     {
-        uint32_t set_mask = config->var_mask;
-        config->var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
-        load_eth_params(config);
         uint8_t swapper = prev_lan_flag;
         prev_lan_flag = config->lan.flag;
         config->lan.flag = swapper;
-        config->var_mask = set_mask;
     }
 
     if (config->var_mask & ETHVAR_MSK(ETHVAR_LAN_FLAGS)) {
@@ -223,7 +223,7 @@ uint32_t set_loaded_eth_params(ETH_config_t *config) {
         }
         // from DHCP to DHCP: do nothing
     }
-
+    config->var_mask = save_mask;
     save_eth_params(config);
 
     return 1;

--- a/src/gui/screen_menu_lan_settings.cpp
+++ b/src/gui/screen_menu_lan_settings.cpp
@@ -131,18 +131,14 @@ bool Eth::IsUpdated() {
 
 bool Eth::SetStatic() {
     ETH_config_t ethconfig;
-    ethconfig.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS) | ETHVAR_MSK(ETHVAR_LAN_ADDR_IP4);
+    ethconfig.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS) | ETHVAR_STATIC_LAN_ADDRS;
     load_eth_params(&ethconfig);
 
     if (ethconfig.lan.addr_ip4.addr == 0) {
         msg = Msg::StaicAddrErr;
         return false;
     }
-    ethconfig.var_mask = ETHVAR_STATIC_LAN_ADDRS;
-    load_eth_params(&ethconfig);
     set_LAN_to_static(&ethconfig);
-    ethconfig.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
-    save_eth_params(&ethconfig);
     new_data_flg = true;
     return true;
 }
@@ -151,10 +147,7 @@ bool Eth::SetDHCP() {
     ETH_config_t ethconfig;
     ethconfig.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
     load_eth_params(&ethconfig);
-
     set_LAN_to_dhcp(&ethconfig);
-    ethconfig.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
-    save_eth_params(&ethconfig);
     new_data_flg = true;
     conn_flg = true;
     return true;

--- a/src/gui/screen_menu_lan_settings.cpp
+++ b/src/gui/screen_menu_lan_settings.cpp
@@ -82,7 +82,6 @@ void Eth::Off() {
     ethconfig.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
     load_eth_params(&ethconfig);
     turn_off_LAN(&ethconfig);
-    save_eth_params(&ethconfig);
     new_data_flg = true;
 }
 
@@ -91,7 +90,6 @@ void Eth::On() {
     ethconfig.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
     load_eth_params(&ethconfig);
     turn_on_LAN(&ethconfig);
-    save_eth_params(&ethconfig);
     new_data_flg = true;
     if (IS_LAN_DHCP(ethconfig.lan.flag)) {
         conn_flg = true;


### PR DESCRIPTION
FIxed bugs:
- crash after restarting printer with USB (with DHCP ini) [problem: ini load was executed before lwip init func]
- couldn't load and **set** static addrs nor dhcp addrs [problem: loading was correct, but while setting, lwip callback was called before saving params in eeprom, thus old values were set]
- couldn't change static to dhcp and vise versa [problem: lwip callback before saving new values -> settings old values]
- couldn't turn off or on properly [problem: lwip callback before saving new values -> settings old values]
- couldn't turn on after restart with turn off flag [problem: link_up flag in netif is initializing in ethernet low lvl init]

New improvements:
- netif status callback removed [reason: status callback was called through link callback as well as outside, there was redundant calling]
- add dhcp_release() [reason: I probably forget about it, it may reduce memory useage].
- simplification of ethernet link update function, netif_link_up and link down are executing in wui infinite cycle [reason: for easier handling, also its better to have connected things together]