### PR TITLE
Add language singleton to set, get & store active language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,6 +473,7 @@ target_sources(
           src/common/print_utils.cpp
           src/common/base64_stream_decoder.cpp
           src/common/sound.cpp
+          src/common/language_eeprom.cpp
           src/common/support_utils.cpp
           src/common/str_utils.cpp
           src/common/errors.cpp

--- a/src/common/appmain.cpp
+++ b/src/common/appmain.cpp
@@ -11,6 +11,7 @@
 #include "sys.h"
 #include "gpio.h"
 #include "sound.hpp"
+#include "language_eeprom.hpp"
 
 #ifdef SIM_HEATER
     #include "sim_heater.h"
@@ -75,6 +76,7 @@ void app_run(void) {
     crc32_init();
 
     uint8_t defaults_loaded = eeprom_init();
+    LangEEPROM::getInstance();
 
     marlin_server_init();
     marlin_server_idle_cb = app_idle;

--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -66,6 +66,8 @@ typedef struct _eeprom_vars_t {
     char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
     int8_t TIMEZONE;
     uint8_t SOUND_MODE;
+    uint8_t SOUND_VOLUME;
+    uint16_t LANGUAGE;
     char _PADDING[EEPROM__PADDING];
     uint32_t CRC32;
 } eeprom_vars_t;
@@ -103,6 +105,8 @@ static const eeprom_entry_t eeprom_map[] = {
     { "LAN_HOSTNAME",    VARIANT8_PCHAR, LAN_HOSTNAME_MAX_LEN + 1, 0 }, // EEVAR_LAN_HOSTNAME
     { "TIMEZONE",        VARIANT8_I8,    1, 0 }, // EEVAR_TIMEZONE
     { "SOUND_MODE",      VARIANT8_UI8,   1, 0 }, // EEVAR_SOUND_MODE
+    { "SOUND_VOLUME",      VARIANT8_UI8,   1, 0 }, // EEVAR_SOUND_VOLUME
+    { "LANGUAGE",					VARIANT8_UI16,   1, 0 }, // EEVAR_LANGUAGE
     { "_PADDING",        VARIANT8_PCHAR, EEPROM__PADDING, 0 }, // EEVAR__PADDING32
     { "CRC32",           VARIANT8_UI32,  1, 0 }, // EEVAR_CRC32
 };
@@ -136,6 +140,8 @@ static const eeprom_vars_t eeprom_var_defaults = {
     "PrusaMINI",     // EEVAR_LAN_HOSTNAME
     0,               // EEVAR_TIMEZONE
     0xff,            // EEVAR_SOUND_MODE
+    0x64,            // EEVAR_SOUND_VOLUME
+    0xffff,            // EEVAR_LANGUAGE
     "",              // EEVAR__PADDING
     0xffffffff,      // EEVAR_CRC32
 };
@@ -383,12 +389,46 @@ static int eeprom_convert_from_v4(void) {
     return 1;
 }
 
+// conversion function for old version 6 (v 4.1.0)
+static int eeprom_convert_from_v6(void) {
+    uint16_t addr_start;
+    uint16_t addr_end;
+    eeprom_vars_t vars = eeprom_var_defaults;
+
+    // these variables not initialised in eeprom_var_defaults
+    vars.FWBUILD = project_build_number;
+    vars.FWVERSION = eeprom_fwversion_ui16();
+
+    // start addres of imported data first block (FILAMENT_TYPE..EEVAR_ZOFFSET)
+    addr_start = eeprom_var_addr(EEVAR_FILAMENT_TYPE);
+    // end addres of imported data - we want not import PID constants
+    addr_end = eeprom_var_addr(EEVAR_PID_NOZ_P);
+    // read first block
+    st25dv64k_user_read_bytes(addr_start, &(vars.FILAMENT_TYPE), addr_end - addr_start);
+
+    // start addres of imported data second block (EEVAR_LAN_FLAG..EEVAR_SOUND_MODE)
+    addr_start = eeprom_var_addr(EEVAR_LAN_FLAG);
+    // end addres of imported data - we want not import PID constants
+    addr_end = eeprom_var_addr(EEVAR_SOUND_VOLUME);
+    // read first block
+    st25dv64k_user_read_bytes(addr_start, &(vars.LAN_FLAG), addr_end - addr_start);
+
+    // calculate crc32
+    vars.CRC32 = crc32_calc((uint32_t *)(&vars), (EEPROM_DATASIZE - 4) / 4);
+    // write data to eeprom
+    st25dv64k_user_write_bytes(EEPROM_ADDRESS, (void *)&vars, EEPROM_DATASIZE);
+
+    return 1;
+}
+
 // conversion function for new version format (features, firmware version/build)
 static int eeprom_convert_from(uint16_t version, uint16_t features) {
     if (version == 2)
         return eeprom_convert_from_v2();
     if (version == 4)
         return eeprom_convert_from_v4();
+    if (version == 6)
+        return eeprom_convert_from_v6();
     return 0;
 }
 

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -6,7 +6,7 @@
 #include "variant8.h"
 
 #define EEPROM_ADDRESS  0x0500
-#define EEPROM_VERSION  6
+#define EEPROM_VERSION  7
 #define EEPROM_FEATURES (EEPROM_FEATURE_PID_NOZ | EEPROM_FEATURE_PID_BED | EEPROM_FEATURE_LAN)
 
 #define EEPROM_FEATURE_PID_NOZ 0x0001
@@ -54,11 +54,13 @@
 #endif                              // (EEPROM_FEATURES & EEPROM_FEATURE_LAN)
 
 // sound variable
-#define EEVAR_SOUND_MODE 0x1a // uint8_t
+#define EEVAR_SOUND_MODE   0x1a // uint8_t
+#define EEVAR_SOUND_VOLUME 0x1b // uint8_t
+#define EEVAR_LANGUAGE     0x1c // uint16_t
 
-#define EEVAR__PADDING 0x1b // 1..4 chars, to ensure (DATASIZE % 4 == 0)
+#define EEVAR__PADDING 0x1d // 1..4 chars, to ensure (DATASIZE % 4 == 0)
 
-#define EEVAR_CRC32 0x1c // uint32_t crc32 for
+#define EEVAR_CRC32 0x1e // uint32_t crc32 for
 
 #define LAN_HOSTNAME_MAX_LEN 20
 #define CONNECT_TOKEN_SIZE   20

--- a/src/common/language_eeprom.cpp
+++ b/src/common/language_eeprom.cpp
@@ -1,0 +1,45 @@
+
+#include "language_eeprom.hpp"
+#include "../lang/translator.hpp"
+
+/*!
+ * Setter & getter class to store language code into a EEPROM
+ * Constructor will check if language code is not set, then it will set
+ * a default value.
+ * If it's set, then Translator is called to start translating.
+ */
+LangEEPROM::LangEEPROM() : _language(0) {
+    uint16_t _language = static_cast<uint16_t>(eeprom_get_var(EEVAR_LANGUAGE).ui16);
+    if (_language == static_cast<uint16_t>(0xffff)) {
+        setLanguage(Translations::MakeLangCode("cs"));
+    } else {
+        Translations::Instance().ChangeLanguage(_language);
+    }
+}
+
+/*!
+ * Set new active language by it's code (char[2] -> uint16_t)
+ * Then new code is saved into a EEPROM and Translator is called to start
+ * translating strings
+ */
+void LangEEPROM::setLanguage(uint16_t lang) {
+    _language = lang;
+    saveLanguage();
+
+    Translations::Instance().ChangeLanguage(_language);
+}
+
+/// save new language code into a EEPROM
+void LangEEPROM::saveLanguage() {
+    eeprom_set_var(EEVAR_LANGUAGE, variant8_ui16((uint16_t)_language));
+}
+
+/// return set language code in uint16_t
+uint16_t LangEEPROM::getLanguage() {
+    return _language;
+}
+
+/// return set language code in char[2]
+const char * LangEEPROM::getLanguageChar() {
+    return reinterpret_cast<const char*>(_language);
+}

--- a/src/common/language_eeprom.hpp
+++ b/src/common/language_eeprom.hpp
@@ -1,0 +1,23 @@
+#include <stdint.h>
+#include "eeprom.h"
+
+class LangEEPROM {
+public:
+    inline static LangEEPROM &getInstance() {
+        static LangEEPROM lang_prom;
+        return lang_prom;
+    }
+    LangEEPROM(const LangEEPROM &) = delete;
+    LangEEPROM &operator=(const LangEEPROM &) = delete;
+
+    void setLanguage(uint16_t lang);
+    void saveLanguage();
+    uint16_t getLanguage();
+    const char* getLanguageChar();
+
+private:
+    LangEEPROM();
+    ~LangEEPROM() {};
+
+    uint16_t _language;
+};

--- a/src/gui/screen_menu_languages.cpp
+++ b/src/gui/screen_menu_languages.cpp
@@ -7,6 +7,7 @@
 #include "WindowMenuItems.hpp"
 #include "MItem_print.hpp"
 #include "../lang/translator.hpp"
+#include "language_eeprom.hpp"
 
 class MI_LangBase : public WI_LABEL_t {
 public:
@@ -15,7 +16,7 @@ public:
 
 protected:
     virtual void click(IWindowMenu & /*window_menu*/) override {
-        Translations::Instance().ChangeLanguage(LangCode());
+        LangEEPROM::getInstance().setLanguage(LangCode());
     }
     virtual uint16_t LangCode() const = 0;
 };

--- a/src/gui/screen_splash.cpp
+++ b/src/gui/screen_splash.cpp
@@ -102,6 +102,11 @@ int screen_splash_event(screen_t *screen, window_t *window, uint8_t event, void 
         uint8_t run_xyzcalib = eeprom_get_var(EEVAR_RUN_XYZCALIB).ui8;
         uint8_t run_firstlay = eeprom_get_var(EEVAR_RUN_FIRSTLAY).ui8;
         uint8_t run_wizard = (run_selftest && run_xyzcalib && run_firstlay) ? 1 : 0;
+        // uint8_t run_language = eeprom_get_var(EEVAR_LANGUAGE).ui16 == static_cast<uint16_t>(0xffff) ? 1 : 0;
+        // if (run_language) {
+        //     // screen_stack_push(get_scr_home()->id);
+        //     screen_open(get_scr_menu_languages()->id);
+        // }
         if ((run_wizard || run_firstlay)) {
             if (run_wizard) {
                 screen_stack_push(get_scr_home()->id);


### PR DESCRIPTION
- Updated EEPROM values with new sound Volume & Language
- Added convert function from old EEPROM version to new (4.1.0 -> 4.2.0)
- Added language EEPROM managing singleton class to set, get & store new active language set by user
- Prepared splash screen if language is not set to open the language setting screen (TODO)

BFW-1117