### PR TITLE
Make Pause, Stop Buttons on Print Screen update State

### DIFF
--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -60,6 +60,7 @@ void screen_printing_data_t::tuneAction() {
     case printing_state_t::PRINTING:
     case printing_state_t::PAUSED:
         Screens::Access()->Open(GetScreenMenuTune);
+        change_print_state();
         break;
     default:
         break;
@@ -73,12 +74,15 @@ void screen_printing_data_t::pauseAction() {
     switch (GetState()) {
     case printing_state_t::PRINTING:
         marlin_print_pause();
+        change_print_state();
         break;
     case printing_state_t::PAUSED:
         marlin_print_resume();
+        change_print_state();
         break;
     case printing_state_t::PRINTED:
         screen_printing_reprint();
+        change_print_state();
         break;
     default:
         break;
@@ -91,6 +95,7 @@ void screen_printing_data_t::stopAction() {
     }
     switch (GetState()) {
     case printing_state_t::PRINTED:
+        change_print_state();
         Screens::Access()->Close();
         return;
     case printing_state_t::PAUSING:

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -60,7 +60,6 @@ void screen_printing_data_t::tuneAction() {
     case printing_state_t::PRINTING:
     case printing_state_t::PAUSED:
         Screens::Access()->Open(GetScreenMenuTune);
-        change_print_state();
         break;
     default:
         break;
@@ -95,7 +94,6 @@ void screen_printing_data_t::stopAction() {
     }
     switch (GetState()) {
     case printing_state_t::PRINTED:
-        change_print_state();
         Screens::Access()->Close();
         return;
     case printing_state_t::PAUSING:


### PR DESCRIPTION
Addresses issue #1052  
https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/1052

Previously, only the stopAction() on the printing screen updated the
state of the GUI (based on the state of the printer given by the
Marlin server. Now, both the Tune and Pause buttons will cause the
printer's state to update.

Signed-off-by: Jeff Glass <glass.jeffrey@gmail.com>