### PR TITLE
Rename "Anonymized QR" to "Device hash in QR"

### DIFF
--- a/src/common/bsod.cpp
+++ b/src/common/bsod.cpp
@@ -275,8 +275,8 @@ void draw_error_screen(const uint16_t error_code_short) {
         char qr_text[MAX_LEN_4QR + 1];
 
         /// switch for sending UID of printer or not
-        bool qr_privacy = variant_get_ui8(eeprom_get_var(EEVAR_QR_PRIVACY));
-        if (!qr_privacy) {
+        bool devhash_in_qr = variant_get_ui8(eeprom_get_var(EEVAR_DEVHASH_IN_QR));
+        if (devhash_in_qr) {
             error_url_long(qr_text, sizeof(qr_text), error_code);
         } else {
             error_url_short(qr_text, sizeof(qr_text), error_code);

--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -90,7 +90,7 @@ typedef struct _eeprom_vars_t {
     Sheet SHEET_PROFILE6;
     Sheet SHEET_PROFILE7;
     uint32_t SELFTEST_RESULT;
-    uint8_t QR_PRIVACY;
+    uint8_t DEVHASH_IN_QR;
     char _PADDING[EEPROM__PADDING];
     uint32_t CRC32;
 } eeprom_vars_t;
@@ -143,7 +143,7 @@ static const eeprom_entry_t eeprom_map[] = {
     { "SHEET_PROFILE6",  VARIANT8_PUI8,  sizeof(Sheet), 0 },
     { "SHEET_PROFILE7",  VARIANT8_PUI8,  sizeof(Sheet), 0 },
     { "SELFTEST_RESULT", VARIANT8_UI32,  1, 0 }, // EEVAR_SELFTEST_RESULT
-    { "QR_PRIVACY",      VARIANT8_UI8,   1, 0 }, // EEVAR_QR_PRIVACY
+    { "DEVHASH_IN_QR",   VARIANT8_UI8,   1, 0 }, // EEVAR_DEVHASH_IN_QR
     { "_PADDING",        VARIANT8_PCHAR, EEPROM__PADDING, 0 }, // EEVAR__PADDING32
     { "CRC32",           VARIANT8_UI32,  1, 0 }, // EEVAR_CRC32
 };
@@ -197,8 +197,8 @@ static const eeprom_vars_t eeprom_var_defaults = {
     {"Custom2", FLT_MAX },
     {"Custom3", FLT_MAX },
     {"Custom4", FLT_MAX },
-	  0,               // EEVAR_SELFTEST_RESULT
-    1,               // EEVAR_QR_PRIVACY
+    0,               // EEVAR_SELFTEST_RESULT
+    1,               // EEVAR_DEVHASH_IN_QR
     "",              // EEVAR__PADDING
     0xffffffff,      // EEVAR_CRC32
 };

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -77,7 +77,7 @@ enum {
     EEVAR_SHEET_PROFILE6 = 0x26,
     EEVAR_SHEET_PROFILE7 = 0x27,
     EEVAR_SELFTEST_RESULT = 0x28, // uint32_t, two bits for each selftest part
-    EEVAR_QR_PRIVACY = 0x29,      // uint8_t on / off sending UID in QR
+    EEVAR_DEVHASH_IN_QR = 0x29,   // uint8_t on / off sending UID in QR
     EEVAR__PADDING = 0x2a,        // 1..4 chars, to ensure (DATASIZE % 4 == 0)
     EEVAR_CRC32 = 0x2b,           // uint32_t crc32 for
 };

--- a/src/gui/screen_menu_settings.cpp
+++ b/src/gui/screen_menu_settings.cpp
@@ -73,7 +73,7 @@ using Screen = ScreenMenu<EHeader::Off, EFooter::On, HelpLines_None, MI_RETURN, 
     MI_TIMEZONE,
     #endif // BUDDY_ENABLE_ETHERNET
     MI_SAVE_DUMP, MI_SOUND_MODE, MI_SOUND_VOLUME,
-    MI_QR_PRIVACY, MI_LANGUAGE, MI_SORT_FILES,
+    MI_DEVHASH_IN_QR, MI_LANGUAGE, MI_SORT_FILES,
     MI_SOUND_TYPE, MI_HF_TEST_0, MI_HF_TEST_1,
     MI_EEPROM>;
 #else
@@ -83,7 +83,7 @@ using Screen = ScreenMenu<EHeader::Off, EFooter::On, HelpLines_None, MI_RETURN, 
     MI_LAN_SETTINGS,
     MI_TIMEZONE,
     #endif //BUDDY_ENABLE_ETHERNET
-    MI_SAVE_DUMP, MI_SOUND_MODE, MI_SOUND_VOLUME, MI_QR_PRIVACY, MI_LANGUAGE>;
+    MI_SAVE_DUMP, MI_SOUND_MODE, MI_SOUND_VOLUME, MI_DEVHASH_IN_QR, MI_LANGUAGE>;
 #endif
 
 class ScreenMenuSettings : public Screen {

--- a/src/guiapi/include/MItem_menus.hpp
+++ b/src/guiapi/include/MItem_menus.hpp
@@ -188,10 +188,10 @@ protected:
     virtual void click(IWindowMenu &window_menu) override;
 };
 
-class MI_QR_PRIVACY : public WI_SWITCH_OFF_ON_t {
+class MI_DEVHASH_IN_QR : public WI_SWITCH_OFF_ON_t {
     constexpr static const char *const label = N_("Device hash in QR");
 
 public:
-    MI_QR_PRIVACY();
+    MI_DEVHASH_IN_QR();
     virtual void OnChange(size_t old_index) override;
 };

--- a/src/guiapi/include/MItem_menus.hpp
+++ b/src/guiapi/include/MItem_menus.hpp
@@ -189,7 +189,7 @@ protected:
 };
 
 class MI_QR_PRIVACY : public WI_SWITCH_OFF_ON_t {
-    constexpr static const char *const label = N_("Anonymized QR");
+    constexpr static const char *const label = N_("Device hash in QR");
 
 public:
     MI_QR_PRIVACY();

--- a/src/guiapi/src/MItem_menus.cpp
+++ b/src/guiapi/src/MItem_menus.cpp
@@ -187,15 +187,15 @@ void MI_EEPROM::click(IWindowMenu & /*window_menu*/) {
 }
 
 /*****************************************************************************/
-//MI_QR_PRIVACY
-MI_QR_PRIVACY::MI_QR_PRIVACY()
-    : WI_SWITCH_OFF_ON_t(variant_get_ui8(eeprom_get_var(EEVAR_QR_PRIVACY)), _(label), 0, is_enabled_t::yes, is_hidden_t::no) {}
-void MI_QR_PRIVACY::OnChange(size_t old_index) {
+//MI_DEVHASH_IN_QR
+MI_DEVHASH_IN_QR::MI_DEVHASH_IN_QR()
+    : WI_SWITCH_OFF_ON_t(variant_get_ui8(eeprom_get_var(EEVAR_DEVHASH_IN_QR)), _(label), 0, is_enabled_t::yes, is_hidden_t::no) {}
+void MI_DEVHASH_IN_QR::OnChange(size_t old_index) {
     if (!old_index) {
         /// enable
-        eeprom_set_var(EEVAR_QR_PRIVACY, variant8_ui8(1));
+        eeprom_set_var(EEVAR_DEVHASH_IN_QR, variant8_ui8(1));
     } else {
         /// disable
-        eeprom_set_var(EEVAR_QR_PRIVACY, variant8_ui8(0));
+        eeprom_set_var(EEVAR_DEVHASH_IN_QR, variant8_ui8(0));
     }
 }

--- a/src/lang/po/Prusa-Firmware-Buddy.pot
+++ b/src/lang/po/Prusa-Firmware-Buddy.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Prusa-Firmware-Buddy 4.1\n"
 "Report-Msgid-Bugs-To: info@prusa3d.com\n"
-"POT-Creation-Date: 2020-11-26 13:46+0100\n"
+"POT-Creation-Date: 2020-11-30 18:06+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,10 +50,6 @@ msgstr ""
 
 #: src/gui/screen_menu_fw_update.cpp:30
 msgid "Always"
-msgstr ""
-
-#: src/guiapi/include/MItem_menus.hpp:192
-msgid "Anonymized QR"
 msgstr ""
 
 #: src/gui/screen_printing.cpp:103
@@ -119,7 +115,7 @@ msgstr ""
 msgid "Calibration successful! Happy printing!"
 msgstr ""
 
-#: src/guiapi/include/MItem_tools.hpp:249 src/gui/screen_menu_filament.cpp:89
+#: src/gui/screen_menu_filament.cpp:89 src/guiapi/include/MItem_tools.hpp:249
 msgid "Change Filament"
 msgstr ""
 
@@ -163,7 +159,7 @@ msgstr ""
 msgid "Congratulations! XYZ calibration is ok. XY axes are perpendicular."
 msgstr ""
 
-#: src/gui/screen_menu_temperature.cpp:12 src/common/filament.cpp:13
+#: src/common/filament.cpp:13 src/gui/screen_menu_temperature.cpp:12
 msgid "Cooldown"
 msgstr ""
 
@@ -178,6 +174,10 @@ msgstr ""
 #. Continue
 #: src/gui/dialogs/dialog_response.cpp:15
 msgid "DISABLE SENSOR"
+msgstr ""
+
+#: src/guiapi/include/MItem_menus.hpp:192
+msgid "Device hash in QR"
 msgstr ""
 
 #: src/guiapi/include/MItem_tools.hpp:119
@@ -204,7 +204,7 @@ msgid ""
 "Click NO to use the default value (recommended)"
 msgstr ""
 
-#: src/gui/screen_sysinf.cpp:86 src/gui/test/screen_mesh_bed_lv.cpp:62
+#: src/gui/test/screen_mesh_bed_lv.cpp:62 src/gui/screen_sysinf.cpp:86
 msgid "EXIT"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgstr ""
 msgid "FW UPDATE"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:119 src/gui/screen_menu_fw_update.cpp:17
+#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:119
 msgid "FW Update"
 msgstr ""
 
@@ -268,11 +268,11 @@ msgstr ""
 msgid "Fan1 RPM"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:29 src/gui/screen_home.cpp:35
+#: src/gui/screen_home.cpp:35 src/guiapi/include/MItem_menus.hpp:29
 msgid "Filament"
 msgstr ""
 
-#: src/guiapi/include/MItem_tools.hpp:354 src/gui/screen_menu_settings.cpp:25
+#: src/gui/screen_menu_settings.cpp:25 src/guiapi/include/MItem_tools.hpp:354
 msgid "Filament Sensor"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 
 #. ***************************************************************************
 #. clang-format off
-#: src/gui/dialogs/DialogLoadUnload.cpp:14 src/gui/dialogs/DialogG162.cpp:8
+#: src/gui/dialogs/DialogG162.cpp:8 src/gui/dialogs/DialogLoadUnload.cpp:14
 msgid "Finishing buffered gcodes."
 msgstr ""
 
@@ -299,8 +299,8 @@ msgstr ""
 msgid "Firmware Version\n"
 msgstr ""
 
-#: src/guiapi/include/MItem_tools.hpp:59
 #: src/gui/screen_menu_steel_sheets.cpp:46 src/gui/ScreenFirstLayer.hpp:12
+#: src/guiapi/include/MItem_tools.hpp:59
 msgid "First Layer Calibration"
 msgstr ""
 
@@ -321,12 +321,12 @@ msgstr ""
 msgid "HOME TO MAX"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:159 src/gui/screen_menu_hw_setup.cpp:32
+#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:159
 msgid "HW Setup"
 msgstr ""
 
-#: src/guiapi/include/MItem_print.hpp:16
 #: src/gui/dialogs/DialogSelftestTemp.cpp:24
+#: src/guiapi/include/MItem_print.hpp:16
 msgid "Heatbed"
 msgstr ""
 
@@ -354,7 +354,7 @@ msgstr ""
 
 #. special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
 #. and will get a nice house-like icon
-#: src/gui/screen_printing.cpp:45 src/gui/window_file_list.cpp:104
+#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:45
 msgid "Home"
 msgstr ""
 
@@ -589,8 +589,8 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: src/guiapi/include/WindowMenuItems.hpp:19
 #: src/gui/screen_menu_fw_update.cpp:28
+#: src/guiapi/include/WindowMenuItems.hpp:19
 msgid "Off"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "PREHEAT for UNLOAD"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:360 src/gui/screen_printing.hpp:46
+#: src/gui/screen_printing.hpp:46 src/gui/screen_printing.cpp:360
 msgid "PRINTING"
 msgstr ""
 
@@ -645,11 +645,11 @@ msgstr ""
 msgid "PURGE MORE"
 msgstr ""
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:15 src/gui/dialogs/DialogG162.cpp:9
+#: src/gui/dialogs/DialogG162.cpp:9 src/gui/dialogs/DialogLoadUnload.cpp:15
 msgid "Parking"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:38 src/gui/ScreenPrintingModel.hpp:16
+#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:38
 msgid "Pause"
 msgstr ""
 
@@ -718,8 +718,8 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: src/guiapi/include/MItem_print.hpp:24
 #: src/gui/dialogs/DialogSelftestFans.cpp:15
+#: src/guiapi/include/MItem_print.hpp:24
 msgid "Print Fan"
 msgstr ""
 
@@ -762,7 +762,7 @@ msgstr ""
 msgid "RENAME"
 msgstr ""
 
-#: src/gui/guimain.cpp:207 src/common/MindaRedscreen.cpp:175
+#: src/common/MindaRedscreen.cpp:175 src/gui/guimain.cpp:207
 msgid "RESET PRINTER"
 msgstr ""
 
@@ -929,11 +929,11 @@ msgstr ""
 msgid "Statistic"
 msgstr ""
 
-#: src/gui/screen_menu_hw_setup.cpp:16 src/gui/screen_menu_steel_sheets.cpp:176
+#: src/gui/screen_menu_steel_sheets.cpp:176 src/gui/screen_menu_hw_setup.cpp:16
 msgid "Steel Sheets"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:40 src/gui/ScreenPrintingModel.hpp:17
+#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:40
 msgid "Stop"
 msgstr ""
 
@@ -1066,7 +1066,7 @@ msgstr ""
 msgid "Tue"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:37 src/gui/ScreenPrintingModel.hpp:15
+#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:37
 msgid "Tune"
 msgstr ""
 


### PR DESCRIPTION
Naming the menu item as agreed with the Content team recently.

Please note - I kept the EEPROM value, but only inverted its meaning:
- 1 means include the device hash in QR code
- 0 means do not include the hash

The condition in bsod.cpp was inverted as well to reflect this...