### PR TITLE
Do not jump by default to MINI bootloader start address when debuging.

### DIFF
--- a/utils/cproject/A3ides-Debug.launch
+++ b/utils/cproject/A3ides-Debug.launch
@@ -37,7 +37,7 @@
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value="800ba49"/>
 <intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="61234"/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.runCommands" value=""/>
-<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>


### PR DESCRIPTION
Address is preserved, so one who wants to jump to MINI bootloader can always just enable checkbox.