### PR TITLE
Add #define to support moving serial to UART1

### DIFF
--- a/lib/Arduino_Core_A3ides/cores/arduino/HardwareSerial.h
+++ b/lib/Arduino_Core_A3ides/cores/arduino/HardwareSerial.h
@@ -5,6 +5,11 @@
 #include <inttypes.h>
 #include "Stream.h"
 
+// Changes the serial output to UART1 TX/RX.
+// Note you also need to change the marlin serial
+// port from -1 to 1 in the marlin config.
+//#define USE_UART1_SERIAL
+
 class HardwareSerial : public Stream {
 public:
     HardwareSerial(void *peripheral);
@@ -18,6 +23,23 @@ public:
     virtual size_t write(const uint8_t *buffer, size_t size);
     operator bool();
 };
+
+#ifdef USE_UART1_SERIAL
+// Route to USART1 instead of USB
+class HardwareSerial2 : public Stream {
+public:
+    HardwareSerial2(void *p) {};
+    void begin(unsigned long baud);
+    virtual int available(void);
+    virtual int peek(void) { return -1; };
+    virtual int read(void);
+    virtual void flush(void);
+    virtual size_t write(uint8_t);
+    virtual size_t write(uint8_t *buffer, size_t size);
+    operator bool() { return true; };
+};
+extern HardwareSerial2 SerialUART1;
+#endif
 
 extern HardwareSerial Serial3;
 

--- a/src/common/hardware_serial.cpp
+++ b/src/common/hardware_serial.cpp
@@ -1,6 +1,7 @@
 //HardwareSerial.cpp - A3ides/STM32
 #include <Arduino.h>
 #include "buffered_serial.hpp"
+#include "HardwareSerial.h"
 #include "cmsis_os.h"
 #include "bsod.h"
 
@@ -46,5 +47,50 @@ size_t HardwareSerial::write(const uint8_t *buffer, size_t size) {
 HardwareSerial::operator bool() {
     return true;
 }
+
+#ifdef USE_UART1_SERIAL
+
+extern "C" {
+extern UART_HandleTypeDef huart1;
+}
+
+void HardwareSerial2::begin(unsigned long baud) {
+    // Do nothing, the MX_UART_Init() function takes care of this.
+}
+
+int HardwareSerial2::read(void) {
+    if (huart1.Instance->SR & UART_FLAG_RXNE)
+        return huart1.Instance->DR;
+    else
+        return -1;
+}
+
+int HardwareSerial2::available() {
+    return (huart1.Instance->SR & UART_FLAG_RXNE) > 0;
+}
+
+void HardwareSerial2::flush() {
+    // Nothing to do here, the TX is blocking.
+}
+
+size_t HardwareSerial2::write(uint8_t c) {
+    if (HAL_UART_Transmit(&huart1, &c, 1, HAL_MAX_DELAY) == HAL_OK) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+size_t HardwareSerial2::write(uint8_t *buffer, size_t size) {
+    if (HAL_UART_Transmit(&huart1, buffer, size, HAL_MAX_DELAY) == HAL_OK) {
+        return size;
+    } else {
+        return 0;
+    }
+}
+
+HardwareSerial2 SerialUART1(USART1);
+
+#endif // SERIAL_PORT == 1
 
 HardwareSerial Serial3(USART3);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@
 #include "usb_device.h"
 #include "usb_host.h"
 #include "buffered_serial.hpp"
+#include "HardwareSerial.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -96,8 +97,11 @@ TIM_HandleTypeDef htim1;
 TIM_HandleTypeDef htim2;
 TIM_HandleTypeDef htim3;
 TIM_HandleTypeDef htim14;
-
+#ifdef USE_UART1_SERIAL
+UART_HandleTypeDef huart1;
+#else
 static UART_HandleTypeDef huart1;
+#endif
 UART_HandleTypeDef huart2;
 UART_HandleTypeDef huart6;
 DMA_HandleTypeDef hdma_usart1_rx;
@@ -228,9 +232,11 @@ int main(void) {
 
     buddy::hw::BufferedSerial::uart2.Open();
 
+#ifndef USE_UART1_SERIAL
     uartrxbuff_init(&uart1rxbuff, &huart1, &hdma_usart1_rx, sizeof(uart1rx_data), uart1rx_data);
     HAL_UART_Receive_DMA(&huart1, uart1rxbuff.buffer, uart1rxbuff.buffer_size);
     uartrxbuff_reset(&uart1rxbuff);
+#endif
 
     uartrxbuff_init(&uart6rxbuff, &huart6, &hdma_usart6_rx, sizeof(uart6rx_data), uart6rx_data);
     HAL_UART_Receive_DMA(&huart6, uart6rxbuff.buffer, uart6rxbuff.buffer_size);


### PR DESCRIPTION
This adds an alternate wiring option to route the serial output from USB to UART1 (the TX/RX pins on the white 10 pin header)

To use:
- #define (uncomment) `USE_UART1_SERIAL` in `HardwareSerial.h`
- Change `SERIAL_PORT` from `-1` to `1` in `Configuration_A3ides_2209_MINI.h`