### PR TITLE
fix menu blinking

### DIFF
--- a/src/gui/screen_menu.cpp
+++ b/src/gui/screen_menu.cpp
@@ -50,4 +50,8 @@ IScreenMenu::IScreenMenu(window_t *parent, string_view_utf8 label, rect_ui16_t r
 void IScreenMenu::windowEvent(window_t *sender, uint8_t event, void *param) {
     header.EventClr();
     window_menu_t::windowEvent(sender, event, param);
+    if ((event == WINDOW_EVENT_ENC_DN) || (event == WINDOW_EVENT_ENC_UP)) { // hack because we want prevent redrawing header/footer to prevent blinking
+        header.Validate();
+        footer.Validate();
+    }
 }

--- a/src/guiapi/include/window_menu.hpp
+++ b/src/guiapi/include/window_menu.hpp
@@ -23,6 +23,7 @@ public:
     IWindowMenuItem *GetActiveItem();
 
 protected:
+    virtual void draw() override;
     virtual void unconditionalDraw() override;
     virtual void windowEvent(window_t *sender, uint8_t event, void *param) override;
 };

--- a/src/guiapi/src/window.cpp
+++ b/src/guiapi/src/window.cpp
@@ -17,8 +17,7 @@ bool window_t::IsDialog() const { return flag_dialog == is_dialog_t::yes; }
 void window_t::Validate(rect_ui16_t validation_rect) {
     //todo check validation_rect intersection
     flag_invalid = false;
-    invalidate(validation_rect);
-    gui_invalidate();
+    validate(validation_rect);
 }
 
 void window_t::Invalidate(rect_ui16_t validation_rect) {

--- a/src/guiapi/src/window_menu.cpp
+++ b/src/guiapi/src/window_menu.cpp
@@ -135,12 +135,26 @@ void window_menu_t::windowEvent(window_t *sender, uint8_t event, void *param) {
         }
         break;
     }
-    if (invalid)
-        Invalidate();
+    //    if (invalid)
+    //        Invalidate();
+}
+
+// overrided window_frame implementation to prevent menu blinking
+void window_menu_t::draw() {
+    if (IsInvalid()) {
+        unconditionalDraw();
+        Validate();
+    }
+    window_t *ptr = first;
+    while (ptr) {
+        ptr->Draw();
+        ptr = ptr->GetNext();
+    }
 }
 
 void window_menu_t::unconditionalDraw() {
-    IWindowMenu::unconditionalDraw();
+    // temporarily disabled erasing background to prevent menu blinking
+    //    IWindowMenu::unconditionalDraw();
 
     const int item_height = font->h + padding.top + padding.bottom;
     rect_ui16_t rc_win = rect;


### PR DESCRIPTION
BFW-1167

hacked window_menu/screen_menu
+fix in window.cpp (validate instead of invalidate)