### PR TITLE
Enable EEPROM upgrading from 4.2.1

### DIFF
--- a/src/common/crc32.c
+++ b/src/common/crc32.c
@@ -63,6 +63,21 @@ static uint32_t crc32_hw(const uint32_t *buffer, uint32_t length, uint32_t crc) 
     return result;
 }
 
+uint32_t crc32_eeprom(const uint32_t *buffer, uint32_t length) {
+    // ensure nobody else uses the peripheral
+    osMutexWait(crc32_hw_mutex_id, osWaitForever);
+    // prepare the CRC unit
+    CRC->CR = CRC_CR_RESET;
+    // calculate the CRC32 value
+    while (length--) {
+        CRC->DR = *((uint32_t *)buffer++);
+    }
+    uint32_t result = CRC->DR;
+    // release the peripheral
+    osMutexRelease(crc32_hw_mutex_id);
+    return result;
+}
+
 static uint32_t crc32_soft(const uint8_t *buffer, uint32_t length, uint32_t crc) {
     uint32_t value = crc ^ 0xFFFFFFFF;
     while (length--) {

--- a/src/common/crc32.h
+++ b/src/common/crc32.h
@@ -9,11 +9,17 @@ extern "C" {
 /// Initialize the CRC peripheral and asociated mutex
 extern void crc32_init(void);
 
-/// Calculate CRC32 for a given buffer
+/// Calculate reverse CRC32 for a given buffer
 extern uint32_t crc32_calc(const uint8_t *data, uint32_t count);
 
-/// Calculate CRC32 for a given buffer with an explicit initial CRC value
+/// Calculate reverse CRC32 for a given buffer with an explicit initial CRC value
 extern uint32_t crc32_calc_ex(uint32_t crc, const uint8_t *data, uint32_t count);
+
+/// Calculate normal CRC32 for EEPROM
+/// Do not use anywhere else than EEPROM - necessary for backwards compatibility
+/// @param data 4-byte aligned data of size divisible by 4
+/// @param count numbed of dwords
+extern uint32_t crc32_eeprom(const uint32_t *data, uint32_t count);
 
 #ifdef __cplusplus
 }

--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -421,6 +421,12 @@ static void eeprom_init_FW_identifiers(eeprom_vars_t &vars) {
     vars.FWVERSION = eeprom_fwversion_ui16();
 }
 
+static void eeprom_make_patches(eeprom_vars_t &vars) {
+    // patch active sheet profile's live-z value
+    // copying the ZOFFSET var directly is safe, it has been in the eeprom at least from v2
+    vars.SHEET_PROFILE0.z_offset = vars.ZOFFSET;
+}
+
 // conversion function for old version 2 format (marlin eeprom)
 static int eeprom_convert_from_v2(void) {
     eeprom_vars_t vars = eeprom_var_defaults;
@@ -439,6 +445,9 @@ static int eeprom_convert_from_v2(void) {
     // check ZOFFSET valid range, cancel conversion if not of valid range (defaults will be loaded)
     if ((vars.ZOFFSET < -2) || (vars.ZOFFSET > 0))
         return 0;
+
+    eeprom_make_patches(vars);
+
     eeprom_save_upgraded(vars);
     return 1;
 }
@@ -456,6 +465,8 @@ static int eeprom_convert_from_v4(void) {
 
     // TODO: keep LAN host name (?)
 
+    eeprom_make_patches(vars);
+
     eeprom_save_upgraded(vars);
     return 1;
 }
@@ -468,6 +479,8 @@ static int eeprom_convert_from_v6(void) {
     // start addres of imported data block (FILAMENT_TYPE..EEVAR_SOUND_MODE)
     eeprom_import_block(EEVAR_FILAMENT_TYPE, EEVAR_SOUND_VOLUME, &(vars.FILAMENT_TYPE));
 
+    eeprom_make_patches(vars);
+
     eeprom_save_upgraded(vars);
     return 1;
 }
@@ -477,13 +490,10 @@ static int eeprom_convert_from_v7(void) {
     eeprom_vars_t vars = eeprom_var_defaults;
     eeprom_init_FW_identifiers(vars);
 
-    float active_z_offset = variant8_get_flt(eeprom_get_var(EEVAR_ZOFFSET));
-
     // start addres of imported data block (FILAMENT_TYPE..EEVAR_LANGUAGE)
     eeprom_import_block(EEVAR_FILAMENT_TYPE, EEVAR_FILE_SORT, &(vars.FILAMENT_TYPE));
 
-    // patch active sheet profile's live-z value
-    vars.SHEET_PROFILE0.z_offset = active_z_offset;
+    eeprom_make_patches(vars);
 
     eeprom_save_upgraded(vars);
     return 1;
@@ -494,13 +504,10 @@ static int eeprom_convert_from_v8(void) {
     eeprom_vars_t vars = eeprom_var_defaults;
     eeprom_init_FW_identifiers(vars);
 
-    float active_z_offset = variant8_get_flt(eeprom_get_var(EEVAR_ZOFFSET));
-
     // start addres of imported data block (FILAMENT_TYPE..EEVAR_SOUND_MODE)
     eeprom_import_block(EEVAR_FILAMENT_TYPE, EEVAR_MENU_TIMEOUT, &(vars.FILAMENT_TYPE));
 
-    // patch active sheet profile's live-z value
-    vars.SHEET_PROFILE0.z_offset = active_z_offset;
+    eeprom_make_patches(vars);
 
     eeprom_save_upgraded(vars);
     return 1;

--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -259,7 +259,7 @@ void eeprom_defaults(void) {
     vars.FWVERSION = eeprom_fwversion_ui16();
     eeprom_lock();
     // calculate crc32
-    vars.CRC32 = crc32_calc((uint8_t *)(&vars), EEPROM_DATASIZE - 4);
+    vars.CRC32 = crc32_eeprom((uint32_t *)(&vars), (EEPROM_DATASIZE - 4) / 4);
     // write data to eeprom
     st25dv64k_user_write_bytes(EEPROM_ADDRESS, (void *)&vars, EEPROM_DATASIZE);
     eeprom_unlock();
@@ -399,11 +399,32 @@ static const constexpr uint16_t ADDR_V2_ZOFFSET = 0x010e;
 static const constexpr uint16_t ADDR_V2_PID_NOZ_P = 0x019d;
 static const constexpr uint16_t ADDR_V2_PID_BED_P = 0x01af;
 
+static void eeprom_save_upgraded(eeprom_vars_t &vars) {
+    // calculate crc32
+    vars.CRC32 = crc32_eeprom((uint32_t *)(&vars), (EEPROM_DATASIZE - 4) / 4);
+    // write data to eeprom
+    st25dv64k_user_write_bytes(EEPROM_ADDRESS, (void *)&vars, EEPROM_DATASIZE);
+}
+
+static void eeprom_import_block(uint8_t begin, uint8_t end, void *dst) {
+    // start addres of imported data block
+    uint16_t addr_start = eeprom_var_addr(begin);
+    // end addres of imported data - end means the next first eeprom var we do NOT want to copy
+    uint16_t addr_end = eeprom_var_addr(end);
+    // read first block
+    st25dv64k_user_read_bytes(addr_start, dst, addr_end - addr_start);
+}
+
+static void eeprom_init_FW_identifiers(eeprom_vars_t &vars) {
+    // these variables are intentionally not initialised in eeprom_var_defaults
+    vars.FWBUILD = project_build_number;
+    vars.FWVERSION = eeprom_fwversion_ui16();
+}
+
 // conversion function for old version 2 format (marlin eeprom)
 static int eeprom_convert_from_v2(void) {
     eeprom_vars_t vars = eeprom_var_defaults;
-    vars.FWBUILD = project_build_number;
-    vars.FWVERSION = eeprom_fwversion_ui16();
+    eeprom_init_FW_identifiers(vars);
     // read FILAMENT_TYPE (uint8_t)
     st25dv64k_user_read_bytes(ADDR_V2_FILAMENT_TYPE, &(vars.FILAMENT_TYPE), sizeof(uint8_t));
     // initialize to zero, maybe not necessary
@@ -418,94 +439,70 @@ static int eeprom_convert_from_v2(void) {
     // check ZOFFSET valid range, cancel conversion if not of valid range (defaults will be loaded)
     if ((vars.ZOFFSET < -2) || (vars.ZOFFSET > 0))
         return 0;
-    // calculate crc32
-    vars.CRC32 = crc32_calc((uint8_t *)(&vars), EEPROM_DATASIZE - 4);
-    // write data to eeprom
-    st25dv64k_user_write_bytes(EEPROM_ADDRESS, (void *)&vars, EEPROM_DATASIZE);
+    eeprom_save_upgraded(vars);
     return 1;
 }
 
 // conversion function for old version 4 (v 4.0.5)
 static int eeprom_convert_from_v4(void) {
-    uint16_t addr_start;
-    uint16_t addr_end;
     eeprom_vars_t vars = eeprom_var_defaults;
-
-    // these variables not initialised in eeprom_var_defaults
-    vars.FWBUILD = project_build_number;
-    vars.FWVERSION = eeprom_fwversion_ui16();
+    eeprom_init_FW_identifiers(vars);
 
     // start addres of imported data first block (FILAMENT_TYPE..EEVAR_ZOFFSET)
-    addr_start = eeprom_var_addr(EEVAR_FILAMENT_TYPE);
-    // end addres of imported data - we want not import PID constants
-    addr_end = eeprom_var_addr(EEVAR_PID_NOZ_P);
-    // read first block
-    st25dv64k_user_read_bytes(addr_start, &(vars.FILAMENT_TYPE), addr_end - addr_start);
+    eeprom_import_block(EEVAR_FILAMENT_TYPE, EEVAR_PID_NOZ_P, &(vars.FILAMENT_TYPE));
 
     // start addres of imported data second block (EEVAR_LAN_FLAG..EEVAR_LAN_IP4_DNS2)
-    addr_start = eeprom_var_addr(EEVAR_LAN_FLAG);
-    // end addres of imported data - we want not import PID constants
-    addr_end = eeprom_var_addr(EEVAR_LAN_HOSTNAME);
-    // read first block
-    st25dv64k_user_read_bytes(addr_start, &(vars.LAN_FLAG), addr_end - addr_start);
+    eeprom_import_block(EEVAR_LAN_FLAG, EEVAR_LAN_HOSTNAME, &(vars.LAN_FLAG));
 
     // TODO: keep LAN host name (?)
 
-    // calculate crc32
-    vars.CRC32 = crc32_calc((uint8_t *)(&vars), EEPROM_DATASIZE - 4);
-    // write data to eeprom
-    st25dv64k_user_write_bytes(EEPROM_ADDRESS, (void *)&vars, EEPROM_DATASIZE);
-
+    eeprom_save_upgraded(vars);
     return 1;
 }
 
 // conversion function for old version 6 (v 4.1.0)
 static int eeprom_convert_from_v6(void) {
-    uint16_t addr_start;
-    uint16_t addr_end;
     eeprom_vars_t vars = eeprom_var_defaults;
-
-    // these variables not initialised in eeprom_var_defaults
-    vars.FWBUILD = project_build_number;
-    vars.FWVERSION = eeprom_fwversion_ui16();
+    eeprom_init_FW_identifiers(vars);
 
     // start addres of imported data block (FILAMENT_TYPE..EEVAR_SOUND_MODE)
-    addr_start = eeprom_var_addr(EEVAR_FILAMENT_TYPE);
-    // end addres of imported data
-    addr_end = eeprom_var_addr(EEVAR_SOUND_VOLUME);
-    // read first block
-    st25dv64k_user_read_bytes(addr_start, &(vars.FILAMENT_TYPE), addr_end - addr_start);
+    eeprom_import_block(EEVAR_FILAMENT_TYPE, EEVAR_SOUND_VOLUME, &(vars.FILAMENT_TYPE));
 
-    // calculate crc32
-    vars.CRC32 = crc32_calc((uint8_t *)(&vars), EEPROM_DATASIZE - 4);
-    // write data to eeprom
-    st25dv64k_user_write_bytes(EEPROM_ADDRESS, (void *)&vars, EEPROM_DATASIZE);
+    eeprom_save_upgraded(vars);
+    return 1;
+}
 
+// conversion function for old version 8 (v 4.2.x)
+static int eeprom_convert_from_v7(void) {
+    eeprom_vars_t vars = eeprom_var_defaults;
+    eeprom_init_FW_identifiers(vars);
+
+    float active_z_offset = variant8_get_flt(eeprom_get_var(EEVAR_ZOFFSET));
+
+    // start addres of imported data block (FILAMENT_TYPE..EEVAR_LANGUAGE)
+    eeprom_import_block(EEVAR_FILAMENT_TYPE, EEVAR_FILE_SORT, &(vars.FILAMENT_TYPE));
+
+    // patch active sheet profile's live-z value
+    vars.SHEET_PROFILE0.z_offset = active_z_offset;
+
+    eeprom_save_upgraded(vars);
     return 1;
 }
 
 // conversion function for old version 8 (v 4.3.RC)
 static int eeprom_convert_from_v8(void) {
-    uint16_t addr_start;
-    uint16_t addr_end;
     eeprom_vars_t vars = eeprom_var_defaults;
+    eeprom_init_FW_identifiers(vars);
+
     float active_z_offset = variant8_get_flt(eeprom_get_var(EEVAR_ZOFFSET));
-    // these variables not initialised in eeprom_var_defaults
-    vars.FWBUILD = project_build_number;
-    vars.FWVERSION = eeprom_fwversion_ui16();
 
     // start addres of imported data block (FILAMENT_TYPE..EEVAR_SOUND_MODE)
-    addr_start = eeprom_var_addr(EEVAR_FILAMENT_TYPE);
-    // end addres of imported data
-    addr_end = eeprom_var_addr(EEVAR_MENU_TIMEOUT);
-    // read first block
-    st25dv64k_user_read_bytes(addr_start, &(vars.FILAMENT_TYPE), addr_end - addr_start);
-    vars.SHEET_PROFILE0.z_offset = active_z_offset;
-    // calculate crc32
-    vars.CRC32 = crc32_calc((uint8_t *)(&vars), EEPROM_DATASIZE - 4);
-    // write data to eeprom
-    st25dv64k_user_write_bytes(EEPROM_ADDRESS, (void *)&vars, EEPROM_DATASIZE);
+    eeprom_import_block(EEVAR_FILAMENT_TYPE, EEVAR_MENU_TIMEOUT, &(vars.FILAMENT_TYPE));
 
+    // patch active sheet profile's live-z value
+    vars.SHEET_PROFILE0.z_offset = active_z_offset;
+
+    eeprom_save_upgraded(vars);
     return 1;
 }
 
@@ -517,6 +514,8 @@ static int eeprom_convert_from(uint16_t version, uint16_t features) {
         return eeprom_convert_from_v4();
     if (version == 6)
         return eeprom_convert_from_v6();
+    if (version == 7)
+        return eeprom_convert_from_v7();
     if (version == 8)
         return eeprom_convert_from_v8();
     return 0;
@@ -534,7 +533,7 @@ static int eeprom_check_crc32(void) {
     uint8_t data[EEPROM_MAX_DATASIZE];
     uint32_t crc2;
     st25dv64k_user_read_bytes(EEPROM_ADDRESS, data, datasize);
-    crc2 = crc32_calc((uint8_t *)data, datasize - 4);
+    crc2 = crc32_eeprom((uint32_t *)data, (datasize - 4) / 4);
     return (crc == crc2) ? 1 : 0;
 #else //
 #endif
@@ -549,7 +548,7 @@ static void eeprom_update_crc32() {
     // read eeprom data
     st25dv64k_user_read_bytes(EEPROM_ADDRESS, (void *)&vars, EEPROM_DATASIZE);
     // calculate crc32
-    vars.CRC32 = crc32_calc((uint8_t *)(&vars), EEPROM_DATASIZE - 4);
+    vars.CRC32 = crc32_eeprom((uint32_t *)(&vars), (EEPROM_DATASIZE - 4) / 4);
     // write crc to eeprom
     st25dv64k_user_write_bytes(EEPROM_ADDRESS + EEPROM_DATASIZE - 4, &(vars.CRC32), 4);
 #else //


### PR DESCRIPTION
The main trouble arose with the change of implementation of the CRC32 algorithm recently.
The new impl. uses the reverse CRC32, while the EEPROM checks used the normal CRC32.
This legacy behavior must be kept for backwards compatibility, thus there are now
both algorithms (both HW accelerated).

Kudos to @dragomirecky for help with the CRC32 HW chip.

Two issues remain to be solved/explained:
- `float active_z_offset = variant8_get_flt(eeprom_get_var(EEVAR_ZOFFSET));` will probably work, but is not entirely correct (the live-z value gets read when the eeprom block gets copied)
- EEPROM v8 probably never made it into the public, it is some pre-4.3-RC1 variant

BFW-1541