### PR TITLE
Fix translation of load/unload/change filament dlgs

### DIFF
--- a/src/gui/dialogs/DialogStateful.hpp
+++ b/src/gui/dialogs/DialogStateful.hpp
@@ -76,7 +76,7 @@ protected:
     // get arguments callbacks and call them
     virtual void phaseEnter() {
         radio.Change(&states[phase].btn_resp, &states[phase].btn_labels);
-        label.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)states[phase].label));
+        label.SetText(_(states[phase].label));
         if (states[phase].onEnter) {
             states[phase].onEnter();
         }


### PR DESCRIPTION
The state texts were incorrectly referenced directly instead of passing them to the translator engine.