### PR TITLE
Preheat for load dialog timeout

### DIFF
--- a/src/gui/dialogs/DialogRadioButton.cpp
+++ b/src/gui/dialogs/DialogRadioButton.cpp
@@ -1,6 +1,7 @@
 #include "DialogRadioButton.hpp"
 #include <algorithm> //find
 #include "button_draw.h"
+#include "sound_C_wrapper.h"
 /*****************************************************************************/
 //static variables and methods
 static const PhaseResponses no_responses = { Response::_none, Response::_none, Response::_none, Response::_none }; //used in constructor
@@ -38,6 +39,8 @@ RadioButton &RadioButton::operator++() {
     if ((selected_index + 1) < btn_count) {
         ++selected_index; //btn_count can be 0
         need_redraw = true;
+    } else {
+        Sound_Play(eSOUND_TYPE_BlindAlert);
     }
     return *this;
 }
@@ -47,6 +50,8 @@ RadioButton &RadioButton::operator--() {
     if (selected_index > 0) {
         --selected_index;
         need_redraw = true;
+    } else {
+        Sound_Play(eSOUND_TYPE_BlindAlert);
     }
     return *this;
 }

--- a/src/gui/dialogs/window_dlg_preheat.c
+++ b/src/gui/dialogs/window_dlg_preheat.c
@@ -127,7 +127,7 @@ FILAMENT_t gui_dlg_preheat(const char *caption) {
         window_list_filament_item_cb,
         window_dlg_preheat_click_cb,
         _PREHEAT_FILAMENT_CNT + 1, //+1 back option
-        30000);
+        -1);
     if (ret < 0)
         return FILAMENT_NONE; //timeout
     return (FILAMENT_t)ret;   //RETURN option will return FILAMENT_NONE


### PR DESCRIPTION
When choosing new filament to load, then dialog with filament options will timeout.
This behavior is not wished.

BFW-997