### PR TITLE
Replace simple jogwheel encoder move sound

### DIFF
--- a/src/common/sound.cpp
+++ b/src/common/sound.cpp
@@ -21,6 +21,8 @@ const int Sound::loudRepeats[6] = { 1, 1, -1, 3, -1, 1 };
 const int Sound::silentRepeats[3] = { 1, 1, 1 };
 const int Sound::assistRepeats[8] = { 1, 1, -1, 3, 1, 1, -1, 1 };
 
+/* const bool Sound::forced[8] = { false, false, false, false, false, true, false, false }; */
+
 eSOUND_MODE Sound_GetMode() { return Sound::getInstance().getMode(); }
 int Sound_GetVolume() { return Sound::getInstance().getVolume(); }
 void Sound_SetMode(eSOUND_MODE eSMode) { Sound::getInstance().setMode(eSMode); }
@@ -107,7 +109,7 @@ void Sound::_playSound(eSOUND_TYPE sound, const eSOUND_TYPE types[], const int r
     for (unsigned i = 0; i < size; i++) {
         eSOUND_TYPE type = types[i];
         if (type == sound) {
-            _sound(repeats[i], frequencies[type], durations[type], volumes[type]);
+            _sound(repeats[i], frequencies[type], durations[type], volumes[type] /* , Sound::forced[type] */);
             break;
         }
     }
@@ -140,10 +142,10 @@ void Sound::play(eSOUND_TYPE eSoundType) {
     }
 }
 
-/// Generic [_sound[ method with setting values and repeating logic
-void Sound::_sound(int rep, float frq, uint32_t dur, float vol) {
+/// Generic [_sound] method with setting values and repeating logic
+void Sound::_sound(int rep, float frq, uint32_t dur, float vol /*, bool forced*/) {
     /// if sound is already playing, then don't interrupt
-    if (repeat - 1 > 0 || repeat == -1) {
+    if ((repeat - 1 > 0 || repeat == -1) /*  && !forced */) {
         return;
     }
 

--- a/src/common/sound.hpp
+++ b/src/common/sound.hpp
@@ -47,7 +47,7 @@ private:
     void init();
     void saveMode();
     void saveVolume();
-    void _sound(int rep, float frq, uint32_t dur, float vol);
+    void _sound(int rep, float frq, uint32_t dur, float vol /* , bool forced */);
     void _playSound(eSOUND_TYPE sound, const eSOUND_TYPE types[], const int repeats[], unsigned size);
 
     void nextRepeat();
@@ -78,6 +78,9 @@ private:
     static const int loudRepeats[6];
     static const int silentRepeats[3];
     static const int assistRepeats[8];
+
+    /// forced sound types TODO: posible forced sounds
+    /* static const bool forced[8]; */
 
     eSOUND_MODE eSoundMode;
 };

--- a/src/gui/dialogs/DialogRadioButton.cpp
+++ b/src/gui/dialogs/DialogRadioButton.cpp
@@ -44,6 +44,7 @@ RadioButton &RadioButton::operator++() {
     if ((index + 1) < GetBtnCount()) {
         SetBtnIndex(index + 1);
         Invalidate();
+        Sound_Play(eSOUND_TYPE_EncoderMove);
     } else {
         Sound_Play(eSOUND_TYPE_BlindAlert);
     }
@@ -56,6 +57,7 @@ RadioButton &RadioButton::operator--() {
     if (index > 0) {
         SetBtnIndex(index - 1);
         Invalidate();
+        Sound_Play(eSOUND_TYPE_EncoderMove);
     } else {
         Sound_Play(eSOUND_TYPE_BlindAlert);
     }

--- a/src/gui/window_file_list.cpp
+++ b/src/gui/window_file_list.cpp
@@ -237,6 +237,7 @@ void window_file_list_t::inc(int dif) {
         // here we know exactly, that the selected item changed -> prepare text rolling
         init_text_roll();
         Invalidate();
+        Sound_Play(eSOUND_TYPE_EncoderMove);
     }
 }
 
@@ -256,5 +257,6 @@ void window_file_list_t::dec(int dif) {
     if (repaint) {
         init_text_roll();
         Invalidate();
+        Sound_Play(eSOUND_TYPE_EncoderMove);
     }
 }

--- a/src/guiapi/src/gui.cpp
+++ b/src/guiapi/src/gui.cpp
@@ -82,7 +82,6 @@ void gui_loop(void) {
             } else {
                 capturedWin->WindowEvent(capturedWin, WINDOW_EVENT_ENC_DN, (void *)-diff);
             }
-            Sound_Play(eSOUND_TYPE_EncoderMove);
             gui_reset_menu_timer();
         }
         if (btn != Jogwheel::ButtonAction::BTN_NO_ACTION) {

--- a/src/guiapi/src/window_frame.cpp
+++ b/src/guiapi/src/window_frame.cpp
@@ -137,6 +137,8 @@ void window_frame_t::windowEvent(window_t *sender, uint8_t event, void *param) {
             if (!pPrev) {
                 Sound_Play(eSOUND_TYPE_BlindAlert);
                 break;
+            } else {
+                Sound_Play(eSOUND_TYPE_EncoderMove);
             }
             pWin = pPrev;
         }
@@ -150,6 +152,8 @@ void window_frame_t::windowEvent(window_t *sender, uint8_t event, void *param) {
             if (!pNext) {
                 Sound_Play(eSOUND_TYPE_BlindAlert);
                 break;
+            } else {
+                Sound_Play(eSOUND_TYPE_EncoderMove);
             }
             pWin = pNext;
         }

--- a/src/guiapi/src/window_menu.cpp
+++ b/src/guiapi/src/window_menu.cpp
@@ -105,6 +105,7 @@ void window_menu_t::Increment(int dif) {
         if (new_index != old_index) { // optimization do not redraw when no change - still on end
             SetIndex(new_index);
             Invalidate();
+            Sound_Play(eSOUND_TYPE_EncoderMove);
         }
     }
 }


### PR DESCRIPTION
In final - this is just putting back old sound signals logic, because it will solve issue with sound move depending on GUI and not on jogwheel interupt.

BFW-879