### PR TITLE
holly: Skip building emptyboot configuration

### DIFF
--- a/utils/holly/build-pr.jenkins
+++ b/utils/holly/build-pr.jenkins
@@ -23,7 +23,6 @@ pipeline {
                     // required configurations
                     def configurations = [
                         [printer: "mini", build_type: "release", bootloader: "no"],
-                        [printer: "mini", build_type: "release", bootloader: "empty"],
                         [printer: "mini", build_type: "release", bootloader: "yes"],
                     ]
 


### PR DESCRIPTION
Currently, building the `emptyboot` configuration is essentially the same, as building the `boot` configuration and there is no benefit in building both of them.