### PR TITLE
holly: Use single docker image for all stages

### DIFF
--- a/utils/holly/Dockerfile
+++ b/utils/holly/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3.7.6-stretch
-RUN pip install pre-commit ecdsa
+FROM gcc:10
+RUN apt-get clean && \
+    apt-get update -qq -y && \
+    apt-get install curl python3 python3-pip -y
+RUN pip3 install pre-commit ecdsa
 ADD utils/bootstrap.py bootstrap.py
-RUN python bootstrap.py
+RUN gcc --version
+RUN python3 bootstrap.py

--- a/utils/holly/TestDockerfile
+++ b/utils/holly/TestDockerfile
@@ -1,8 +1,0 @@
-FROM gcc:10
-RUN apt-get clean && \
-    apt-get update -qq -y && \
-    apt-get install curl python3 -y
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py
-RUN python3 -m pip install pre-commit ecdsa
-ADD utils/bootstrap.py bootstrap.py
-RUN python3 bootstrap.py

--- a/utils/holly/build-pr.jenkins
+++ b/utils/holly/build-pr.jenkins
@@ -1,6 +1,7 @@
 pipeline {
     agent {
         dockerfile {
+            label 'docker'
             filename 'utils/holly/Dockerfile'
             additionalBuildArgs '-t prusa-firmware-buddy'
         }
@@ -57,7 +58,7 @@ pipeline {
                         stage("Build - ${config.printer},${config.build_type},${config.bootloader}boot") {
                             catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                                 sh """
-                                    python utils/build.py \
+                                    python3 utils/build.py \
                                         --printer ${config.printer} \
                                         --build-type ${config.build_type} \
                                         --bootloader ${config.bootloader} \
@@ -80,7 +81,6 @@ pipeline {
                 expression { env.CHANGE_TARGET }
             }
             steps {
-                sh "pip install pre-commit"
                 sh "pre-commit install"
                 sh """pre-commit run \
                     --source remotes/origin/${env.CHANGE_TARGET} \
@@ -92,13 +92,6 @@ pipeline {
         }
 
         stage('Test') {
-            agent {
-                dockerfile {
-                    reuseNode true
-                    filename 'utils/holly/TestDockerfile'
-                    additionalBuildArgs '-t prusa-firmware-buddy-test'
-                }
-            }
             steps {
                 sh """
                 python3 utils/bootstrap.py


### PR DESCRIPTION
Makes Holly use a single docker image for all stages. Results in faster builds and solves a problem with nested containers on the new build agent.