### PR TITLE
Reset dump in XFLASH when FW upgraded or EEPROM reset

### DIFF
--- a/src/common/appmain.cpp
+++ b/src/common/appmain.cpp
@@ -31,6 +31,7 @@
 #include "safe_state.h"
 #include "crc32.h"
 #include "ff.h"
+#include "dump.h"
 
 #include <Arduino.h>
 #include "trinamic.h"
@@ -98,7 +99,11 @@ void app_run(void) {
 
     crc32_init();
 
-    uint8_t defaults_loaded = eeprom_init();
+    uint8_t eeprom_init_status = eeprom_init();
+    if (eeprom_init_status == EEPROM_INIT_Defaults || eeprom_init_status == EEPROM_INIT_Upgraded) {
+        // this means we are either starting from defaults or after a FW upgrade -> invalidate the XFLASH dump, since it is not relevant anymore
+        dump_in_xflash_reset();
+    }
     LangEEPROM::getInstance();
 
     marlin_server_init();
@@ -128,7 +133,7 @@ void app_run(void) {
     }
     //DBG("after setup (%ld ms)", HAL_GetTick());
 
-    if (defaults_loaded && marlin_server_processing()) {
+    if (eeprom_init_status == EEPROM_INIT_Defaults && marlin_server_processing()) {
         settings.reset();
     }
 

--- a/src/common/dump.c
+++ b/src/common/dump.c
@@ -97,6 +97,18 @@ void dump_in_xflash_set_displayed(void) {
     dump_in_xflash_clear_flag(DUMP_NOT_DISPL);
 }
 
+void dump_in_xflash_reset(void) {
+    if (w25x_init()) {
+        for (uint32_t addr = 0; addr < DUMP_XFLASH_SIZE; addr += 0x10000) {
+            w25x_wait_busy();
+            w25x_enable_wr();
+            w25x_block64_erase(DUMP_OFFSET + addr);
+        }
+        w25x_wait_busy();
+        w25x_disable_wr();
+    }
+}
+
 unsigned int dump_in_xflash_read_RAM(void *pRAM, unsigned int addr, unsigned int size) {
     if ((addr >= DUMP_RAM_ADDR) && (addr < (DUMP_RAM_ADDR + DUMP_RAM_SIZE))) {
         if (size > (DUMP_RAM_ADDR + DUMP_RAM_SIZE - addr))

--- a/src/common/dump.h
+++ b/src/common/dump.h
@@ -164,6 +164,8 @@ extern unsigned short dump_in_xflash_get_code(void);
 
 extern void dump_in_xflash_set_displayed(void);
 
+extern void dump_in_xflash_reset(void);
+
 extern unsigned int dump_in_xflash_read_RAM(void *pRAM, unsigned int addr, unsigned int size);
 
 extern unsigned int dump_in_xflash_read_regs_SCB(void *pRegsSCB, unsigned int size);

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -108,11 +108,20 @@ typedef union _SelftestResultEEprom_t {
     uint32_t ui32;
 } SelftestResultEEprom_t;
 
+enum {
+    EEPROM_INIT_Normal = 0,
+    EEPROM_INIT_Defaults = 1,
+    EEPROM_INIT_Upgraded = 2
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif //__cplusplus
 
-// initialize eeprom, return values:  1 - defaults loaded, 0 - normal init (eeprom data valid)
+/// initialize eeprom
+/// @returns 0 - normal init (eeprom data valid)
+///          1 - defaults loaded
+///          2 - eeprom upgraded successfully from a previous version
 extern uint8_t eeprom_init(void);
 
 // write default values to all variables


### PR DESCRIPTION
In rare scenarios, the XFLASH dump could remain "unprocessed".
That would lead to not displaying a red error screen after printer reset.
All the safety features were working fine, but the user wouldn't get notified about the error that caused the reset.
This should be fixed with this PR - whenever there is a FW upgrade or the machine loads defaults into the EEPROM (usually CRC mismatch or similar problems), the XFLASH dump gets erased completely as well - since it becomes obsolete anyway.