### PR TITLE
Disable exceptions and prevent false-positive of FLASH overflowing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,10 @@ target_link_libraries(Marlin_Config INTERFACE A3idesHeaders FreeRTOS::FreeRTOS)
 # Global Compiler & Linker Configuration
 #
 
+# Disable exceptions and related metadata
+add_compile_options(-fno-exceptions -fno-unwind-tables)
+add_link_options(-Wl,--defsym,__exidx_start=0,--defsym,__exidx_end=0)
+
 # Thread safe newlib
 add_compile_options(-DconfigUSE_NEWLIB_REENTRANT=1)
 

--- a/src/STM32F407VG_FLASH.ld
+++ b/src/STM32F407VG_FLASH.ld
@@ -87,13 +87,6 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
-  .ARM : {
-    __exidx_start = .;
-    *(.ARM.exidx*)
-    __exidx_end = .;
-  } >FLASH
-
   .preinit_array     :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
@@ -202,6 +195,8 @@ SECTIONS
     libc.a ( * )
     libm.a ( * )
     libgcc.a ( * )
+    *(.ARM.exidx*)
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }

--- a/src/STM32F407VG_FLASH.ld
+++ b/src/STM32F407VG_FLASH.ld
@@ -150,7 +150,7 @@ SECTIONS
 
     . = ALIGN(4);
     _eccmram = .;       /* create a global symbol at ccmram end */
-  } >CCMRAM AT> FLASH
+  } >CCMRAM
 
   /* Uninitialized data section */
   . = ALIGN(4);

--- a/src/STM32F407VG_FLASH_boot.ld
+++ b/src/STM32F407VG_FLASH_boot.ld
@@ -87,13 +87,6 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
-  .ARM : {
-    __exidx_start = .;
-    *(.ARM.exidx*)
-    __exidx_end = .;
-  } >FLASH
-
   .preinit_array     :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
@@ -202,6 +195,8 @@ SECTIONS
     libc.a ( * )
     libm.a ( * )
     libgcc.a ( * )
+    *(.ARM.exidx*)
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
   }
 
   .ARM.attributes 0 : { *(.ARM.attributes) }

--- a/src/STM32F407VG_FLASH_boot.ld
+++ b/src/STM32F407VG_FLASH_boot.ld
@@ -150,7 +150,7 @@ SECTIONS
 
     . = ALIGN(4);
     _eccmram = .;       /* create a global symbol at ccmram end */
-  } >CCMRAM AT> FLASH
+  } >CCMRAM
 
   /* Uninitialized data section */
   . = ALIGN(4);


### PR DESCRIPTION
- Disable exceptions (saves around 40 KB)
- Fixes a false-positive linker error `firmware section ".ccmram" will not fit in region "FLASH"` when building a Debug build for a bootloader. 