### PR TITLE
Fix EEPROM padding.

### DIFF
--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -13,7 +13,7 @@
 #include "wdt.h"
 #include "../Marlin/src/module/temperature.h"
 
-static const constexpr uint8_t EEPROM__PADDING = 2;
+static const constexpr uint8_t EEPROM__PADDING = 1;
 static const constexpr uint8_t EEPROM_MAX_NAME = 16;               // maximum name length (with '\0')
 static const constexpr uint16_t EEPROM_MAX_DATASIZE = 256;         // maximum datasize
 static const constexpr uint16_t EEPROM_FIRST_VERSION_CRC = 0x0004; // first eeprom version with crc support


### PR DESCRIPTION
As a reviewer you should check, if EEPROM_VERSION = 8 with broken padding didn't make it to some released firmware.