### PR TITLE
holly: Use dependencies from docker image

### DIFF
--- a/utils/holly/build-pr.jenkins
+++ b/utils/holly/build-pr.jenkins
@@ -57,6 +57,7 @@ pipeline {
                         stage("Build - ${config.printer},${config.build_type},${config.bootloader}boot") {
                             catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                                 sh """
+                                    ln -fs /.dependencies
                                     python3 utils/build.py \
                                         --printer ${config.printer} \
                                         --build-type ${config.build_type} \


### PR DESCRIPTION
- makes Holly use cached dependencies within the docker image, instead of downloading them for every build