### PR TITLE
GUI: fix unnessessary redrawing bug

### DIFF
--- a/src/guiapi/include/window_menu.hpp
+++ b/src/guiapi/include/window_menu.hpp
@@ -10,6 +10,7 @@
 class window_menu_t : public IWindowMenu {
     uint8_t index;    /// index of cursor
     int8_t moveIndex; /// accumulator for cursor changes
+    bool initialized; /// triggers first redraw
 
     void setIndex(uint8_t index); //for ctor (cannot fail)
     /// Prints single item in the menu

--- a/src/guiapi/src/window_menu.cpp
+++ b/src/guiapi/src/window_menu.cpp
@@ -11,9 +11,10 @@
 
 window_menu_t::window_menu_t(window_t *parent, Rect16 rect, IWinMenuContainer *pContainer, uint8_t index)
     : IWindowMenu(parent, rect)
+    , moveIndex(0)
+    , initialized(false)
     , pContainer(pContainer) {
     setIndex(index);
-    moveIndex = 0;
     top_index = 0;
     updateTopIndex();
 }
@@ -231,12 +232,12 @@ void window_menu_t::unconditionalDraw() {
         return;
     }
 
-    if (moveIndex == 0) { /// startup or single item change
-        if (item->IsSelected()) {
-            unconditionalDrawItem(index);
-        } else {
-            redrawWholeMenu();
-        }
+    if (!initialized) {
+        initialized = true;
+        redrawWholeMenu();
+        return;
+    } else if (item->IsSelected()) {
+        unconditionalDrawItem(index);
         return;
     }
 
@@ -246,8 +247,10 @@ void window_menu_t::unconditionalDraw() {
     if (updateTopIndex()) {
         redrawWholeMenu(); /// whole menu moved, redraw everything
     } else {
-        unconditionalDrawItem(old_index); /// just cursor moved, redraw cursor only
-        unconditionalDrawItem(index);
+        if (old_index != index) {
+            unconditionalDrawItem(old_index); /// just cursor moved, redraw cursor only
+            unconditionalDrawItem(index);
+        }
     }
 }
 


### PR DESCRIPTION
BFW-1537 (as part of)

BUG: 
There was an unnessessary reprinting of the whole menu with every move. It was caused due to this condition `if (moveIndex == 0)`. Variable `moveIndex` was set to 0 in every loop before the condition.

SOLUTION:
Introduce variable `initialized`, which handles the first menu redraw. Removing dependency on `moveIndex` solved it.