### PR TITLE
GUI: Fix calculation of menu rect height

### DIFF
--- a/src/gui/dialogs/window_dlg_preheat.cpp
+++ b/src/gui/dialogs/window_dlg_preheat.cpp
@@ -42,7 +42,7 @@ using ScreenNoRet = ScreenMenu<EHeader::Off, EFooter::On,
 template <class T>
 FILAMENT_t make_preheat_dialog(string_view_utf8 caption) {
     set_last_preheated_filament(FILAMENT_NONE);
-    T dlg(caption, Screens::Access()->Get(), GuiDefaults::RectScreenBody);
+    T dlg(caption, Screens::Access()->Get());
     create_blocking_dialog_from_normal_window(dlg);
     return get_last_preheated_filament();
 }

--- a/src/gui/screen_menu.cpp
+++ b/src/gui/screen_menu.cpp
@@ -5,10 +5,10 @@
 
 string_view_utf8 IScreenMenu::no_label = string_view_utf8::MakeCPUFLASH((const uint8_t *)no_labelS);
 
-IScreenMenu::IScreenMenu(window_t *parent, string_view_utf8 label, Rect16 menu_item_rect, EFooter FOOTER)
+IScreenMenu::IScreenMenu(window_t *parent, string_view_utf8 label, EFooter FOOTER)
     : AddSuperWindow<screen_t>(parent, GuiDefaults::RectScreen, parent != nullptr ? win_type_t::dialog : win_type_t::normal)
     , header(this)
-    , menu(this, menu_item_rect, nullptr)
+    , menu(this, FOOTER == EFooter::On ? GuiDefaults::RectScreenBody : GuiDefaults::RectScreenBodyNoFoot, nullptr)
     , footer(this) {
 
     header.SetText(label);

--- a/src/gui/screen_menu.hpp
+++ b/src/gui/screen_menu.hpp
@@ -26,7 +26,7 @@ protected:
     status_footer_t footer;
 
 public:
-    IScreenMenu(window_t *parent, string_view_utf8 label, Rect16 menu_item_rect, EFooter FOOTER);
+    IScreenMenu(window_t *parent, string_view_utf8 label, EFooter FOOTER);
     void unconditionalDrawItem(uint8_t index);
 };
 
@@ -37,7 +37,7 @@ protected:
     WinMenuContainer<T...> container;
 
 public:
-    ScreenMenu(string_view_utf8 label, window_t *parent = nullptr, Rect16 menu_item_rect = GuiDefaults::RectScreenBody);
+    ScreenMenu(string_view_utf8 label, window_t *parent = nullptr);
 
     //compiletime access by index
     template <std::size_t I>
@@ -52,8 +52,8 @@ public:
 };
 
 template <EHeader HEADER, EFooter FOOTER, class... T>
-ScreenMenu<HEADER, FOOTER, T...>::ScreenMenu(string_view_utf8 label, window_t *parent, Rect16 menu_item_rect)
-    : AddSuperWindow<IScreenMenu>(parent, label, menu_item_rect, FOOTER) {
+ScreenMenu<HEADER, FOOTER, T...>::ScreenMenu(string_view_utf8 label, window_t *parent)
+    : AddSuperWindow<IScreenMenu>(parent, label, FOOTER) {
     menu.pContainer = &container;
     menu.GetActiveItem()->SetFocus(); //set focus on new item//containder was not valid during construction, have to set its index again
 }


### PR DESCRIPTION
Parameter 'menu_rect_item' in ScreenMenu constructor was not used -> it's default value was set each time menu was created. This default value is not correct in all cases. When FOOTER is hidden, menu rect should reach to the bottom of the display.

This effect all menus that doesn't have footer (scrollbar will not stop 30px before the bottom and probably one more menu item can fit in those menus)