### PR TITLE
Fix rendering Live-Adj-Z dlg

### DIFF
--- a/src/gui/dialogs/liveadjust_z.cpp
+++ b/src/gui/dialogs/liveadjust_z.cpp
@@ -203,7 +203,7 @@ LiveAdjustZ::LiveAdjustZ()
 
     /// title text
     constexpr static const char *txt = N_("Adjust the nozzle height above the heatbed by turning the knob");
-    static const string_view_utf8 text_view = _(txt);
+    const string_view_utf8 text_view = _(txt);
     text.SetText(text_view);
     text.SetPadding({ 20, 5, 0, 0 });
 
@@ -212,7 +212,7 @@ LiveAdjustZ::LiveAdjustZ()
 }
 
 const Rect16 LiveAdjustZ::getTextRect() {
-    return Rect16(0, 32, 240, 60);
+    return Rect16(0, 32, 240, 4 * 18); // make space for 4 rows of text rendered with 18px font
 }
 
 const Rect16 LiveAdjustZ::getNozzleRect() {

--- a/src/gui/dialogs/liveadjust_z.cpp
+++ b/src/gui/dialogs/liveadjust_z.cpp
@@ -191,6 +191,8 @@ void WindowLiveAdjustZ_withText::windowEvent(EventLock /*has private ctor*/, win
 /*****************************************************************************/
 //LiveAdjustZ
 
+static constexpr const padding_ui8_t textPadding = { 10, 5, 0, 0 };
+
 LiveAdjustZ::LiveAdjustZ()
     : AddSuperWindow<IDialog>(GuiDefaults::RectScreenBody)
     , text(this, getTextRect(), is_multiline::yes, is_closed_on_click_t::no)
@@ -202,17 +204,16 @@ LiveAdjustZ::LiveAdjustZ()
     flags.close_on_click = is_closed_on_click_t::yes;
 
     /// title text
-    constexpr static const char *txt = N_("Adjust the nozzle height above the heatbed by turning the knob");
-    const string_view_utf8 text_view = _(txt);
-    text.SetText(text_view);
-    text.SetPadding({ 20, 5, 0, 0 });
+    text.SetText(_("Adjust the nozzle height above the heatbed by turning the knob"));
+    text.SetPadding(textPadding);
 
     /// set right position of the nozzle for our value
     moveNozzle();
 }
 
 const Rect16 LiveAdjustZ::getTextRect() {
-    return Rect16(0, 32, 240, 4 * 18); // make space for 4 rows of text rendered with 18px font
+    // make space for 4 rows of text rendered with the default GUI font
+    return Rect16(0, 32, 240, 4 * GuiDefaults::Font->h + textPadding.bottom + textPadding.top);
 }
 
 const Rect16 LiveAdjustZ::getNozzleRect() {


### PR DESCRIPTION
2 issues:
- text was incorrectly set just once according to then valid language, any further language changes weren't reflected
- text had only space for 3 rows while all translations require 4 rows (incl. EN)

BFW-1681