### PR TITLE
Serial print fixes

### DIFF
--- a/src/gui/screen_printing_serial.cpp
+++ b/src/gui/screen_printing_serial.cpp
@@ -145,6 +145,14 @@ void screen_printing_serial_done(screen_t *screen) {
 void screen_printing_serial_draw(screen_t *screen) {
 }
 
+static void disable_button(screen_t *screen, buttons_t b) {
+    window_icon_t *p_button = &pw->w_buttons[static_cast<size_t>(b)];
+    if (!p_button->win.f_disabled) {
+        p_button->win.f_disabled = 1;
+        window_invalidate(p_button->win.id);
+    }
+}
+
 int screen_printing_serial_event(screen_t *screen, window_t *window, uint8_t event, void *param) {
     window_header_events(&(pw->header));
 
@@ -179,6 +187,11 @@ int screen_printing_serial_event(screen_t *screen, window_t *window, uint8_t eve
     case buttons_t::DISCONNECT:
         if (gui_msgbox(_("Really Disconnect?"), MSGBOX_BTN_YESNO | MSGBOX_ICO_WARNING | MSGBOX_DEF_BUTTON1) == MSGBOX_RES_YES) {
             pw->disconnect_pressed = true;
+
+            disable_button(screen, buttons_t::TUNE);
+            disable_button(screen, buttons_t::PAUSE);
+            disable_button(screen, buttons_t::DISCONNECT);
+
             marlin_gcode("M118 A1 action:disconnect");
         }
         return 1;

--- a/src/gui/screen_printing_serial.cpp
+++ b/src/gui/screen_printing_serial.cpp
@@ -165,7 +165,7 @@ int screen_printing_serial_event(screen_t *screen, window_t *window, uint8_t eve
             marlin_gcode("M118 A1 action:disconnect");
             marlin_gcode("G27 P2");     /// park nozzle and raise Z axis
             marlin_gcode("M104 S0 D0"); /// set temperatures to zero
-            marlin_gcode("M140 S0"); /// set temperatures to zero
+            marlin_gcode("M140 S0");    /// set temperatures to zero
             screen_close();
         }
         return 1;

--- a/src/gui/screen_printing_serial.cpp
+++ b/src/gui/screen_printing_serial.cpp
@@ -134,8 +134,6 @@ void screen_printing_serial_init(screen_t *screen) {
 }
 
 void screen_printing_serial_done(screen_t *screen) {
-    marlin_gcode("G27 P2"); /// park nozzle and raise Z axis
-    marlin_gcode("M86 S1"); /// enable safety timer
     window_destroy(pw->root.win.id);
 }
 
@@ -163,8 +161,11 @@ int screen_printing_serial_event(screen_t *screen, window_t *window, uint8_t eve
         return 1;
         break;
     case BUTTON_DISCONNECT:
-        if (gui_msgbox(_("Really Disconnect?"), MSGBOX_BTN_YESNO) == MSGBOX_RES_YES) {
+        if (gui_msgbox(_("Really Disconnect?"), MSGBOX_BTN_YESNO | MSGBOX_ICO_WARNING | MSGBOX_DEF_BUTTON1) == MSGBOX_RES_YES) {
             marlin_gcode("M118 A1 action:disconnect");
+            marlin_gcode("G27 P2");     /// park nozzle and raise Z axis
+            marlin_gcode("M104 S0 D0"); /// set temperatures to zero
+            marlin_gcode("M140 S0"); /// set temperatures to zero
             screen_close();
         }
         return 1;

--- a/src/marlin_stubs/M876.cpp
+++ b/src/marlin_stubs/M876.cpp
@@ -23,6 +23,7 @@
 
 #if ENABLED(HOST_PROMPT_SUPPORT) && DISABLED(EMERGENCY_PARSER)
 
+		#include "../../lib/Marlin/Marlin/src/feature/safety_timer.h"
     #include "../../lib/Marlin/Marlin/src/feature/host_actions.h"
     #include "../../lib/Marlin/Marlin/src/feature/safety_timer.h"
     #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
@@ -38,7 +39,7 @@ void GcodeSuite::M876() {
             fsm_create(ClientFSM::Serial_printing, 0);
         } else {
             fsm_destroy(ClientFSM::Serial_printing);
-            safety_timer_set_interval(1800000); //in miliseconds
+            safety_timer_set_interval(1800000); // in miliseconds
         }
     }
     if (parser.seenval('S'))

--- a/src/marlin_stubs/M876.cpp
+++ b/src/marlin_stubs/M876.cpp
@@ -23,7 +23,6 @@
 
 #if ENABLED(HOST_PROMPT_SUPPORT) && DISABLED(EMERGENCY_PARSER)
 
-		#include "../../lib/Marlin/Marlin/src/feature/safety_timer.h"
     #include "../../lib/Marlin/Marlin/src/feature/host_actions.h"
     #include "../../lib/Marlin/Marlin/src/feature/safety_timer.h"
     #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"


### PR DESCRIPTION
- fixed tune menu - moving Z axis every time when user stepped into a tune menu
- fixed M876 P0 gcode making a BSOD
- fixed disconnect default confirm message box to have "NO" selected
- fixed safety timer (now cooldown) when disconnected from host (M876 P0 is called OR printer's DISCONNECT button is pressed)
- fixed marlin queue to make last gcode - parking and cooldown - now waiting for Marlin's gcode queue is empty then do the sequence