### PR TITLE
GUI: Fix redrawing all from dialog

### DIFF
--- a/src/guiapi/include/window.hpp
+++ b/src/guiapi/include/window.hpp
@@ -52,7 +52,7 @@ public:
     void Shadow();
     void Unshadow();
     void HideBehindDialog();
-    void ShowAfterDialog();
+    virtual void ShowAfterDialog();
     void SetBackColor(color_t clr);
     color_t GetBackColor() const;
 

--- a/src/guiapi/include/window_menu.hpp
+++ b/src/guiapi/include/window_menu.hpp
@@ -10,7 +10,7 @@
 class window_menu_t : public IWindowMenu {
     uint8_t index;    /// index of cursor
     int8_t moveIndex; /// accumulator for cursor changes
-    bool initialized; /// triggers first redraw
+    bool redrawAll;   /// triggers whole menu redraw
     bool clicked;     /// triggers click redraw (item->Click invalidates whole menu, but we need to know what happend to redraw only nessessary items)
 
     void setIndex(uint8_t index); //for ctor (cannot fail)
@@ -59,4 +59,5 @@ public:
 protected:
     virtual void unconditionalDraw() override;
     virtual void windowEvent(EventLock /*has private ctor*/, window_t *sender, GUI_event_t event, void *param) override;
+    virtual void ShowAfterDialog() override;
 };

--- a/src/guiapi/src/window_menu.cpp
+++ b/src/guiapi/src/window_menu.cpp
@@ -12,7 +12,7 @@
 window_menu_t::window_menu_t(window_t *parent, Rect16 rect, IWinMenuContainer *pContainer, uint8_t index)
     : IWindowMenu(parent, rect)
     , moveIndex(0)
-    , initialized(false)
+    , redrawAll(true)
     , clicked(false)
     , pContainer(pContainer) {
     setIndex(index);
@@ -234,8 +234,8 @@ void window_menu_t::unconditionalDraw() {
         return;
     }
 
-    if (!initialized) {
-        initialized = true;
+    if (redrawAll) {
+        redrawAll = false;
         redrawWholeMenu();
         return;
     } else if (item->IsSelected() || clicked) {
@@ -318,5 +318,14 @@ void window_menu_t::unconditionalDrawItem(uint8_t index) {
             break;
         }
         ++visible_count;
+    }
+}
+
+void window_menu_t::ShowAfterDialog() {
+    if (flags.hidden_behind_dialog) {
+        flags.hidden_behind_dialog = false;
+        //must invalidate even when is not visible
+        redrawAll = true;
+        Invalidate();
     }
 }


### PR DESCRIPTION
Menu was not redrawing all, when user returned from dialogue, it redrawed only focused item. Now it redraws whole menu.