### PR TITLE
Make malloc's lock recursive

### DIFF
--- a/src/common/heap.c
+++ b/src/common/heap.c
@@ -85,11 +85,18 @@ void *_sbrk(int incr) { return sbrk(incr); };
 //
 
 static UBaseType_t malloc_saved_interrupt_status;
+static int malloc_lock_counter = 0;
 
 void __malloc_lock(struct _reent *r) {
-    ENTER_CRITICAL_SECTION(malloc_saved_interrupt_status);
+    UBaseType_t interrupt_status;
+    ENTER_CRITICAL_SECTION(interrupt_status);
+    if (malloc_lock_counter == 0)
+        malloc_saved_interrupt_status = interrupt_status;
+    malloc_lock_counter += 1;
 };
 
 void __malloc_unlock(struct _reent *r) {
-    EXIT_CRITICAL_SECTION(malloc_saved_interrupt_status);
+    malloc_lock_counter -= 1;
+    if (malloc_lock_counter == 0)
+        EXIT_CRITICAL_SECTION(malloc_saved_interrupt_status);
 };


### PR DESCRIPTION
As defined here https://sourceware.org/newlib/libc.html#g_t_005f_005fmalloc_005flock, the `__malloc_[un]lock` should act as a recursive lock. It is not clear to me whether this could be/become an issue for us but hey, why not conform to the specification right?