### PR TITLE
Remove unnecessary formatting from texts/translations

### DIFF
--- a/src/gui/wizard/firstlay.cpp
+++ b/src/gui/wizard/firstlay.cpp
@@ -105,10 +105,10 @@ WizardState_t StateFnc_FIRSTLAY_MSBX_USEVAL() {
     //show dialog only when values are not equal
     float diff = marlin_vars()->z_offset - z_offset_def;
     if ((diff <= -z_offset_step) || (diff >= z_offset_step)) {
-        char buff[21 * 7];
+        char buff[21 * 9];
         {
-            char fmt[21 * 7];
-            // c=21 r=7
+            char fmt[21 * 9];
+            // c=21 r=9
             static const char fmt2Translate[] = N_("Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)");
             _(fmt2Translate).copyToRAM(fmt, sizeof(fmt)); // note the underscore at the beginning of this line
             snprintf(buff, sizeof(buff) / sizeof(char), fmt, (double)marlin_vars()->z_offset, (double)z_offset_def);

--- a/src/gui/wizard/firstlay.cpp
+++ b/src/gui/wizard/firstlay.cpp
@@ -105,10 +105,10 @@ WizardState_t StateFnc_FIRSTLAY_MSBX_USEVAL() {
     //show dialog only when values are not equal
     float diff = marlin_vars()->z_offset - z_offset_def;
     if ((diff <= -z_offset_step) || (diff >= z_offset_step)) {
-        char buff[20 * 7];
+        char buff[21 * 7];
         {
-            char fmt[20 * 7];
-            // c=20 r=6
+            char fmt[21 * 7];
+            // c=21 r=7
             static const char fmt2Translate[] = N_("Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)");
             _(fmt2Translate).copyToRAM(fmt, sizeof(fmt)); // note the underscore at the beginning of this line
             snprintf(buff, sizeof(buff) / sizeof(char), fmt, (double)marlin_vars()->z_offset, (double)z_offset_def);

--- a/src/lang/po/cs/Prusa-Firmware-Buddy_cs.po
+++ b/src/lang/po/cs/Prusa-Firmware-Buddy_cs.po
@@ -172,7 +172,7 @@ msgstr "Chcete zopakovat poslední krok a upravit nastavení vzdálenosti mezi t
 #: src/gui/wizard/firstlay.cpp:112
 #, c-format
 msgid "Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)"
-msgstr "Chcete použít aktuální hodnotu?\nAktuální: %0.3f.\nVýchozí: %03.f.\nZvolením NE vyberete výchozí hodnotu (doporučeno)"
+msgstr "Chcete použít aktuální hodnotu?\nAktuální: %0.3f.\nVýchozí: %0.3f.\nZvolením NE vyberete výchozí hodnotu (doporučeno)"
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:27
 msgid "Ejecting"

--- a/src/lang/po/de/Prusa-Firmware-Buddy_de.po
+++ b/src/lang/po/de/Prusa-Firmware-Buddy_de.po
@@ -25,7 +25,7 @@ msgstr "Abbruch"
 #. / title text
 #: src/gui/dialogs/liveadjust_z.cpp:205
 msgid "Adjust the nozzle height above the heatbed by turning the knob"
-msgstr "Stellen Sie die Düsenhöhe über dem Heizbett durch Drehen des Knopfes ein"
+msgstr "Stellen Sie die Düsenhöhe zum Heiz- bett durch drehen des Knopfes ein"
 
 #: src/gui/wizard/selftest.cpp:43
 msgid "All tests finished successfully!"
@@ -96,26 +96,26 @@ msgstr "Filament wechseln"
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:44
 msgid "Check the heatbed heater & thermistor wiring for possible damage."
-msgstr "Die Verkabelung von\nHeizbettheizung und\nThermistor auf\nmögliche Schäden\nprüfen."
+msgstr "Die Verkabelung von Heizbettheizung und Thermistor auf mögliche Schäden prüfen."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:56
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:68
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:80
 msgid "Check the heatbed thermistor wiring for possible damage."
-msgstr "Die Verkabelung des\nHeizbettthermistors\nauf mögliche Schäden\nprüfen."
+msgstr "Die Verkabelung des Heizbettthermistors auf mögliche Schäden prüfen."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:50
 msgid "Check the print head heater & thermistor wiring for possible damage."
-msgstr "Die Verkabelung der\nDruckkopfheizung und\ndes Thermistors auf\nmögliche Schäden\nprüfen."
+msgstr "Die Verkabelung der Druckkopfheizung und des Thermistors auf mögliche Schäden prüfen."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:62
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:74
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:86
 msgid "Check the print head thermistor wiring for possible damage."
-msgstr "Die Verkabelung des\nDruckkopf-Thermistor\nauf mögliche Schäden\nprüfen."
+msgstr "Die Verkabelung des Druckkopf-Thermistor auf mögliche Schäden prüfen."
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:42
 #: src/gui/dialogs/DialogSelftestAxis.cpp:18
@@ -952,7 +952,7 @@ msgstr "Dieser G-Code ist für einen anderen Druckertyp."
 #. window_menu
 #: src/guiapi/src/MItem_tools.cpp:185
 msgid "This operation can't be undone, current configuration will be lost! Are you really sure to reset printer to factory defaults?"
-msgstr "Diese Operation kann\nnicht rückgängig ge-\nmacht werden und die\naktuelle Konfiguration\ngeht verloren!\nDen Drucker auf die\nWerkseinstellungen\nzurücksetzen?"
+msgstr "Diese Operation kann nicht rückgängig ge- macht werden und die aktuelle Konfiguration geht verloren! Den Drucker auf die Werkseinstellungen zurücksetzen?"
 
 #. abbreviated Thursday - max 3 characters
 #: src/lang/format_print_will_end.cpp:51

--- a/src/lang/po/es/Prusa-Firmware-Buddy_es.po
+++ b/src/lang/po/es/Prusa-Firmware-Buddy_es.po
@@ -243,7 +243,7 @@ msgstr "Sensor fil."
 #. clang-format off
 #: src/gui/dialogs/DialogG162.cpp:8 src/gui/dialogs/DialogLoadUnload.cpp:14
 msgid "Finishing buffered gcodes."
-msgstr "Finalizando \nCod. G en memoria.\n"
+msgstr "Finalizando Cod. G en memoria."
 
 #. r=1 c=20
 #: src/gui/screen_menu_version_info.cpp:60
@@ -360,11 +360,11 @@ msgstr "Las direcciones IP o los parámetros no son válidos o el archivo \"lan_
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Is color correct?"
-msgstr "¿Está bien\nel color?"
+msgstr "¿Está bien el color?"
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:26
 msgid "Is filament in extruder gear?"
-msgstr "¿Está el filamento \nen los engranajes \ndel extrusor?"
+msgstr "¿Está el filamento en los engranajes del extrusor?"
 
 #: src/gui/wizard/xyzcalib.cpp:47 src/gui/wizard/xyzcalib.cpp:240
 msgid "Is steel sheet on heatbed?"
@@ -413,7 +413,7 @@ msgstr "Cargando..."
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:28
 msgid "Loading to nozzle"
-msgstr "Cargando     \na la boquilla"
+msgstr "Cargando a la boquilla"
 
 #: src/guiapi/include/MItem_tools.hpp:305
 msgid "Loud"
@@ -425,7 +425,7 @@ msgstr "M.I.N.D.A."
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:24
 msgid "Make sure the filament is inserted through the sensor."
-msgstr "Asegúrate que     \nfilamento está    \ninsertado a través\ndel sensor.       "
+msgstr "Asegúrate que filamento está insertado a través del sensor."
 
 #: src/gui/screen_print_preview.cpp:128
 msgid "Material"
@@ -640,7 +640,7 @@ msgstr "Preparando para expulsar"
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:23
 msgid "Press CONTINUE and push filament into the extruder."
-msgstr "Presiona CONTINUAR\ny empuja el       \nfilamento en      \nel extrusor.      "
+msgstr "Presiona CONTINUAR y empuja el filamento en el extrusor."
 
 #: src/gui/wizard/screen_wizard.cpp:185
 msgid "Press NEXT to run the Selftest, which checks for potential issues related to the assembly."
@@ -790,7 +790,7 @@ msgstr "SELECC. IDIOMA"
 
 #: src/gui/screen_menu_fw_update.cpp:74
 msgid "Select when you want to automatically flash updated firmware from USB flash disk."
-msgstr "Selecciona donde\nquieres flashear\nautomáticamente\nel firmware\nactualizado desde\nuna memoria USB."
+msgstr "Selecciona donde quieres flashear automáticamente el firmware actualizado desde una memoria USB."
 
 #: src/guiapi/include/MItem_tools.hpp:49
 msgid "SelfTest"

--- a/src/lang/po/fr/Prusa-Firmware-Buddy_fr.po
+++ b/src/lang/po/fr/Prusa-Firmware-Buddy_fr.po
@@ -253,11 +253,11 @@ msgstr "Version Firmware\n"
 #: src/gui/screen_menu_steel_sheets.cpp:46 src/gui/ScreenFirstLayer.hpp:12
 #: src/guiapi/include/MItem_tools.hpp:69
 msgid "First Layer Calibration"
-msgstr "Calibration\nPremière Couche"
+msgstr "Calibration Première Couche"
 
 #: src/gui/wizard/screen_wizard.cpp:31
 msgid "FIRST LAYER CALIBRATION"
-msgstr "CALIBRATION\nPREMIÈRE COUCHE"
+msgstr "CALIBRATION PREMIÈRE COUCHE"
 
 #: src/guiapi/include/MItem_print.hpp:40
 msgid "Flow Factor"
@@ -592,7 +592,7 @@ msgstr "Veuillez insérer la clé USB fournie avec votre MINI et redémarrez l'i
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:22
 msgid "Please open idler and remove filament manually"
-msgstr "Ouvrez l'idler et\nretirez le filament\nmanuellement"
+msgstr "Ouvrez l'idler et retirez le filament manuellement"
 
 #: src/gui/wizard/xyzcalib.cpp:85 src/gui/wizard/xyzcalib.cpp:273
 msgid "Please place steel sheet on heatbed."
@@ -778,7 +778,7 @@ msgstr "Sélectionner"
 
 #: src/gui/wizard/firstlay.cpp:71
 msgid "Select Filament Type"
-msgstr "Sélectionner\nle Type de Filament"
+msgstr "Sélectionner le Type de Filament"
 
 #: src/gui/screen_filebrowser.cpp:42
 msgid "SELECT FILE"

--- a/src/lang/po/pl/Prusa-Firmware-Buddy_pl.po
+++ b/src/lang/po/pl/Prusa-Firmware-Buddy_pl.po
@@ -640,7 +640,7 @@ msgstr "Przygotowywanie do wyciskania"
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:23
 msgid "Press CONTINUE and push filament into the extruder."
-msgstr "Naciśnij KONTYNUUJ i wsuń filament do ekstrudera.    "
+msgstr "Naciśnij KONTYNUUJ i wsuń filament do ekstrudera."
 
 #: src/gui/wizard/screen_wizard.cpp:185
 msgid "Press NEXT to run the Selftest, which checks for potential issues related to the assembly."


### PR DESCRIPTION
Matches the new functionality of correct text wrapper and should improve the user experience of rendered text. However, some typographical rules might have been broken since there is no stable support for nonbreakable spaces yet.

Additionally, some more had to be done:
- fix CZ formatting string
- adjust formatting buffer size for first layer calibration dialog