### PR TITLE
Make the empty translator provider a singleton

### DIFF
--- a/src/lang/translation_provider_empty.hpp
+++ b/src/lang/translation_provider_empty.hpp
@@ -5,7 +5,13 @@
 /// The simplest usable translation provider - only takes the input text
 /// and returns it in a form of string_view_utf8
 class EmptyTranslationProvider : public ITranslationProvider {
+    EmptyTranslationProvider() {}
+
 public:
+    static const EmptyTranslationProvider *Instance() {
+        static const EmptyTranslationProvider i;
+        return &i;
+    }
     virtual string_view_utf8 GetText(const char *src) const {
         return string_view_utf8::MakeCPUFLASH((const uint8_t *)src);
     }

--- a/src/lang/translator.cpp
+++ b/src/lang/translator.cpp
@@ -5,19 +5,15 @@ string_view_utf8 gettext(const char *src) {
     return Translations::Instance().CurrentProvider()->GetText(src);
 }
 
-/// Just to have a meaningfull translation provider if there are no real translations available
-/// ... or at least until there some translations available
-static const EmptyTranslationProvider emptyProvider;
-
 namespace {
 // register the emptyProvider as "translator" for EN language ... i.e. return the source string intact
-ProviderRegistrator prEN("en", &emptyProvider);
+ProviderRegistrator prEN("en", EmptyTranslationProvider::Instance());
 }
 
 // this explicit initialization of currentProvider is here to make sure the pointer is always initialized
 // even if there were no registered languages at all
 Translations::Translations()
-    : currentProvider(&emptyProvider) {
+    : currentProvider(EmptyTranslationProvider::Instance()) {
 }
 
 bool Translations::RegisterProvider(uint16_t langCode, const ITranslationProvider *provider) {


### PR DESCRIPTION
May fix a possible crash upon startup