### PR TITLE
GUI layout

### DIFF
--- a/src/common/bsod.cpp
+++ b/src/common/bsod.cpp
@@ -191,7 +191,7 @@ void general_error(const char *error, const char *module) {
     display::DrawLine(point_ui16(PADDING, 30), point_ui16(display::GetW() - 1 - PADDING, 30), COLOR_WHITE);
 
     addFormatText(buffer, buffer_size, buffer_pos, "%s\n", module);
-    display::DrawText(Rect16(PADDING, 60, 240, 260), string_view_utf8::MakeCPUFLASH((const uint8_t *)buffer), GuiDefaults::Font, COLOR_RED_ALERT, COLOR_WHITE, RENDER_FLG_WORDB);
+    render_text_align(Rect16(PADDING, 60, 240, 260), string_view_utf8::MakeCPUFLASH((const uint8_t *)buffer), GuiDefaults::Font, COLOR_RED_ALERT, COLOR_WHITE, { 0, 0, 0, 0 }, RENDER_FLG_WORDB);
 
     static const char rp[] = "RESET PRINTER"; // intentionally not translated yet
     render_text_align(Rect16(PADDING, 260, X_MAX, 30), string_view_utf8::MakeCPUFLASH((const uint8_t *)rp), GuiDefaults::Font,
@@ -261,7 +261,7 @@ void draw_error_screen(const uint16_t error_code_short) {
         /// draw header & main text
         display::DrawText(Rect16(13, 12, display::GetW() - 13, display::GetH() - 12), _(text_title), GuiDefaults::Font, COLOR_RED_ALERT, COLOR_WHITE);
         display::DrawLine(point_ui16(10, 33), point_ui16(229, 33), COLOR_WHITE);
-        display::DrawText(Rect16(PADDING, 31 + PADDING, X_MAX, 220), _(text_body), GuiDefaults::Font, COLOR_RED_ALERT, COLOR_WHITE, RENDER_FLG_WORDB);
+        render_text_align(Rect16(PADDING, 31 + PADDING, X_MAX, 220), _(text_body), GuiDefaults::Font, COLOR_RED_ALERT, COLOR_WHITE, { 0, 0, 0, 0 }, RENDER_FLG_WORDB);
 
         /// draw "Hand QR" icon
         render_icon_align(Rect16(20, 165, 64, 82), IDR_PNG_hand_qr, COLOR_RED_ALERT, 0);
@@ -461,7 +461,7 @@ void _bsod(const char *fmt, const char *file_name, int line_number, ...) {
     for (StackType_t *i = pTopOfStack; i != lastAddr; --i) {
         addFormatNum(buffer, buffer_size, buffer_pos, "%08x  ", (uint32_t)*i);
     }
-    display::DrawText(Rect16(10, 10, 230, 290), string_view_utf8::MakeCPUFLASH((const uint8_t *)buffer), resource_font(IDR_FNT_SMALL), COLOR_NAVY, COLOR_WHITE, RENDER_FLG_WORDB);
+    render_text_align(Rect16(10, 10, 230, 290), string_view_utf8::MakeCPUFLASH((const uint8_t *)buffer), resource_font(IDR_FNT_SMALL), COLOR_NAVY, COLOR_WHITE, { 0, 0, 0, 0 }, RENDER_FLG_WORDB);
     display::DrawText(Rect16(10, 290, 220, 20), string_view_utf8::MakeCPUFLASH((const uint8_t *)project_version_full), resource_font(IDR_FNT_NORMAL), COLOR_NAVY, COLOR_WHITE);
 
     #endif
@@ -743,7 +743,7 @@ void ScreenHardFault(void) {
         addFormatNum(buffer, buffer_size, buffer_pos, "0x%08x ", sp);
     }
 
-    display::DrawText(Rect16(8, 10, 232, 290), string_view_utf8::MakeCPUFLASH((const uint8_t *)buffer), resource_font(IDR_FNT_SMALL), COLOR_NAVY, COLOR_WHITE, RENDER_FLG_WORDB);
+    render_text_align(Rect16(8, 10, 232, 290), string_view_utf8::MakeCPUFLASH((const uint8_t *)buffer), resource_font(IDR_FNT_SMALL), COLOR_NAVY, COLOR_WHITE, { 0, 0, 0, 0 }, RENDER_FLG_WORDB);
     display::DrawText(Rect16(8, 290, 220, 20), string_view_utf8::MakeCPUFLASH((const uint8_t *)project_version_full), resource_font(IDR_FNT_SMALL), COLOR_NAVY, COLOR_WHITE);
 }
 

--- a/src/common/str_utils.hpp
+++ b/src/common/str_utils.hpp
@@ -26,10 +26,18 @@ int str2multilineUnicode(uint32_t *str, size_t max_size, const size_t line_width
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
-/// Emulate font with the constant character width
+/// Emulate font with the constant character width == 12
 ///
 struct monospace {
-    const uint32_t w = 12;
+    static constexpr uint32_t w = 12;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Emulate font with the constant character width == 1
+///
+struct font_emulation_w1 {
+    static constexpr size_t w = 1;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -100,6 +108,53 @@ struct ram_buffer {
 
 private:
     word_buffer *p_word_buffer_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// numbers of characters in lines
+class RectTextLayout {
+public:
+    static constexpr size_t MaxLines = 31;
+    static constexpr uint8_t MaxCharInLine = 255;     //uint8_t
+    using Data_t = std::array<uint8_t, MaxLines + 1>; // last elem stores current line
+private:
+    Data_t data;
+    uint8_t currentLine() const { return data[MaxLines]; }
+
+public:
+    RectTextLayout() {
+        data.fill(0);
+    }
+
+    uint8_t LineCharacters(uint8_t line) const {
+        return data[line];
+    }
+
+    uint8_t CurrentLineCharacters() const {
+        return LineCharacters(currentLine());
+    }
+
+    uint8_t GetLineCount() const {
+        return CurrentLineCharacters() == 0 ? currentLine() : currentLine() + 1;
+    }
+
+    //increment number of lines
+    bool NewLine() {
+        if (currentLine() >= MaxLines)
+            return false;
+        data[MaxLines] += 1;
+        return true;
+    }
+
+    bool IncrementNumOfCharsUpTo(uint8_t max_val) {
+        if (currentLine() >= MaxLines)
+            return false;
+        if (CurrentLineCharacters() >= max_val)
+            return false;
+        data[currentLine()] += 1;
+        return true;
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/guiapi/include/Rect16.h
+++ b/src/guiapi/include/Rect16.h
@@ -496,6 +496,22 @@ public:
 		 * @param[in] ratio[] ratio of wanted splits (optional = nullptr)
 		 */
     void VerticalSplit(Rect16 splits[], Rect16 spaces[], const size_t count, const uint16_t spacing = 0, uint8_t ratio[] = nullptr) const;
+
+    /**
+     * @brief Line operation substracts subtrahend
+     * Top and Height is ignored
+     * @param subtrahend the rect that is to be subtracted.
+     * @return Rect16 front part of original rect after substraction
+     */
+    Rect16 LeftSubrect(Rect16 subtrahend);
+
+    /**
+     * @brief Line operation substracts subtrahend
+     * Top and Height is ignored
+     * @param subtrahend the rect that is to be subtracted.
+     * @return Rect16 tail part of original rect after substraction
+     */
+    Rect16 RightSubrect(Rect16 subtrahend);
 };
 
 ////////////////////////////////////////////////////////////////////////////

--- a/src/guiapi/include/display.h
+++ b/src/guiapi/include/display.h
@@ -20,7 +20,7 @@ typedef void(display_fill_rect_t)(Rect16 rc, color_t clr);
 /// @param charX x-coordinate of character (glyph) in font bitmap (remember, fonts are bitmaps 16 chars wide and arbitrary lines of chars tall)
 /// @param charY y-coordinate of character (glyph) in font bitmap
 typedef bool(display_draw_char_t)(point_ui16_t pt, uint8_t charX, uint8_t charY, const font_t *pf, color_t clr_bg, color_t clr_fg);
-typedef size_ui16_t(display_draw_text_t)(Rect16 rc, string_view_utf8 str, const font_t *pf, color_t clr_bg, color_t clr_fg, uint16_t flags);
+typedef size_ui16_t(display_draw_text_t)(Rect16 rc, string_view_utf8 str, const font_t *pf, color_t clr_bg, color_t clr_fg);
 typedef void(display_draw_icon_t)(point_ui16_t pt, uint16_t id_res, color_t clr0, uint8_t rop);
 typedef void(display_draw_png_t)(point_ui16_t pt, FILE *pf);
 
@@ -56,8 +56,8 @@ public:
         // ... and also because doing it in C++ is much easier than in plain C
         uint8_t charX = 15, charY = 1;
 
-        if (c < pf->asc_min) { // this really happens with non-utf8 characters on filesystems
-            c = '?';           // substitute with a '?' or any other suitable character, which is in the range of the fonts
+        if (c < uint8_t(pf->asc_min)) { // this really happens with non-utf8 characters on filesystems
+            c = '?';                    // substitute with a '?' or any other suitable character, which is in the range of the fonts
         }
         // here is intentionally no else
         if (c < 128) {
@@ -84,7 +84,7 @@ public:
     /// \param rc rectangle where text will be placed
     /// \param flags if RENDER_FLG_WORDB is set, the text is wrapped to fit the rectangle,
     /// otherwise, the first line (until \0 or \n) will be drawn only.
-    static size_ui16_t DrawText(Rect16 rc, string_view_utf8 str, const font_t *pf, color_t clr_bg, color_t clr_fg, uint16_t flags = 0) { return DRAW_TEXT(rc, str, pf, clr_bg, clr_fg, flags); }
+    static size_ui16_t DrawText(Rect16 rc, string_view_utf8 str, const font_t *pf, color_t clr_bg, color_t clr_fg) { return DRAW_TEXT(rc, str, pf, clr_bg, clr_fg); }
     constexpr static void DrawIcon(point_ui16_t pt, uint16_t id_res, color_t clr0, uint8_t rop) { DRAW_ICON(pt, id_res, clr0, rop); }
     constexpr static void DrawPng(point_ui16_t pt, FILE *pf) { DRAW_PNG(pt, pf); }
 };
@@ -100,6 +100,6 @@ using display = Display<ST7789V_COLS, ST7789V_ROWS,
     display_ex_draw_rect,
     display_ex_fill_rect,
     display_ex_draw_charUnicode,
-    render_text,
+    render_text_singleline,
     display_ex_draw_icon,
     display_ex_draw_png>;

--- a/src/guiapi/include/display_helper.h
+++ b/src/guiapi/include/display_helper.h
@@ -10,7 +10,7 @@ static const uint16_t RENDER_FLG_ROPFN = 0x0f00; // raster operation function ma
 static const uint16_t RENDER_FLG_WORDB = 0x1000; // multiline text
 #define RENDER_FLG(a, r) (a | r << 8)            // render flag macro (ALIGN and ROPFN)
 
-extern size_ui16_t render_text(Rect16 rc, string_view_utf8 str, const font_t *pf, color_t clr_bg, color_t clr_fg, uint16_t flags);
+extern size_ui16_t render_text_singleline(Rect16 rc, string_view_utf8 str, const font_t *pf, color_t clr_bg, color_t clr_fg);
 /// FIXME add \param flags documentation
 extern void render_text_align(Rect16 rc, string_view_utf8 text, const font_t *font, color_t clr0, color_t clr1, padding_ui8_t padding, uint16_t flags);
 extern void render_icon_align(Rect16 rc, uint16_t id_res, color_t clr0, uint16_t flags);

--- a/src/guiapi/src/Rect16.cpp
+++ b/src/guiapi/src/Rect16.cpp
@@ -81,6 +81,8 @@ Rect16::Rect16(point_i16_t top_left, size_ui16_t s)
 }
 
 Rect16 Rect16::Intersection(Rect16 const &r) const {
+    if (IsEmpty() || r.IsEmpty())
+        return Rect16(0, 0, 0, 0);
     point_i16_t top_left;
     point_i16_t bot_right;
 
@@ -133,7 +135,7 @@ Rect16 Rect16::Union(Rect16 const &r) const {
 }
 
 bool Rect16::HasIntersection(Rect16 const &r) const {
-    if (r.IsEmpty())
+    if (IsEmpty() || r.IsEmpty())
         return false;
     return TopLeft().x < r.EndPoint().x
         && EndPoint().x > r.TopLeft().x
@@ -241,4 +243,33 @@ void Rect16::VerticalSplit(Rect16 splits[], Rect16 spaces[], const size_t count,
     if (final_height < Height()) {
         splits[count - 1].height_ += Height() - final_height;
     }
+}
+
+Rect16 Rect16::LeftSubrect(Rect16 subtrahend) {
+    Rect16 ret = *this;
+    if (subtrahend.Left() < Left()) {
+        ret = Width_t(0);
+        return ret;
+    }
+
+    if (subtrahend.Left() >= (Left() + Width())) {
+        return ret;
+    }
+
+    ret = Width_t(subtrahend.Left() - ret.Left());
+    return ret;
+}
+
+Rect16 Rect16::RightSubrect(Rect16 subtrahend) {
+    Rect16 ret = *this;
+
+    if (subtrahend.Left() + subtrahend.Width() >= Left() + Width()) {
+        ret = Width_t(0);
+        return ret;
+    }
+
+    ret = Left_t(subtrahend.Left() + subtrahend.Width());
+    ret -= Width_t(subtrahend.Left() - Left());
+    ret -= subtrahend.Width();
+    return ret;
 }

--- a/src/guiapi/src/text_roll.cpp
+++ b/src/guiapi/src/text_roll.cpp
@@ -114,7 +114,7 @@ void txtroll_t::renderTextAlign(Rect16 rc, string_view_utf8 text, const font_t *
 
     if (!set_txt_rc.IsEmpty()) {
         fill_between_rectangles(&rc, &set_txt_rc, clr_back);
-        render_text(set_txt_rc, /*str*/ text, font, clr_back, clr_text, 0);
+        render_text_singleline(set_txt_rc, /*str*/ text, font, clr_back, clr_text);
     } else {
         display::FillRect(rc, clr_back);
     }


### PR DESCRIPTION
* fix rectangle intersection (was cutting some letters by 1 pixel)

* remove flags from render_text (remove multiline support from basic display api)

* new multiline loop counting characters in lines

* fix multiline text align