### PR TITLE
Serial print - disconnect, safety timer, park nozzle

### DIFF
--- a/src/gui/screen_printing_serial.cpp
+++ b/src/gui/screen_printing_serial.cpp
@@ -134,6 +134,8 @@ void screen_printing_serial_init(screen_t *screen) {
 }
 
 void screen_printing_serial_done(screen_t *screen) {
+    marlin_gcode("G27 P2"); /// park nozzle and raise Z axis
+    marlin_gcode("M86 S1"); /// enable safety timer
     window_destroy(pw->root.win.id);
 }
 

--- a/src/gui/screen_printing_serial.cpp
+++ b/src/gui/screen_printing_serial.cpp
@@ -9,6 +9,7 @@
 #include "guitypes.h"      //font_meas_text
 #include "stm32f4xx_hal.h" //HAL_GetTick
 #include "screens.h"
+#include "../lang/i18n.h"
 
 #define BUTTON_TUNE       0
 #define BUTTON_PAUSE      1
@@ -160,8 +161,10 @@ int screen_printing_serial_event(screen_t *screen, window_t *window, uint8_t eve
         return 1;
         break;
     case BUTTON_DISCONNECT:
-        marlin_gcode("M118 A1 action:disconnect");
-        screen_close();
+        if (gui_msgbox(_("Really Disconnect?"), MSGBOX_BTN_YESNO) == MSGBOX_RES_YES) {
+            marlin_gcode("M118 A1 action:disconnect");
+            screen_close();
+        }
         return 1;
         break;
     }


### PR DESCRIPTION
Added few updates for Serial Printing Screen
- disconnect now have message box (YES / NO) to confirm disconnect from host
- after disconnect (serial printing screen is closed) G27 is called to park nozzle outside of the print
- after disconnect (serial printing screen is closed) - safety timer is called to cooldown nozzle & bed

BFW-1004, BFW-1003, BFW-1002, BFW-923, BFW-924, BFW-926