### PR TITLE
Warn when comparing signed and unsigned integral types.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ if(CMAKE_CROSSCOMPILING)
 endif()
 
 # enable all warnings (well, not all, but some)
-add_compile_options(-Wall)
+add_compile_options(-Wall -Wsign-compare)
 
 # support _DEBUG macro (some code uses to recognize debug builds)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/lib/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pcd.c
+++ b/lib/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pcd.c
@@ -1261,7 +1261,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
 {
   USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
   USB_OTG_EPTypeDef *ep;
-  int32_t len = 0U;
+  uint32_t len = 0U;
   uint32_t len32b;
   uint32_t fifoemptymsk = 0U;
 
@@ -1295,7 +1295,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
     ep->xfer_count += len;
   }
 
-  if(len <= 0U)
+  if(ep->xfer_count >= ep->xfer_len)
   {
     fifoemptymsk = 0x1U << epnum;
     USBx_DEVICE->DIEPEMPMSK &= ~fifoemptymsk;

--- a/src/common/hwio_a3ides_2209_02.c
+++ b/src/common/hwio_a3ides_2209_02.c
@@ -322,7 +322,7 @@ void _hwio_pwm_set_val(int i_pwm, int val) //write pwm output
 {
     uint32_t chan = _pwm_get_chan(i_pwm);
     TIM_HandleTypeDef *htim = _pwm_get_htim(i_pwm);
-    if ((chan == -1) || htim->Instance == 0) {
+    if ((chan == (uint32_t)-1) || htim->Instance == 0) {
         return;
     }
 

--- a/src/common/marlin_client.c
+++ b/src/common/marlin_client.c
@@ -453,7 +453,7 @@ variant8_t marlin_set_var(uint8_t var_id, variant8_t val) {
         const int v = marlin_vars_value_to_str(&(client->vars), var_id, request + n, sizeof(request) - n);
         if (v < 0)
             bsod("Error formatting var value.");
-        if ((size_t)v >= (sizeof(request) - (size_t)n))
+        if (((size_t)v + (size_t)n) >= sizeof(request))
             bsod("Request too long.");
         _send_request_to_server(client->id, request);
         _wait_ack_from_server(client->id);

--- a/src/guiapi/src/st7789v.c
+++ b/src/guiapi/src/st7789v.c
@@ -416,7 +416,7 @@ void st7789v_fill_rect_colorFormat565(uint16_t rect_x, uint16_t rect_y, uint16_t
     st7789v_cmd_raset(rect_y, rect_y + rect_h - 1);
     st7789v_cmd_ramwr(0, 0);
 
-    for (int i = 0; i < size / sizeof(st7789v_buff); i++) // writer buffer by buffer
+    for (unsigned int i = 0; i < size / sizeof(st7789v_buff); i++) // writer buffer by buffer
         st7789v_wr(st7789v_buff, sizeof(st7789v_buff));
 
     st7789v_wr(st7789v_buff, size % sizeof(st7789v_buff)); // write the remainder data


### PR DESCRIPTION
Such comparison doesn't obey mathematical rules as signed type is promoted to unsigned according to language rules leading to negative number becoming big positive number.