### PR TITLE
Switch submodules back to absolute urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "TMCStepper"]
 	path = lib/TMCStepper
-	url = ../../prusa3d/TMCStepper.git
+	url = https://github.com/prusa3d/TMCStepper.git
 [submodule "Marlin"]
 	path = lib/Marlin
-	url = ../../prusa3d/Marlin.git
+	url = https://github.com/prusa3d/Marlin.git
 [submodule "inih"]
 	path = lib/inih
-	url = ../../benhoyt/inih.git
+	url = https://github.com/benhoyt/inih.git
 [submodule "LwIP"]
 	path = lib/Middlewares/Third_Party/LwIP
-	url = ../../prusa3d/LwIP_212.git
+	url = https://github.com/prusa3d/LwIP_212.git
 [submodule "lib/jsmn"]
 	path = lib/jsmn
-	url = ../../zserge/jsmn.git
+	url = https://github.com/zserge/jsmn.git
 [submodule "lib/Catch2"]
 	path = lib/Catch2
-	url = ../../catchorg/Catch2.git
+	url = https://github.com/catchorg/Catch2.git


### PR DESCRIPTION
This reverts commit fffebf1bea0de91f42fc3e2489097a56298fe213.

It seems that Github does not handle relative submodules correctly (not showing diff in pull requests)
![Screenshot 2020-07-08 at 11 59 02](https://user-images.githubusercontent.com/1269664/86905500-6d90ce00-c112-11ea-8003-5f1604998a10.png)
