### PR TITLE
if  gui_dlg_unload() does not return OK it would freeze

### DIFF
--- a/src/gui/screen_menu_filament.cpp
+++ b/src/gui/screen_menu_filament.cpp
@@ -87,12 +87,12 @@ public:
         return header_label;
     }
     virtual void Do() override {
-        gui_dlg_unload();
+        if (gui_dlg_unload() == DLG_OK) {
+            //opens unload dialog if it is not already openned
+            DialogHandler::WaitUntilClosed(ClientFSM::Load_unload, uint8_t(LoadUnloadMode::Unload));
 
-        //opens unload dialog if it is not already openned
-        DialogHandler::WaitUntilClosed(ClientFSM::Load_unload, uint8_t(LoadUnloadMode::Unload));
-
-        gui_dlg_load() == DLG_OK ? setPreheatTemp() : clrPreheatTemp();
+            gui_dlg_load() == DLG_OK ? setPreheatTemp() : clrPreheatTemp();
+        }
     }
 };
 


### PR DESCRIPTION
it cannot happen now since change option is disabled when filament is not loaded
and if it is loaded, it is prepicked and retur value as always ok
but still better to fix it