### PR TITLE
Fix BSOD with non-ASCII chars in file names

### DIFF
--- a/src/gui/lazyfilelist.h
+++ b/src/gui/lazyfilelist.h
@@ -218,13 +218,28 @@ private:
             sfn[0] = 0;
             date = time = 0;
         }
+        void ReplaceNonAsciiChars(size_t charsCopied) {
+            for (char *p = lfn; p != lfn + charsCopied; ++p) {
+                if (*p < 32 || *p > 127) {
+                    *p = '*';
+                }
+            }
+        }
         void CopyFrom(const FILINFO &fno) {
-            strlcpy(lfn, fno.fname, sizeof(lfn));
+            size_t charsCopied = strlcpy(lfn, fno.fname, sizeof(lfn));
             if (fno.altname[0] == 0) { // the lfn is identical to sfn
                 strlcpy(sfn, lfn, sizeof(sfn));
             } else {
                 strlcpy(sfn, fno.altname, sizeof(sfn));
             }
+            // Safety precautions - remove all non-ascii characters from the LFN, which are not in range <32-127>
+            // and replace them with a placeholder - in our case a '*'
+            // @@TODO beware: if someone deliberately makes 2 filenames differing only in one non-ascii character,
+            // this may break the whole file sorting - because both filenames will have a '*' at that index,
+            // i.e. the file names will not be unique. In such a case the list of files may be incomplete or work
+            // incorrectly. But remember - we do not support diacritics in filenames AT ALL.
+            ReplaceNonAsciiChars(charsCopied);
+
             isFile = (fno.fattrib & AM_DIR) == 0;
             date = fno.fdate;
             time = fno.ftime;

--- a/src/gui/lazyfilelist.h
+++ b/src/gui/lazyfilelist.h
@@ -13,6 +13,7 @@
 #else
     #define _MAX_LFN          103
     #define FILE_PATH_MAX_LEN 103
+extern "C" size_t strlcpy(char *dst, const char *src, size_t dsize);
 #endif
 
 /// Lazy Dir View

--- a/src/guiapi/include/display.h
+++ b/src/guiapi/include/display.h
@@ -55,6 +55,11 @@ public:
         // convert unichar into font index - all fonts have the same layout, thus this can be computed here
         // ... and also because doing it in C++ is much easier than in plain C
         uint8_t charX = 15, charY = 1;
+
+        if (c < pf->asc_min) { // this really happens with non-utf8 characters on filesystems
+            c = '?';           // substitute with a '?' or any other suitable character, which is in the range of the fonts
+        }
+        // here is intentionally no else
         if (c < 128) {
             // normal ASCII character
             charX = (c - pf->asc_min) % 16;

--- a/tests/unit/gui/lazyfilelist/CMakeLists.txt
+++ b/tests/unit/gui/lazyfilelist/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # define the test executable
-add_executable(lazyfilelist_tests tests.cpp fatfs.cpp)
+add_executable(lazyfilelist_tests tests.cpp fatfs.cpp strlcpy.c)
 
 # define required search paths
 target_include_directories(lazyfilelist_tests PUBLIC . ${CMAKE_SOURCE_DIR}/src/gui)

--- a/tests/unit/gui/lazyfilelist/strlcpy.c
+++ b/tests/unit/gui/lazyfilelist/strlcpy.c
@@ -1,0 +1,48 @@
+/*	$OpenBSD: strlcpy.c,v 1.12 2015/01/15 03:54:12 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+// modified a bit to overcome gcc's standard libc missing the strlcpy function
+// for unit_test purposes
+#include <stddef.h>
+/*
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+size_t strlcpy(char *dst, const char *src, size_t dsize) {
+    const char *osrc = src;
+    size_t nleft = dsize;
+
+    /* Copy as many bytes as will fit. */
+    if (nleft != 0) {
+        while (--nleft != 0) {
+            if ((*dst++ = *src++) == '\0')
+                break;
+        }
+    }
+
+    /* Not enough room in dst, add NUL and traverse rest of src. */
+    if (nleft == 0) {
+        if (dsize != 0)
+            *dst = '\0'; /* NUL-terminate dst */
+        while (*src++)
+            ;
+    }
+
+    return (src - osrc - 1); /* count does not include NUL */
+}

--- a/utils/holly/build-pr.jenkins
+++ b/utils/holly/build-pr.jenkins
@@ -105,7 +105,6 @@ pipeline {
                     -DCMAKE_MAKE_PROGRAM=\$PWD/.dependencies/ninja-1.9.0/ninja \
                     --build-generator Ninja \
                     --build-target tests \
-                    --build-options -DCUSTOM_COMPILE_OPTIONS:STRING=-Dstrlcpy=strncpy \
                     --test-command ctest
                 """
             }


### PR DESCRIPTION
BFW-1236

From now on we even may be able to print the files with filenames containing non-ASCII characters, but please note you shouldn't abuse it, there are still some edge cases, when it may break the list of files. It shall not crash hard anymore though.

Fixes #791