### PR TITLE
Fix application does not start after power up.

### DIFF
--- a/src/common/diag.cpp
+++ b/src/common/diag.cpp
@@ -25,10 +25,16 @@ void diag_delay(int delay) {
     }
 }
 
+/**
+ * @brief Is fast boot requested?
+ *
+ * Even though it uses GPIO, it can be called before MX_GPIO_Init() as it configures sensitive pin itself.
+ */
 void diag_check_fastboot(void) {
     if (otp_lock_sector0) //not locked
     {
         __HAL_RCC_GPIOC_CLK_ENABLE();
+        fastBoot.configure();
         diag_delay(100000);
         int i;
         for (i = 0; i < 10; i++) {


### PR DESCRIPTION
This problem was experienced after "Refactor hwio (#624) 089b442e16389becfe".

Problem was that diag_check_fastboot() was called before MX_GPIO_Init() so fastBoot pin was not configured when read.