### PR TITLE
Restoring Print Speed

### DIFF
--- a/lib/Marlin/Marlin/src/module/motion.cpp
+++ b/lib/Marlin/Marlin/src/module/motion.cpp
@@ -483,8 +483,10 @@ void remember_feedrate_scaling_off() {
   feedrate_percentage = 100;
 }
 void restore_feedrate_and_scaling() {
-  feedrate_mm_s = saved_feedrate_mm_s;
-  feedrate_percentage = saved_feedrate_percentage;
+  if (feedrate_percentage == 100) {
+    feedrate_mm_s = saved_feedrate_mm_s;
+    feedrate_percentage = saved_feedrate_percentage;
+  }
 }
 
 #if HAS_SOFTWARE_ENDSTOPS


### PR DESCRIPTION
BFW-1193
Motivation:
When printing starts executing G28 and G30 it saves and sets its own feedrate_percentage (100%). When user overwrites those settings during executing, at the end, old saved values will be restored. (This discards user defined feedrate value)

Solution:
The settings from before will be set back only if feedrate_percentage(100%) was not changed during G28/G30. Otherwise it keeps user defined values.