### PR TITLE
LAN changes

### DIFF
--- a/src/gui/window_header.cpp
+++ b/src/gui/window_header.cpp
@@ -44,7 +44,8 @@ window_header_t::window_header_t(window_t *parent, string_view_utf8 txt)
     , icon_base(this, Rect16(rect.TopLeft(), icon_base_width, rect.Height() - 5), 0)
     , label(this, rect - Rect16::Width_t(icons_width + span + icon_base_width) + Rect16::Left_t(icon_base_width), txt)
     , icon_usb(this, (rect + Rect16::Left_t(rect.Width() - icon_usb_width)) = icon_usb_width, IDR_PNG_usb_16px)
-    , icon_lan(this, (rect + Rect16::Left_t(rect.Width() - icons_width)) = icon_lan_width, IDR_PNG_lan_16px) {
+    , icon_lan(this, (rect + Rect16::Left_t(rect.Width() - icons_width)) = icon_lan_width, IDR_PNG_lan_16px)
+    , LAN_changed_off(false) {
     /// label and icon aligmnent and offset
     label.SetAlignment(ALIGN_LEFT_BOTTOM);
     icon_base.SetAlignment(ALIGN_CENTER_BOTTOM);
@@ -64,12 +65,20 @@ void window_header_t::USB_Activate() {
     icon_usb.Show();
     icon_usb.Unshadow();
 }
-void window_header_t::LAN_Off() { icon_lan.Hide(); }
+void window_header_t::LAN_Off() {
+    icon_lan.Hide();
+    if (!LAN_changed_off) {
+        LAN_changed_off = true;
+        Invalidate();
+    }
+}
 void window_header_t::LAN_On() {
+    LAN_changed_off = false;
     icon_lan.Show();
     icon_lan.Shadow();
 }
 void window_header_t::LAN_Activate() {
+    LAN_changed_off = false;
     icon_lan.Show();
     icon_lan.Unshadow();
 }

--- a/src/gui/window_header.hpp
+++ b/src/gui/window_header.hpp
@@ -14,6 +14,8 @@ struct window_header_t : public AddSuperWindow<window_frame_t> {
     window_icon_t icon_usb;
     window_icon_t icon_lan;
 
+    bool LAN_changed_off;
+
     void SetIcon(int16_t id_res);
     void SetText(string_view_utf8 txt);
     header_states_t GetStateUSB() const;


### PR DESCRIPTION
- netif_state & get_eth_status() was depend on GUI part of showing LAN icon
- those flags and logic behind them ignored LAN on/off flag
- added conditions if IS_LAN_ON(..)

changes after conditions is updated
- LWIP init won't called netif_set_up when LAN is OFF
- so DHCP is not started
- we're trying to renew DHCP when LAN is set ON via GUI

WANTED behavior
- ETH cabel is IN & LAN is OFF
  - ETH icon is gray
  - netif_set_up is not called (because of flag)
- ETH cabel is IN & LAN is OFF & FW is initializing
  - ETH icon is gray
  - DHCP is not started
  - netif_set_up is not called

BFW-1588