### PR TITLE
Fix Octoprint

### DIFF
--- a/src/gui/screen_printing_serial.cpp
+++ b/src/gui/screen_printing_serial.cpp
@@ -140,8 +140,6 @@ void screen_printing_serial_init(screen_t *screen) {
 }
 
 void screen_printing_serial_done(screen_t *screen) {
-    marlin_gcode("G27 P2"); /// park nozzle and raise Z axis
-    marlin_gcode("M86 S1"); /// enable safety timer
     window_destroy(pw->root.id);
 }
 


### PR DESCRIPTION
Exiting the tune menu, the extruder does not lift and does not go to the park position.