### PR TITLE
G-code input file filtering+buffering

### DIFF
--- a/src/common/gcode_input_filter.hpp
+++ b/src/common/gcode_input_filter.hpp
@@ -1,0 +1,177 @@
+/// @brief G-code input filtering
+///
+/// Contains a generic and simple read buffering (RDbuf) and a generic filtering class (GCodeInputFilter).
+/// Both classes need parametrization of important functionality:
+/// - the instance of RDbuf needs to know how to fetch input data
+/// - the instance of GCodeInputFilter needs to know how enqueue filtered G-code commands
+///
+/// Design concerns (over previous implementation of media_loop() in media.cpp):
+/// - handle long comment lines correctly, even if they contain G-code commands -> filter these lines out, avoid sending them into Marlin
+/// - detect long G-code lines and stop printing in such a case avoiding damage to the machine
+/// - avoid FS operations for short chunks of data - ideally read the whole block/sector into RAM -> buffering, avoid f_gets()
+/// - make the processing/filtering generic to enable unit testing
+
+#pragma once
+
+#include <stdint.h>
+#include <limits>
+
+/// RDbuf handles buffering of input data stream - for now it shall sit on top of raw FATfs's f_read and f_eof functions.
+/// It may get replaced in the future when we have "normal" libc file interfaces
+///
+/// Memory requirements:
+/// RDBUFFMAX + some state vars
+/// basically any caching size should work, ideally the same size as usb drive sector (but 512 is may be too much for our STM32)
+template <uint32_t RDBUFFMAX = 64>
+class RDbuf {
+    char rdbuf[RDBUFFMAX];
+    uint32_t rdbufSize;
+    char *r = rdbuf;
+    uint32_t startInputOffset; ///< where the buffer starts in the input stream/file
+public:
+    RDbuf() {
+        reset();
+    }
+
+    enum EFill { OK,
+        ERROR,
+        END };
+
+    /// Performs filling the buffer from input stream
+    /// How to read the input stream and how to check for its end of input is parametrized externally via:
+    /// FREAD:
+    /// bool fread(char *rdbuf, uint32_t rdbufsize, uint32_t *bytes_read)
+    /// returns false in case of any read error, otherwise true
+    ///
+    /// FEOF:
+    /// bool feof()
+    /// returns true in case of input file/stream end
+    ///
+    /// @returns EFill::OK - the buffer read at least one byte from the input
+    ///          EFill::ERROR - a read error occurred, the rdbuf's content is unspecified in this case
+    ///          EFill::END - end of input reached
+    template <typename FREAD, typename FEOF>
+    inline EFill Fill(FREAD fread, FEOF feof) {
+        if (feof()) {
+            return END;
+        }
+        // advance "file position" by the last size of buffer read
+        startInputOffset += rdbufSize;
+        return fread(rdbuf, sizeof(rdbuf), &rdbufSize) ? OK : ERROR;
+    }
+
+    // STL-like interface
+    inline const char *begin() const { return rdbuf; }
+    inline const char *end() const { return begin() + size(); }
+    inline uint32_t size() const { return rdbufSize; }
+    inline void reset(uint32_t fileRestartOffset = 0) {
+        rdbufSize = 0;
+        r = rdbuf;
+        startInputOffset = fileRestartOffset;
+    }
+    inline uint32_t startOfs() const { return startInputOffset; }
+};
+
+/// GCodeInputFilter filters an input buffer of raw G-code text by stripping all comments
+/// @returns processed bytes
+///
+/// Sadly, the operation is not zero-copy since the G-code line must be in one continuous block to be handed over to Marlin
+/// thus crossing borders of the rdbuf is not easy to do now.
+///
+/// Memory requirements:
+/// GCODEBUFFSIZE + some state vars
+template <uint32_t GCODEBUFFSIZE = 97>
+class GCodeInputFilter {
+    char *g;
+    const char *r;
+    enum States { COMMENT,
+        COPY,
+        ONHOLD };
+    States state = COPY;
+    char gcbuf[GCODEBUFFSIZE];
+
+public:
+    GCodeInputFilter() {
+        reset();
+    }
+
+    /// resets the filter to initial state
+    inline void reset() {
+        g = gcbuf;
+        r = nullptr;
+        state = COPY;
+    }
+
+    /// Perform filtering of the input data
+    ///
+    /// RDBUF: basically anything that provides the following methods:
+    /// const char *begin()const
+    /// const char *end()const
+    /// uint32_t size()const
+    /// and a few others
+    ///
+    /// ENQUEUE_GCODE:
+    /// void enqueue_gcode(const char *gcodebuff, uint32_t new_file_offset)
+    /// shall take the content of gcodebuff (zero terminated) and push it into Marlin (or any other processing engine)
+    /// new_file_offset represents the offset in the input file/stream AFTER the gcode is pushed into Marlin
+    /// - that's because we want to track which commands were successfully pushed into Marlin and processed
+    ///   to know exactly where to continue in case of an input file/stream removal/error
+    ///
+    /// @returns -1 in case of being "on hold" - i.e. was unable to enqueue the G-code into Marlin (can be called again to retry).
+    ///          Otherwise it returns a positive number of input bytes processed.
+    ///          Please note - if the number != rdbuf.size(), the filter has reached a line which couldn't fit into Marlin's internal line buffer
+    ///             which implies the line would have been truncated and could possibly damage the machine being misinterpreted!
+    template <typename RDBUF, typename ENQUEUE_GCODE>
+    int Filter(const RDBUF &rdbuf, ENQUEUE_GCODE enqueue_gcode) {
+        if (OnHold()) {                                                              // try to enqueue the data again if any
+            if (!enqueue_gcode(gcbuf, rdbuf.startOfs() + (r - rdbuf.begin()) + 1)) { // +1 is to skip the '\n'
+                state = ONHOLD;
+                return -1; // we haven't been able to enqueue the data again
+            }
+            g = gcbuf; // point to the beginning of the buffer again
+            state = COPY;
+        } else {
+            r = rdbuf.begin(); // otherwise restart reading from the start of the input buffer
+        }
+        for (/* nothing */; r < rdbuf.end(); ++r) {
+            switch (*r) {
+            case ';':
+                state = COMMENT;
+                break;
+            case '\n':
+                if (g != gcbuf) {                                                            // if the line was not empty
+                    *g = 0;                                                                  // terminating a copied G-code command
+                    if (!enqueue_gcode(gcbuf, rdbuf.startOfs() + (r - rdbuf.begin()) + 1)) { // +1 is to skip the '\n'
+                        state = ONHOLD;
+                        return -1; // we haven't been able to enqueue the data
+                    }
+                    g = gcbuf; // point to the beginning of the buffer again
+                }
+                state = COPY; // anyway, we are switching to the copy state
+                break;
+            default:
+                if (state == COPY) {
+                    // Verify, we are not writing beyond the buffer
+                    // "normal" g-codes are safe (within 96 bytes), but deliberately malformed lines may overflow if not checked
+                    if (g < gcbuf + GCODEBUFFSIZE - 1) {
+                        *g = *r;
+                        ++g;
+                    } else {
+                        // @@TODO discuss when doing code review
+                        // May be emit a runtime error or a red screen - such a "bad" line may be misinterpreted and possibly damage the machine
+                        // Ideally this situation should get caught by G-code checking before starting a print
+                        return r - rdbuf.begin();
+                    }
+                }
+                break;
+            }
+        }
+        // silently avoiding signed/unsigned warning - rdbuf's size is max a few hundred bytes long on our platform
+        static_assert(sizeof(rdbuf) < std::numeric_limits<int>::max());
+        return (int)rdbuf.size();
+    }
+
+    /// @returns true if the filter was blocked when trying to enqueue a gcode command
+    /// - i.e. the rdbuf has not been processed completely yet
+    bool OnHold() const { return state == ONHOLD; }
+};

--- a/tests/unit/common/CMakeLists.txt
+++ b/tests/unit/common/CMakeLists.txt
@@ -1,33 +1,37 @@
+add_executable(
+  support_utils_tests ${CMAKE_CURRENT_SOURCE_DIR}/support_utils_lib_test.cpp
+                      ${CMAKE_SOURCE_DIR}/src/common/support_utils_lib.cpp
+  )
+target_include_directories(support_utils_tests PUBLIC ${CMAKE_SOURCE_DIR}/src/common)
 
-add_executable(support_utils_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/support_utils_lib_test.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/support_utils_lib.cpp
-)
-target_include_directories(support_utils_tests PUBLIC
-    ${CMAKE_SOURCE_DIR}/src/common
-)
+add_executable(
+  variant8_tests
+  ${CMAKE_SOURCE_DIR}/tests/unit/test_main.cpp ${CMAKE_SOURCE_DIR}/src/common/variant8.cpp
+  ${CMAKE_SOURCE_DIR}/tests/stubs/malloc_stub.cpp ${CMAKE_CURRENT_SOURCE_DIR}/variant8_tests.cpp
+  )
+target_include_directories(
+  variant8_tests PUBLIC ${CMAKE_SOURCE_DIR}/tests/stubs ${CMAKE_SOURCE_DIR}/src
+  )
 
-add_executable(variant8_tests
-    ${CMAKE_SOURCE_DIR}/tests/unit/test_main.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/variant8.cpp
-    ${CMAKE_SOURCE_DIR}/tests/stubs/malloc_stub.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/variant8_tests.cpp
-)
-target_include_directories(variant8_tests PUBLIC
-    ${CMAKE_SOURCE_DIR}/tests/stubs
-    ${CMAKE_SOURCE_DIR}/src
-)
+add_executable(
+  str_utils_tests
+  ${CMAKE_CURRENT_SOURCE_DIR}/str_utils_test.cpp ${CMAKE_SOURCE_DIR}/src/common/str_utils.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/str_utils.hpp
+  )
+target_include_directories(
+  str_utils_tests PUBLIC # ${CMAKE_SOURCE_DIR}/src/common
+                         ${CMAKE_SOURCE_DIR}/src
+  )
 
-add_executable(str_utils_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/str_utils_test.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/str_utils.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/str_utils.hpp
-)
-target_include_directories(str_utils_tests PUBLIC
-#    ${CMAKE_SOURCE_DIR}/src/common
-    ${CMAKE_SOURCE_DIR}/src
-)
+add_executable(
+  media_tests ${CMAKE_CURRENT_SOURCE_DIR}/media_test.cpp
+              ${CMAKE_SOURCE_DIR}/src/common/gcode_input_filter.hpp
+  )
+target_include_directories(
+  media_tests PUBLIC ${CMAKE_SOURCE_DIR}/src/common ${CMAKE_SOURCE_DIR}/src
+  )
 
 add_catch_test(support_utils_tests)
 add_catch_test(variant8_tests)
 add_catch_test(str_utils_tests)
+add_catch_test(media_tests)

--- a/tests/unit/common/media_test.cpp
+++ b/tests/unit/common/media_test.cpp
@@ -1,0 +1,329 @@
+/// media tests
+
+#include <string.h>
+#include <iostream>
+#include <cstdint>
+#include <vector>
+#include <deque>
+
+//#define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
+#include "catch2/catch.hpp"
+
+#include "gcode_input_filter.hpp"
+
+using Catch::Matchers::Equals;
+
+struct GCRec {
+    std::string line;
+    uint32_t lastSuccessfulFileOffset;
+    GCRec(const char *gc, uint32_t o)
+        : line(gc)
+        , lastSuccessfulFileOffset(o) {}
+};
+
+using GCodesDeq = std::deque<GCRec>;
+
+// synthetic tests on memory buffers
+static const char gcodeTooLong[] = "G1\n"
+                                   "G2 ; with comment\n"
+                                   "; G3 commented completely\n"
+                                   "G4 with deliberately insane string behind it to exceed the 96 bytes of input buffer 12345678901234567890\n"
+                                   "; if(condition slicer profile){ G1 G2 G3 G4 G5 G6 G7 G8 G9 G10 }else{ G1 G2 G3 G4 G5 G6 G7 G8 G9 G10 } G1 G2 G3 G4 G5 G6 G7 G8 G9 G10 G1 G2 G3 G4 G5 G6 G7 G8 G9 G10 \n";
+
+static const char gcode0[] = "G1\n"
+                             "G2 ; with comment\n"
+                             "; G3 commented completely\n"
+                             "G4 with normal string behind within 96 bytes of input buffer\n"
+                             "; if(condition slicer profile){ G1 G2 G3 G4 G5 G6 G7 G8 G9 G10 }else{ G1 G2 G3 G4 G5 G6 G7 G8 G9 G10 } G1 G2 G3 G4 G5 G6 G7 G8 G9 G10 G1 G2 G3 G4 G5 G6 G7 G8 G9 G10 \n";
+
+constexpr uint32_t gcBuffSize = 97;
+
+enum EMediaLoop { OK,
+    ERROR,
+    ONHOLD };
+
+template <
+    typename ENQUEUEGCODE,
+    uint32_t RDBUFSIZE = 64,
+    uint32_t GCBUFSIZE = gcBuffSize>
+EMediaLoop media_loop_inner(ENQUEUEGCODE enq) {
+    using R = RDbuf<RDBUFSIZE>;
+    R rdbuf;
+    using G = GCodeInputFilter<GCBUFSIZE>;
+    G g;
+    const char *g1 = gcode0;
+
+    for (;;) {
+        switch (rdbuf.Fill(
+            [&](char *rdbuf, uint32_t rdbufsize, uint32_t *bytes_read) -> bool {
+                uint32_t remainingBytes = (uint32_t)((gcode0 + sizeof(gcode0) - 1) - g1);
+                *bytes_read = std::min(rdbufsize, remainingBytes);
+                std::copy(g1, g1 + *bytes_read, rdbuf);
+                g1 += *bytes_read;
+                return true;
+            },
+            [&]() -> bool {
+                return g1 == gcode0 + sizeof(gcode0) - 1; // skip the terminal '\0'
+            })) {
+        case R::END:
+            return EMediaLoop::OK;
+        case R::OK: {
+            int frv = g.Filter(rdbuf, enq);
+            if (frv == (int)rdbuf.size()) {
+                break; // all data sucessfully processed
+            }
+            if (frv >= 0) {
+                // a serious problem - not all data could have been pushed into Marlin - usually caused by some malformed G-code line
+                return EMediaLoop::ERROR;
+            } else {
+                // on hold with enqueuing data into Marlin - return from this method and wait outside
+                return EMediaLoop::ONHOLD;
+            }
+        } break;
+        case R::ERROR:
+            return EMediaLoop::ERROR;
+        }
+    }
+    return EMediaLoop::ERROR;
+}
+
+void TEST_CASE_preparse_file_basic() {
+    GCodesDeq enqueued_gcodes;
+
+    REQUIRE(media_loop_inner(
+                [&](const char *gcodebuff, uint32_t new_file_offset) -> bool {
+                    enqueued_gcodes.emplace_back(GCRec(gcodebuff, new_file_offset));
+                    return true;
+                })
+        == EMediaLoop::OK);
+
+    // check, that we have in enqueued gcodes:
+    REQUIRE(enqueued_gcodes.size() == 3);
+    REQUIRE(enqueued_gcodes[0].line == "G1");
+    REQUIRE(enqueued_gcodes[0].lastSuccessfulFileOffset == 3);
+    REQUIRE(enqueued_gcodes[1].line == "G2 ");
+    REQUIRE(enqueued_gcodes[1].lastSuccessfulFileOffset == 21);
+    REQUIRE(enqueued_gcodes[2].line == "G4 with normal string behind within 96 bytes of input buffer");
+    REQUIRE(enqueued_gcodes[2].lastSuccessfulFileOffset == 108);
+}
+
+TEST_CASE("preparse_file basic", "") {
+    TEST_CASE_preparse_file_basic();
+}
+
+template <
+    uint32_t RDBUFSIZE = 64,
+    uint32_t GCBUFSIZE = gcBuffSize>
+bool media_loop_inner_cause_error(GCodesDeq &enqueued_gcodes, uint32_t errorOffset, uint32_t faultBytes) {
+    using R = RDbuf<RDBUFSIZE>;
+    R rdbuf;
+    using G = GCodeInputFilter<GCBUFSIZE>;
+    G g;
+    // uint32_t fileRestartOffset = 0; // where the file read was started or restarted after an error
+    const char *g1 = gcode0;
+    uint32_t lastSuccessfulGcodeOffset = 0;
+    bool errorEmitted = false;
+
+    for (;;) {
+        switch (rdbuf.Fill(
+            [&](char *rdbuf, uint32_t rdbufsize, uint32_t *bytes_read) -> bool {
+                uint32_t remainingBytes = (uint32_t)((gcode0 + sizeof(gcode0)) - g1);
+                uint32_t bytesNormallyRead = std::min(rdbufsize, remainingBytes);
+
+                if ((uint32_t)((g1 + bytesNormallyRead) - gcode0) > errorOffset && (!errorEmitted)) { // cause an error
+                    *bytes_read = faultBytes;                                                         // some random number - simulating a read failure inside a block
+                    g1 += *bytes_read;
+                    errorEmitted = true;
+                    return false;
+                }
+
+                *bytes_read = bytesNormallyRead;
+                std::copy(g1, g1 + *bytes_read, rdbuf);
+                g1 += *bytes_read;
+                return true;
+            },
+            [&]() -> bool {
+                return g1 == gcode0 + sizeof(gcode0);
+            })) {
+        case R::END:
+            return true;
+        case R::OK:
+            if (g.Filter(rdbuf,
+                    [&](const char *gcodebuff, uint32_t new_file_offset) -> bool {
+                        enqueued_gcodes.emplace_back(GCRec(gcodebuff, new_file_offset));
+                        lastSuccessfulGcodeOffset = new_file_offset;
+                        return true;
+                    })
+                != (int)rdbuf.size()) {
+                return false;
+            }
+            break;
+        case R::ERROR:
+            // there was an (intentional) error reading the input stream, handle it by recovering reading
+            // - do a "seek" in the input stream from the last successful position "enqueued into Marlin":
+            // that's something media_print_resume() does by calling fseek()
+            g1 = gcode0 + lastSuccessfulGcodeOffset;
+            rdbuf.reset(lastSuccessfulGcodeOffset); // buffer will be filled newly
+            g.reset();                              // filter will also start newly, all the already processed (but failed) content must be scrapped
+            // and leave the cycle run again
+            break;
+        }
+    }
+    return false;
+}
+
+void TEST_CASE_preparse_file_read_error(uint32_t errorOffset, uint32_t faultBytes) {
+    GCodesDeq enqueued_gcodes;
+    REQUIRE(media_loop_inner_cause_error(
+        enqueued_gcodes,
+        errorOffset,
+        faultBytes));
+
+    // check, that we have in enqueued gcodes:
+    REQUIRE(enqueued_gcodes.size() == 3);
+    REQUIRE(enqueued_gcodes[0].line == "G1");
+    REQUIRE(enqueued_gcodes[0].lastSuccessfulFileOffset == 3);
+    REQUIRE(enqueued_gcodes[1].line == "G2 ");
+    REQUIRE(enqueued_gcodes[1].lastSuccessfulFileOffset == 21);
+    REQUIRE(enqueued_gcodes[2].line == "G4 with normal string behind within 96 bytes of input buffer");
+    REQUIRE(enqueued_gcodes[2].lastSuccessfulFileOffset == 108);
+}
+
+TEST_CASE("preparse_file read_errors", "") {
+    for (uint32_t errorOffset = 0; errorOffset < sizeof(gcode0); ++errorOffset) {
+        for (uint32_t faultBytes = 0; faultBytes < 64; ++faultBytes) {
+            TEST_CASE_preparse_file_read_error(errorOffset, faultBytes);
+        }
+    }
+}
+
+EMediaLoop TEST_CASE_preparse_file_on_hold(GCodesDeq &enqueued_gcodes) {
+    // simulate waiting for emptying of the Marlin queue
+    // - just a simple hack - every 3rd call will work/return true
+    uint32_t enqueueCalls = 0;
+
+    using R = RDbuf<64>;
+    R rdbuf;
+    using G = GCodeInputFilter<97>;
+    G g;
+    const char *g1 = gcode0;
+
+    for (;;) {
+        auto rdf = R::OK;
+
+        // avoid filling the buffer again if the filter hasn't finished processing
+        if (!g.OnHold()) {
+            rdf = rdbuf.Fill(
+                [&](char *rdbuf, uint32_t rdbufsize, uint32_t *bytes_read) -> bool {
+                    uint32_t remainingBytes = (uint32_t)((gcode0 + sizeof(gcode0) - 1) - g1);
+                    *bytes_read = std::min(rdbufsize, remainingBytes);
+                    std::copy(g1, g1 + *bytes_read, rdbuf);
+                    g1 += *bytes_read;
+                    return true;
+                },
+                [&]() -> bool {
+                    return g1 == gcode0 + sizeof(gcode0) - 1; // skip the terminal '\0'
+                });
+        }
+
+        switch (rdf) {
+        case R::END:
+            return EMediaLoop::OK;
+        case R::OK: {
+            int frv = g.Filter(rdbuf,
+                [&](const char *gcodebuff, uint32_t new_file_offset) -> bool {
+                    ++enqueueCalls;
+                    if (enqueueCalls % 3 == 0) {
+                        enqueued_gcodes.emplace_back(GCRec(gcodebuff, new_file_offset));
+                        return true;
+                    } else {
+                        return false;
+                    }
+                });
+            if (frv == (int)rdbuf.size()) {
+                break; // all data sucessfully processed
+            }
+            if (frv >= 0) {
+                // a serious problem - not all data could have been pushed into Marlin - usually caused by some malformed G-code line
+                return EMediaLoop::ERROR;
+            } else {
+                // on hold with enqueuing data into Marlin - just break and let the cycle run again
+                break;
+            }
+        } break;
+        case R::ERROR:
+            return EMediaLoop::ERROR;
+        }
+    }
+    return EMediaLoop::ERROR;
+}
+
+TEST_CASE("preparse_file on_hold", "") {
+    GCodesDeq enqueued_gcodes;
+
+    REQUIRE(TEST_CASE_preparse_file_on_hold(enqueued_gcodes) == EMediaLoop::OK);
+
+    // check, that we have in enqueued gcodes:
+    REQUIRE(enqueued_gcodes.size() == 3);
+    REQUIRE(enqueued_gcodes[0].line == "G1");
+    REQUIRE(enqueued_gcodes[0].lastSuccessfulFileOffset == 3);
+    REQUIRE(enqueued_gcodes[1].line == "G2 ");
+    REQUIRE(enqueued_gcodes[1].lastSuccessfulFileOffset == 21);
+    REQUIRE(enqueued_gcodes[2].line == "G4 with normal string behind within 96 bytes of input buffer");
+    REQUIRE(enqueued_gcodes[2].lastSuccessfulFileOffset == 108);
+}
+
+EMediaLoop TEST_CASE_preparse_line_too_long(GCodesDeq &enqueued_gcodes) {
+    using R = RDbuf<64>;
+    R rdbuf;
+    using G = GCodeInputFilter<97>;
+    G g;
+    const char *g1 = gcodeTooLong;
+
+    for (;;) {
+        switch (rdbuf.Fill(
+            [&](char *rdbuf, uint32_t rdbufsize, uint32_t *bytes_read) -> bool {
+                uint32_t remainingBytes = (uint32_t)((gcodeTooLong + sizeof(gcodeTooLong) - 1) - g1);
+                *bytes_read = std::min(rdbufsize, remainingBytes);
+                std::copy(g1, g1 + *bytes_read, rdbuf);
+                g1 += *bytes_read;
+                return true;
+            },
+            [&]() -> bool {
+                return g1 == gcodeTooLong + sizeof(gcode0) - 1; // skip the terminal '\0'
+            })) {
+        case R::END:
+            return EMediaLoop::OK;
+        case R::OK: {
+            int frv = g.Filter(rdbuf, [&](const char *gcodebuff, uint32_t new_file_offset) -> bool {
+                enqueued_gcodes.emplace_back(GCRec(gcodebuff, new_file_offset));
+                return true;
+            });
+            if (frv == (int)rdbuf.size()) {
+                break; // all data sucessfully processed
+            }
+            if (frv >= 0) {
+                // a serious problem - not all data could have been pushed into Marlin - usually caused by some malformed G-code line
+                return EMediaLoop::ERROR;
+            } else {
+                // on hold with enqueuing data into Marlin - return from this method and wait outside
+                return EMediaLoop::ONHOLD;
+            }
+        } break;
+        case R::ERROR:
+            return EMediaLoop::ERROR;
+        }
+    }
+    return EMediaLoop::ERROR;
+}
+
+TEST_CASE("preparse_file line_too_long", "") {
+    GCodesDeq enqueued_gcodes;
+    REQUIRE(TEST_CASE_preparse_line_too_long(enqueued_gcodes) == EMediaLoop::ERROR);
+
+    REQUIRE(enqueued_gcodes.size() == 2);
+    REQUIRE(enqueued_gcodes[0].line == "G1");
+    REQUIRE(enqueued_gcodes[0].lastSuccessfulFileOffset == 3);
+    REQUIRE(enqueued_gcodes[1].line == "G2 ");
+    REQUIRE(enqueued_gcodes[1].lastSuccessfulFileOffset == 21);
+}


### PR DESCRIPTION
This PR contains a generic and simple read buffering (RDbuf) and a generic filtering class (GCodeInputFilter).
Both classes need parametrization of important functionality:
- the instance of RDbuf needs to know how to fetch input data
- the instance of GCodeInputFilter needs to know how enqueue filtered G-code commands

Design concerns (over previous implementation of media_loop() in media.cpp):
- handle long comment lines correctly, even if they contain G-code commands -> filter these lines out, avoid sending them into Marlin
- detect long G-code lines and stop printing in such a case avoiding damage to the machine - need to discuss this, marked with '@@TODO'
- avoid FS operations for short chunks of data - ideally read the whole block/sector into RAM -> buffering, avoid f_gets()
- make the processing/filtering generic to enable unit testing

Compared to previous state of art this implementation needs an additional read buffer of 64B long (can be any number)

BFW-1264, BFW-1159, BFW-1161, BFW-1162