### PR TITLE
Add unit test for extremely long file names

### DIFF
--- a/tests/unit/gui/lazyfilelist/fatfs.cpp
+++ b/tests/unit/gui/lazyfilelist/fatfs.cpp
@@ -6,8 +6,7 @@
 #include <iostream>
 #include <assert.h>
 
-// filesystem se bude simulovat
-// budou ruzne velky adresare s ruznejma casama
+// Simulated filesystem with FATfs interface
 
 #if 0
 static std::vector<FileEntry> testFiles0 = {
@@ -55,8 +54,10 @@ extern "C" {
 /// fill FILINFO with LFN and simulate a SFN based on file's index
 void MakeLFNSFN(FILINFO *fno, const char *lfn, size_t fileindex) {
     assert(fileindex < 100); // to make the SFN numeric suffix within 2 digits for now
+    assert(lfn);
+    assert(fno);
     strncpy(fno->fname, lfn, sizeof(fno->fname));
-    if (strlen(lfn) >= 13) {
+    if (strlen(lfn) >= FF_SFN_BUF) {
         snprintf(fno->altname, sizeof(fno->altname), "%-.6s~%02u.GCO", lfn, fileindex);
     } else {
         fno->altname[0] = 0;
@@ -64,10 +65,10 @@ void MakeLFNSFN(FILINFO *fno, const char *lfn, size_t fileindex) {
 }
 
 FRESULT f_findfirst(
-    DIR *dp,             /* [OUT] Poninter to the directory object */
-    FILINFO *fno,        /* [OUT] Pointer to the file information structure */
-    const TCHAR *path,   /* [IN] Pointer to the directory name to be opened */
-    const TCHAR *pattern /* [IN] Pointer to the matching pattern string */
+    DIR *dp,                /* [OUT] Poninter to the directory object */
+    FILINFO *fno,           /* [OUT] Pointer to the file information structure */
+    const TCHAR * /*path*/, /* [IN] Pointer to the directory name to be opened */
+    const TCHAR *pattern    /* [IN] Pointer to the matching pattern string */
 ) {
     if (!strcmp(pattern, "*")) {
         MakeLFNSFN(fno, testFiles0[0].lfn.c_str(), 0);
@@ -110,8 +111,8 @@ FRESULT f_findnext(
 }
 
 FRESULT f_opendir(
-    DIR *dp,          /* [OUT] Poninter to the directory object */
-    const TCHAR *path /* [IN] Pointer to the directory name to be opened */
+    DIR *dp,               /* [OUT] Poninter to the directory object */
+    const TCHAR * /*path*/ /* [IN] Pointer to the directory name to be opened */
 ) {
     dp->obj = 0;
     return FR_OK;
@@ -134,7 +135,7 @@ FRESULT f_readdir(
 }
 
 FRESULT f_closedir(
-    DIR *dp /* [IN] Pointer to the directory object */
+    DIR * /*dp*/ /* [IN] Pointer to the directory object */
 ) {
     return 1;
 }

--- a/tests/unit/gui/lazyfilelist/fatfs.cpp
+++ b/tests/unit/gui/lazyfilelist/fatfs.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <assert.h>
 
 // filesystem se bude simulovat
 // budou ruzne velky adresare s ruznejma casama
@@ -51,6 +52,17 @@ std::vector<FileEntry> testFiles0;
 
 extern "C" {
 
+/// fill FILINFO with LFN and simulate a SFN based on file's index
+void MakeLFNSFN(FILINFO *fno, const char *lfn, size_t fileindex) {
+    assert(fileindex < 100); // to make the SFN numeric suffix within 2 digits for now
+    strncpy(fno->fname, lfn, sizeof(fno->fname));
+    if (strlen(lfn) >= 13) {
+        snprintf(fno->altname, sizeof(fno->altname), "%-.6s~%02u.GCO", lfn, fileindex);
+    } else {
+        fno->altname[0] = 0;
+    }
+}
+
 FRESULT f_findfirst(
     DIR *dp,             /* [OUT] Poninter to the directory object */
     FILINFO *fno,        /* [OUT] Pointer to the file information structure */
@@ -58,7 +70,7 @@ FRESULT f_findfirst(
     const TCHAR *pattern /* [IN] Pointer to the matching pattern string */
 ) {
     if (!strcmp(pattern, "*")) {
-        strncpy(fno->fname, testFiles0[0].lfn.c_str(), 96);
+        MakeLFNSFN(fno, testFiles0[0].lfn.c_str(), 0);
         fno->fattrib = testFiles0[0].dir ? AM_DIR : 0;
         fno->fdate = testFiles0[0].date;
         fno->ftime = testFiles0[0].time;
@@ -68,7 +80,7 @@ FRESULT f_findfirst(
             return strcmp(pattern, e.lfn.c_str()) == 0;
         });
         if (i != testFiles0.end()) {
-            strncpy(fno->fname, i->lfn.c_str(), 96);
+            MakeLFNSFN(fno, i->lfn.c_str(), std::distance(i, testFiles0.begin()));
             fno->fattrib = i->dir ? AM_DIR : 0;
             fno->fdate = i->date;
             fno->ftime = i->time;
@@ -86,9 +98,10 @@ FRESULT f_findnext(
 ) {
     if (dp->obj >= (int)testFiles0.size() - 1) {
         fno->fname[0] = 0;
+        fno->altname[0] = 0;
     } else {
         ++dp->obj;
-        strncpy(fno->fname, testFiles0[dp->obj].lfn.c_str(), 96);
+        MakeLFNSFN(fno, testFiles0[dp->obj].lfn.c_str(), dp->obj);
         fno->fattrib = testFiles0[dp->obj].dir ? AM_DIR : 0;
         fno->fdate = testFiles0[dp->obj].date;
         fno->ftime = testFiles0[dp->obj].time;
@@ -111,8 +124,7 @@ FRESULT f_readdir(
     if (dp->obj >= (int)testFiles0.size()) {
         fno->fname[0] = 0;
     } else {
-        strncpy(fno->fname, testFiles0[dp->obj].lfn.c_str(), 96);
-        strncpy(fno->altname, testFiles0[dp->obj].lfn.c_str(), 13); // tady je mi to celkem jedno, pak se to muze zlepsit
+        MakeLFNSFN(fno, testFiles0[dp->obj].lfn.c_str(), dp->obj);
         fno->fattrib = testFiles0[dp->obj].dir ? AM_DIR : 0;
         fno->fdate = testFiles0[dp->obj].date;
         fno->ftime = testFiles0[dp->obj].time;

--- a/tests/unit/gui/lazyfilelist/file_list_defs.h
+++ b/tests/unit/gui/lazyfilelist/file_list_defs.h
@@ -22,5 +22,3 @@
 #ifndef MAXPATHNAMELENGTH
     #define F_MAXPATHNAMELENGTH (1 + (F_MAXDIRNAMELENGTH + 1) * (MAX_DIR_DEPTH) + 1 + _MAX_LFN)
 #endif
-
-#define strlcpy strncpy

--- a/tests/unit/gui/lazyfilelist/tests.cpp
+++ b/tests/unit/gui/lazyfilelist/tests.cpp
@@ -94,7 +94,6 @@ TEST_CASE("LazyDirView::SortByName test", "[LazyDirView]") {
         CHECK(CheckFilesSeq(ldv, { "..", "fw", "old", "png-decode", "01.g", "02.g", "03.g", "04.g", "05.g" }));
     }
 }
-
 TEST_CASE("LazyDirView::SortByCrModDateTime test", "[LazyDirView]") {
     using LDV = LazyDirView<9>;
 
@@ -291,4 +290,25 @@ TEST_CASE("LazyDirView::StartWithFile2 test", "[LazyDirView]") {
     CHECK(CheckFilesSeq(ldv, { "..", "3", "tr.g", "", "", "", "", "", "" }));
     CHECK(ldv.MoveUp() == false);
     CHECK(CheckFilesSeq(ldv, { "..", "3", "tr.g", "", "", "", "", "", "" }));
+}
+
+TEST_CASE("LazyDirView::ExtremelyLongFileName test", "[LazyDirView][!shouldfail]") {
+    using LDV = LazyDirView<9>;
+
+    static const char extremeLFN[] = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff - kopie - kopie.gcode";
+    char truncatedLFN[FF_LFN_BUF + 1];
+    strlcpy(truncatedLFN, extremeLFN, sizeof(truncatedLFN)); // prepare the truncated string
+    testFiles0 = {
+        { "3", 1, 0, true },
+        { extremeLFN, 2, 0, false },
+    };
+
+    LDV ldv;
+    ldv.ChangeDirectory("path", LDV::SortPolicy::BY_CRMOD_DATETIME, nullptr);
+    // And here I don't expect the correct path to be in the file list - it is just too long for that
+    // For now this test is expected to fail, to be solved in BFW-1041
+    CHECK(CheckFilesSeq(ldv, { "3", truncatedLFN, "", "", "", "", "", "", "" }));
+    // the file list may survive this unharmed, but I must also make sure the surrounding code survives as well
+    // -> the truncated filename does not exist at all or may even be identical to some other (deliberately chosen) filename
+    // and we must make sure the user prints the right one (the chosen one)
 }


### PR DESCRIPTION
Expected to fail for now, such files are not accepted into the file browser, thus the user cannot print them. To be solved in the future.

BFW-1041