### PR TITLE
GUI: small edits to menu printing

### DIFF
--- a/src/guiapi/include/GuiDefaults.hpp
+++ b/src/guiapi/include/GuiDefaults.hpp
@@ -37,6 +37,7 @@ struct GuiDefaults {
     static constexpr size_t MenuUseFixedUnitWidth = 28; // 0 == calculate in runtime
     static constexpr size_t MenuScrollbarWidth = 2;
     static constexpr size_t MenuItemDelimiterPadding = 6;
+    static constexpr size_t MenuItemDelimeterHeight = 1;
     static constexpr padding_ui8_t MenuPadding = padding_ui8_t({ 6, 6, 6, 6 });
     static constexpr padding_ui8_t MenuPaddingSpecial = padding_ui8_t({ 0, 6, 0, 0 });
 

--- a/src/guiapi/include/IWindowMenuItem.hpp
+++ b/src/guiapi/include/IWindowMenuItem.hpp
@@ -65,6 +65,7 @@ protected:
     virtual void click(IWindowMenu &window_menu) = 0;
 
     void reInitRoll(Rect16 rect);
+    void deInitRoll();
 
 public:
     IWindowMenuItem(string_view_utf8 label, uint16_t id_icon = 0, is_enabled_t enabled = is_enabled_t::yes, is_hidden_t hidden = is_hidden_t::no, expands_t expands = expands_t::no);

--- a/src/guiapi/include/WindowMenuSwitch.hpp
+++ b/src/guiapi/include/WindowMenuSwitch.hpp
@@ -71,10 +71,11 @@ public:
     bool SetIndex(size_t idx);
 
 protected:
-    static Rect16::Width_t calculateExtensionWidth(Items_t items);
-    static Rect16::Width_t calculateExtensionWidth_text(Items_t items);
+    static Rect16::Width_t calculateExtensionWidth(Items_t items, int32_t index);
+    static Rect16::Width_t calculateExtensionWidth_text(Items_t items, int32_t index);
     static Rect16::Width_t calculateExtensionWidth_icon(Items_t items);
 
+    void changeExtentionWidth();
     Rect16 getSwitchRect(Rect16 extension_rect) const;
     Rect16 getLeftBracketRect(Rect16 extension_rect) const;
     Rect16 getRightBracketRect(Rect16 extension_rect) const;

--- a/src/guiapi/src/IWindowMenuItem.cpp
+++ b/src/guiapi/src/IWindowMenuItem.cpp
@@ -102,3 +102,7 @@ void IWindowMenuItem::reInitRoll(Rect16 rect) {
         roll.Init(rect, GetLabel(), GuiDefaults::FontMenuItems, GuiDefaults::MenuPadding, GuiDefaults::MenuAlignment);
     }
 }
+
+void IWindowMenuItem::deInitRoll() {
+    roll.Deinit();
+}

--- a/src/guiapi/src/WindowMenuSwitch.cpp
+++ b/src/guiapi/src/WindowMenuSwitch.cpp
@@ -10,7 +10,7 @@
 /*****************************************************************************/
 //IWiSwitch
 IWiSwitch::IWiSwitch(int32_t index, string_view_utf8 label, uint16_t id_icon, is_enabled_t enabled, is_hidden_t hidden, Items_t items_)
-    : AddSuper<WI_LABEL_t>(label, calculateExtensionWidth(items_), id_icon, enabled, hidden)
+    : AddSuper<WI_LABEL_t>(label, calculateExtensionWidth(items_, index), id_icon, enabled, hidden)
     , index(index)
     , items(items_) {
 }
@@ -26,6 +26,7 @@ void IWiSwitch::click(IWindowMenu & /*window_menu*/) {
     size_t old_index = index;
     Change(0);
     OnChange(old_index);
+    changeExtentionWidth();
 }
 
 bool IWiSwitch::SetIndex(size_t idx) {
@@ -43,19 +44,19 @@ Rect16 IWiSwitch::getSwitchRect(Rect16 extension_rect) const {
     if (!has_brackets)
         return extension_rect;
 
-    extension_rect += Rect16::Left_t(BracketFont->w + Padding.left + Padding.right);
-    extension_rect -= Rect16::Width_t(BracketFont->w * 2 + Padding.left + Padding.right);
+    extension_rect += Rect16::Left_t(BracketFont->w + GuiDefaults::MenuPaddingSpecial.left + GuiDefaults::MenuPaddingSpecial.right);
+    extension_rect -= Rect16::Width_t(BracketFont->w * 2 + GuiDefaults::MenuPaddingSpecial.left + GuiDefaults::MenuPaddingSpecial.right);
     return extension_rect;
 }
 
 Rect16 IWiSwitch::getLeftBracketRect(Rect16 extension_rect) const {
-    extension_rect = Rect16::Width_t(BracketFont->w + Padding.left + Padding.right);
+    extension_rect = Rect16::Width_t(BracketFont->w + GuiDefaults::MenuPaddingSpecial.left + GuiDefaults::MenuPaddingSpecial.right);
     return extension_rect;
 }
 
 Rect16 IWiSwitch::getRightBracketRect(Rect16 extension_rect) const {
-    extension_rect += Rect16::Left_t(extension_rect.Width() - (BracketFont->w + Padding.left + Padding.right));
-    extension_rect = Rect16::Width_t(BracketFont->w * +Padding.left + Padding.right);
+    extension_rect += Rect16::Left_t(extension_rect.Width() - (BracketFont->w + GuiDefaults::MenuPaddingSpecial.left + GuiDefaults::MenuPaddingSpecial.right));
+    extension_rect = Rect16::Width_t(BracketFont->w + GuiDefaults::MenuPaddingSpecial.left + GuiDefaults::MenuPaddingSpecial.right);
     return extension_rect;
 }
 
@@ -81,11 +82,11 @@ void IWiSwitch::printExtension_text(Rect16 extension_rect, color_t color_text, c
         static const uint8_t bf[] = "[";
         static const uint8_t be[] = "]";
         render_text_align(getLeftBracketRect(extension_rect), string_view_utf8::MakeCPUFLASH(bf), BracketFont,
-            color_back, COLOR_SILVER, Padding, GuiDefaults::MenuAlignment);
+            color_back, COLOR_SILVER, GuiDefaults::MenuPaddingSpecial, GuiDefaults::MenuAlignment);
 
         //draw bracket end  TODO: Change font
         render_text_align(getRightBracketRect(extension_rect), string_view_utf8::MakeCPUFLASH(be), BracketFont,
-            color_back, COLOR_SILVER, Padding, GuiDefaults::MenuAlignment);
+            color_back, COLOR_SILVER, GuiDefaults::MenuPaddingSpecial, GuiDefaults::MenuAlignment);
     }
 }
 
@@ -94,10 +95,10 @@ void IWiSwitch::printExtension_icon(Rect16 extension_rect, color_t color_text, c
     render_icon_align(extension_rect, items.icon_resources[index], color_back, RENDER_FLG(ALIGN_CENTER, swap));
 }
 
-Rect16::Width_t IWiSwitch::calculateExtensionWidth(Items_t items) {
+Rect16::Width_t IWiSwitch::calculateExtensionWidth(Items_t items, int32_t idx) {
     switch (items.type) {
     case Items_t::type_t::text:
-        return calculateExtensionWidth_text(items);
+        return calculateExtensionWidth_text(items, idx);
         break;
     case Items_t::type_t::icon:
         return calculateExtensionWidth_icon(items);
@@ -106,14 +107,15 @@ Rect16::Width_t IWiSwitch::calculateExtensionWidth(Items_t items) {
     return 0;
 }
 
-Rect16::Width_t IWiSwitch::calculateExtensionWidth_text(Items_t items) {
-    size_t max_len = 0;
-    for (size_t i = 0; i < items.size; ++i) {
-        size_t len = items.texts[i].computeNumUtf8CharsAndRewind();
-        if (len > max_len)
-            max_len = len;
+void IWiSwitch::changeExtentionWidth() {
+    if (items.type == Items_t::type_t::text) {
+        extension_width = calculateExtensionWidth_text(items, index);
     }
-    size_t ret = GuiDefaults::FontMenuItems->w * max_len + Padding.left + Padding.right + (GuiDefaults::MenuSwitchHasBrackets ? (BracketFont->w + Padding.left + Padding.right) * 2 : 0);
+}
+
+Rect16::Width_t IWiSwitch::calculateExtensionWidth_text(Items_t items, int32_t idx) {
+    size_t len = items.texts[idx].computeNumUtf8CharsAndRewind();
+    size_t ret = GuiDefaults::FontMenuItems->w * len + Padding.left + Padding.right + (GuiDefaults::MenuSwitchHasBrackets ? (BracketFont->w + GuiDefaults::MenuPaddingSpecial.left + GuiDefaults::MenuPaddingSpecial.right) * 2 : 0);
     return ret;
 }
 

--- a/src/guiapi/src/window_menu.cpp
+++ b/src/guiapi/src/window_menu.cpp
@@ -134,8 +134,8 @@ bool window_menu_t::updateTopIndex() {
     if (index == top_index)
         return false;
 
-    const int item_height = GuiDefaults::FontMenuItems->h + GuiDefaults::MenuPadding.top + GuiDefaults::MenuPadding.bottom;
-    const int visible_available = rect.Height() / item_height;
+    const int item_height = GuiDefaults::FontMenuItems->h + GuiDefaults::MenuPadding.top + GuiDefaults::MenuPadding.bottom - GuiDefaults::MenuItemDelimeterHeight;
+    const int visible_available = rect.Height() / (item_height + GuiDefaults::MenuItemDelimeterHeight);
 
     const int visible_index = visibleIndex(index);
 
@@ -207,8 +207,8 @@ void window_menu_t::printItem(const size_t visible_count, IWindowMenuItem *item,
         return;
 
     uint16_t rc_w = rect.Width() - (GuiDefaults::MenuHasScrollbar ? GuiDefaults::MenuScrollbarWidth : 0);
-    Rect16 rc = { rect.Left(), int16_t(rect.Top() + visible_count * item_height),
-        rc_w, uint16_t(item_height - 1) }; // 1 pixel height for menu item delimeter
+    Rect16 rc = { rect.Left(), int16_t(rect.Top() + visible_count * (item_height + GuiDefaults::MenuItemDelimeterHeight)),
+        rc_w, uint16_t(item_height) };
 
     if (rect.Contain(rc)) {
 
@@ -216,8 +216,6 @@ void window_menu_t::printItem(const size_t visible_count, IWindowMenuItem *item,
         item->InitRollIfNeeded(rc);
 
         item->Print(rc);
-        if (GuiDefaults::MenuLinesBetweenItems)
-            display::DrawLine(point_ui16(rc.Left() + GuiDefaults::MenuItemDelimiterPadding, rc.Top() + rc.Height()), point_ui16(rc.Left() + rc.Width() - 2 * GuiDefaults::MenuItemDelimiterPadding, rc.Top() + rc.Height()), COLOR_SILVER);
     }
 }
 
@@ -259,8 +257,8 @@ void window_menu_t::printScrollBar(size_t available_count, uint16_t visible_coun
 }
 
 void window_menu_t::redrawWholeMenu() {
-    const int item_height = GuiDefaults::FontMenuItems->h + GuiDefaults::MenuPadding.top + GuiDefaults::MenuPadding.bottom;
-    const size_t visible_available = rect.Height() / item_height;
+    const int item_height = GuiDefaults::FontMenuItems->h + GuiDefaults::MenuPadding.top + GuiDefaults::MenuPadding.bottom - GuiDefaults::MenuItemDelimeterHeight;
+    const size_t visible_available = rect.Height() / (item_height + GuiDefaults::MenuItemDelimeterHeight);
     size_t visible_count = 0, available_invisible_count = 0;
     IWindowMenuItem *item;
     for (size_t i = 0; i < GetCount(); ++i) {
@@ -277,6 +275,10 @@ void window_menu_t::redrawWholeMenu() {
             available_invisible_count++;
         } else {
             visible_count++;
+            if (GuiDefaults::MenuLinesBetweenItems) {
+                display::DrawLine(point_ui16(rect.Left() + GuiDefaults::MenuItemDelimiterPadding, rect.Top() + visible_count * (item_height + GuiDefaults::MenuItemDelimeterHeight) - 1),
+                    point_ui16(rect.Left() + rect.Width() - 2 * GuiDefaults::MenuItemDelimiterPadding, rect.Top() + visible_count * (item_height + GuiDefaults::MenuItemDelimeterHeight) - 1), COLOR_SILVER);
+            }
         }
     }
 
@@ -287,7 +289,7 @@ void window_menu_t::redrawWholeMenu() {
     }
 
     /// fill the rest of the window by background
-    const int menu_h = visible_count * item_height;
+    const int menu_h = visible_count * (item_height + GuiDefaults::MenuItemDelimeterHeight);
     Rect16 rc_win = rect;
     rc_win -= Rect16::Height_t(menu_h);
     if (rc_win.Height() <= 0)
@@ -297,8 +299,8 @@ void window_menu_t::redrawWholeMenu() {
 }
 
 void window_menu_t::unconditionalDrawItem(uint8_t index) {
-    const int item_height = GuiDefaults::FontMenuItems->h + GuiDefaults::MenuPadding.top + GuiDefaults::MenuPadding.bottom;
-    const size_t visible_available = rect.Height() / item_height;
+    const int item_height = GuiDefaults::FontMenuItems->h + GuiDefaults::MenuPadding.top + GuiDefaults::MenuPadding.bottom - GuiDefaults::MenuItemDelimeterHeight;
+    const size_t visible_available = rect.Height() / (item_height + GuiDefaults::MenuItemDelimeterHeight);
     size_t visible_count = 0;
     IWindowMenuItem *item = nullptr;
     for (size_t i = top_index; visible_count < visible_available && i < GetCount(); ++i) {


### PR DESCRIPTION
- Move printing delimeter outside of printItem() (I subtract delimter_height from item_height and then count with (item_height + delimter_height)
- I erased all left and right paddings from Switch's brackets and from Spin's units (It was not printing well with it)
- Then I add half space padding to extention calculation.
- Switch extention width is calculated in the begining and recalculated with each click