### PR TITLE
GUI: Repair a flaw (switch click)

### DIFF
--- a/src/guiapi/include/window_menu.hpp
+++ b/src/guiapi/include/window_menu.hpp
@@ -11,6 +11,7 @@ class window_menu_t : public IWindowMenu {
     uint8_t index;    /// index of cursor
     int8_t moveIndex; /// accumulator for cursor changes
     bool initialized; /// triggers first redraw
+    bool clicked;     /// triggers click redraw (item->Click invalidates whole menu, but we need to know what happend to redraw only nessessary items)
 
     void setIndex(uint8_t index); //for ctor (cannot fail)
     /// Prints single item in the menu

--- a/src/guiapi/src/window_menu.cpp
+++ b/src/guiapi/src/window_menu.cpp
@@ -13,6 +13,7 @@ window_menu_t::window_menu_t(window_t *parent, Rect16 rect, IWinMenuContainer *p
     : IWindowMenu(parent, rect)
     , moveIndex(0)
     , initialized(false)
+    , clicked(false)
     , pContainer(pContainer) {
     setIndex(index);
     top_index = 0;
@@ -173,6 +174,7 @@ void window_menu_t::windowEvent(EventLock /*has private ctor*/, window_t *sender
     case GUI_event_t::CLICK:
 
         item->Click(*this);
+        clicked = true;
         //Invalidate(); //called inside click
         break;
     case GUI_event_t::ENC_DN:
@@ -236,7 +238,8 @@ void window_menu_t::unconditionalDraw() {
         initialized = true;
         redrawWholeMenu();
         return;
-    } else if (item->IsSelected()) {
+    } else if (item->IsSelected() || clicked) {
+        clicked = false;
         unconditionalDrawItem(index);
         return;
     }


### PR DESCRIPTION
Last PR created a flaw. Switch was not redrawing when you clicked on it.

It's because IWindowMenuItem::Click() only invalidates menu, but we need to know what happend, to redraw only that what is nessessary.

Simple clicked help variable solves it.