### PR TITLE
Initialize eeprom and xflash in main.cpp before threads started

### DIFF
--- a/src/common/appmain.cpp
+++ b/src/common/appmain.cpp
@@ -99,13 +99,6 @@ void app_run(void) {
         osThreadResume(webServerTaskHandle);
 #endif //BUDDY_ENABLE_ETHERNET
 
-    crc32_init();
-
-    uint8_t eeprom_init_status = eeprom_init();
-    if (eeprom_init_status == EEPROM_INIT_Defaults || eeprom_init_status == EEPROM_INIT_Upgraded) {
-        // this means we are either starting from defaults or after a FW upgrade -> invalidate the XFLASH dump, since it is not relevant anymore
-        dump_in_xflash_reset();
-    }
     LangEEPROM::getInstance();
 
     marlin_server_init();
@@ -135,7 +128,7 @@ void app_run(void) {
     }
     //DBG("after setup (%ld ms)", HAL_GetTick());
 
-    if (eeprom_init_status == EEPROM_INIT_Defaults && marlin_server_processing()) {
+    if (eeprom_get_init_status() == EEPROM_INIT_Defaults && marlin_server_processing()) {
         settings.reset();
     }
 

--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -216,11 +216,14 @@ static inline void eeprom_unlock(void) {
     osSemaphoreRelease(eeprom_sema);
 }
 
+// result of eeprom_init (reset defaults, upgrade ...)
+static uint8_t eeprom_init_status = EEPROM_INIT_Undefined;
+
 // forward declarations of private functions
 
 static uint16_t eeprom_var_size(uint8_t id);
 static uint16_t eeprom_var_addr(uint8_t id);
-static void eeprom_print_vars(void);
+//static void eeprom_print_vars(void);
 static int eeprom_convert_from_v2(void);
 static int eeprom_convert_from(uint16_t version, uint16_t features);
 
@@ -252,8 +255,13 @@ uint8_t eeprom_init(void) {
     }
     if (status == EEPROM_INIT_Defaults)
         eeprom_defaults();
-    eeprom_print_vars();
+    //eeprom_print_vars(); this is not possible here because it hangs - init is now done in main.cpp, not in defaultThread
+    eeprom_init_status = status;
     return status;
+}
+
+uint8_t eeprom_get_init_status(void) {
+    return eeprom_init_status;
 }
 
 void eeprom_defaults(void) {
@@ -382,7 +390,7 @@ static uint16_t eeprom_var_addr(uint8_t id) {
     return addr;
 }
 
-static void eeprom_print_vars(void) {
+/*static void eeprom_print_vars(void) {
     uint8_t id;
     char text[128];
     variant8_t var8;
@@ -393,7 +401,7 @@ static void eeprom_print_vars(void) {
         _dbg("%s=%s", eeprom_map[id].name, text);
         variant8_done(&pvar);
     }
-}
+}*/
 
 static const constexpr uint16_t ADDR_V2_FILAMENT_TYPE = 0x0400;
 static const constexpr uint16_t ADDR_V2_FILAMENT_COLOR = EEPROM_ADDRESS + 3;

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -109,6 +109,7 @@ typedef union _SelftestResultEEprom_t {
 } SelftestResultEEprom_t;
 
 enum {
+    EEPROM_INIT_Undefined = -1,
     EEPROM_INIT_Normal = 0,
     EEPROM_INIT_Defaults = 1,
     EEPROM_INIT_Upgraded = 2
@@ -123,6 +124,9 @@ extern "C" {
 ///          1 - defaults loaded
 ///          2 - eeprom upgraded successfully from a previous version
 extern uint8_t eeprom_init(void);
+
+// returns last result of eeprom_init() or EEPROM_INIT_Undefined
+extern uint8_t eeprom_get_init_status(void);
 
 // write default values to all variables
 extern void eeprom_defaults(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,9 @@
 #include "hwio_pindef.h"
 #include "gui.hpp"
 #include "config_a3ides2209_02.h"
+#include "eeprom.h"
+#include "crc32.h"
+#include "w25x.h"
 
 /* USER CODE END Includes */
 
@@ -238,6 +241,21 @@ int main(void) {
     uartslave_init(&uart6slave, &uart6rxbuff, &huart6, sizeof(uart6slave_line), uart6slave_line);
     putslave_init(&uart6slave);
     wdt_iwdg_warning_cb = iwdg_warning_cb;
+
+    crc32_init();
+    w25x_init();
+
+    int irq = __get_PRIMASK() & 1;
+    __enable_irq();
+    eeprom_init();
+    uint8_t status = eeprom_get_init_status();
+    if (status == EEPROM_INIT_Defaults || status == EEPROM_INIT_Upgraded) {
+        // this means we are either starting from defaults or after a FW upgrade -> invalidate the XFLASH dump, since it is not relevant anymore
+        dump_in_xflash_reset();
+    }
+    if (irq == 0)
+        __disable_irq();
+
     /* USER CODE END 2 */
 
     static metric_handler_t *handlers[] = {


### PR DESCRIPTION
synchronization (semaphores) are ignored
problem with eeprom_print_vars() /_dbg - deadlock
trace in eeprom_init temporarily disabled, will be solved later

(cherry picked from commit 332696c8f8749163d4cef57df5da488117ad07fa)