### PR TITLE
Park the head after calibration.

### DIFF
--- a/src/gui/wizard/firstlay.cpp
+++ b/src/gui/wizard/firstlay.cpp
@@ -165,6 +165,7 @@ StateFncData StateFnc_FIRSTLAY_PRINT(StateFncData last_run) {
     marlin_gcode_printf("M104 S%d", temp_nozzle);                          // set displayed temperature
     marlin_gcode_printf("M109 S%d", temp_nozzle);                          // wait for displayed temperature
     marlin_gcode("G26");                                                   //firstlay
+    marlin_gcode("G27 P2");                                                // park nozzle and raise Z axis when done
 
     //todo save to eeprom
     auto ret = last_run.PassToNext();


### PR DESCRIPTION
Move the head higher on Z axis after calibration is done so the plate can be cleaned easily. Fixes #637.