### PR TITLE
safe FSM events (prevent bsod)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,6 +518,7 @@ target_sources(
           src/common/app_metrics.cpp
           src/common/sim_heater.cpp
           src/common/marlin_server.cpp
+          src/common/fsm_types.cpp
           src/common/selftest/selftest_MINI.cpp
           src/common/selftest/selftest_fan.cpp
           src/common/selftest/selftest_axis.cpp

--- a/src/common/client_fsm_types.h
+++ b/src/common/client_fsm_types.h
@@ -101,13 +101,13 @@ enum class WarningType : uint32_t {
 // Open dialog has a parameter because I need to set a caption of change filament dialog (load / unload / change).
 // Use extra state of statemachine to set the caption would be cleaner, but I can miss events.
 // Only the last sent event is guaranteed to pass its data.
-using fsm_cb_t = void (*)(uint32_t); //create/destroy/change finite state machine
+using fsm_cb_t = void (*)(uint32_t, uint16_t); //create/destroy/change finite state machine
 using message_cb_t = void (*)(const char *);
 using warning_cb_t = void (*)(WarningType);
 using startup_cb_t = void (*)(void);
 #else  // !__cplusplus
 //C
-typedef void (*fsm_cb_t)(uint32_t); //create/destroy/change finite state machine
+typedef void (*fsm_cb_t)(uint32_t, uint16_t); //create/destroy/change finite state machine
 typedef void (*message_cb_t)(const char *);
 typedef void (*warning_cb_t)(uint32_t);
 typedef void (*startup_cb_t)(void);

--- a/src/common/client_fsm_types.h
+++ b/src/common/client_fsm_types.h
@@ -20,6 +20,14 @@ enum class ClientFSM : uint8_t {
     _count = _none
 };
 
+enum class ClientFSM_Command : uint8_t {
+    none = 0x00,
+    create = 0x80,
+    destroy = 0x40,
+    change = create | destroy,
+    _mask = change
+};
+
 enum class LoadUnloadMode : uint8_t {
     Change,
     Load,
@@ -93,17 +101,13 @@ enum class WarningType : uint32_t {
 // Open dialog has a parameter because I need to set a caption of change filament dialog (load / unload / change).
 // Use extra state of statemachine to set the caption would be cleaner, but I can miss events.
 // Only the last sent event is guaranteed to pass its data.
-using fsm_create_t = void (*)(ClientFSM, uint8_t);                                               //create finite state machine
-using fsm_destroy_t = void (*)(ClientFSM);                                                       //destroy finite state machine
-using fsm_change_t = void (*)(ClientFSM, uint8_t phase, uint8_t progress_tot, uint8_t progress); //change fsm state or progress
+using fsm_cb_t = void (*)(uint32_t); //create/destroy/change finite state machine
 using message_cb_t = void (*)(const char *);
 using warning_cb_t = void (*)(WarningType);
 using startup_cb_t = void (*)(void);
 #else  // !__cplusplus
 //C
-typedef void (*fsm_create_t)(uint8_t, uint8_t);                                               //create finite state machine
-typedef void (*fsm_destroy_t)(uint8_t);                                                       //destroy finite state machine
-typedef void (*fsm_change_t)(uint8_t, uint8_t phase, uint8_t progress_tot, uint8_t progress); //change fsm state or progress
+typedef void (*fsm_cb_t)(uint32_t); //create/destroy/change finite state machine
 typedef void (*message_cb_t)(const char *);
 typedef void (*warning_cb_t)(uint32_t);
 typedef void (*startup_cb_t)(void);

--- a/src/common/client_response.hpp
+++ b/src/common/client_response.hpp
@@ -76,28 +76,22 @@ enum class PhasesG162 : uint16_t {
 //not bound to responses
 enum class PhasesSelftestFans : uint16_t {
     _first = static_cast<uint16_t>(PhasesLoadUnload::_last) + 1,
-    TestFan0 = _first, //in this case is safe to have TestFan0 == _first //TODO RENAME
-    TestFan1,          //TODO REMOVE
-    _last = TestFan1
+    measure = _first, //in this case is safe to have measure == _first
+    _last = measure
 };
 
 //not bound to responses
 enum class PhasesSelftestAxis : uint16_t {
     _first = static_cast<uint16_t>(PhasesSelftestFans::_last) + 1,
-    Xaxis = _first, //in this case is safe to have Xaxis == _first //TODO RENAME
-    Yaxis,          //TODO REMOVE
-    Zaxis,          //TODO REMOVE
-    _last = Zaxis
+    measure = _first, //in this case is safe to have measure == _first
+    _last = measure
 };
 
 //not bound to responses
 enum class PhasesSelftestHeat : uint16_t {
     _first = static_cast<uint16_t>(PhasesSelftestAxis::_last) + 1,
-    noz_prep = _first, //in this case is safe to have Xaxis == _first //TODO RENAME
-    noz_heat,          //TODO REMOVE
-    bed_prep,          //TODO REMOVE
-    bed_heat,          //TODO REMOVE
-    _last = bed_heat
+    measure = _first, //in this case is safe to have measure == _first
+    _last = measure
 };
 
 //static class for work with fsm responses (like button click)

--- a/src/common/client_response.hpp
+++ b/src/common/client_response.hpp
@@ -76,27 +76,27 @@ enum class PhasesG162 : uint16_t {
 //not bound to responses
 enum class PhasesSelftestFans : uint16_t {
     _first = static_cast<uint16_t>(PhasesLoadUnload::_last) + 1,
-    TestFan0 = _first, //in this case is safe to have TestFan0 == _first
-    TestFan1,
+    TestFan0 = _first, //in this case is safe to have TestFan0 == _first //TODO RENAME
+    TestFan1,          //TODO REMOVE
     _last = TestFan1
 };
 
 //not bound to responses
 enum class PhasesSelftestAxis : uint16_t {
     _first = static_cast<uint16_t>(PhasesSelftestFans::_last) + 1,
-    Xaxis = _first, //in this case is safe to have Xaxis == _first
-    Yaxis,
-    Zaxis,
+    Xaxis = _first, //in this case is safe to have Xaxis == _first //TODO RENAME
+    Yaxis,          //TODO REMOVE
+    Zaxis,          //TODO REMOVE
     _last = Zaxis
 };
 
 //not bound to responses
 enum class PhasesSelftestHeat : uint16_t {
     _first = static_cast<uint16_t>(PhasesSelftestAxis::_last) + 1,
-    noz_prep = _first, //in this case is safe to have Xaxis == _first
-    noz_heat,
-    bed_prep,
-    bed_heat,
+    noz_prep = _first, //in this case is safe to have Xaxis == _first //TODO RENAME
+    noz_heat,          //TODO REMOVE
+    bed_prep,          //TODO REMOVE
+    bed_heat,          //TODO REMOVE
     _last = bed_heat
 };
 

--- a/src/common/fsm_base_types.hpp
+++ b/src/common/fsm_base_types.hpp
@@ -1,0 +1,33 @@
+/**
+ * @file fsm_base_types.hpp
+ * @author Radek Vana
+ * @brief selftest data to be passed between threads
+ * @date 2021-03-01
+ */
+
+#pragma once
+
+#include <array>
+#include <stdint.h>
+
+namespace fsm {
+
+using PhaseData = std::array<uint8_t, 5>;
+
+struct BaseData {
+    std::array<uint8_t, 6> phase_and_data;
+    constexpr uint8_t GetPhase() const { return phase_and_data[0]; }
+    constexpr const uint8_t *Get_pData() const { return phase_and_data.cbegin() + 1; }
+    constexpr void SetPhase(uint8_t phase) { phase_and_data[0] = phase; }
+    void SetData(PhaseData data) { std::copy(data.begin(), data.end(), phase_and_data.begin() + 1); } // std::copy is not const expr until C++20
+
+    constexpr BaseData()
+        : phase_and_data({ {} }) {}
+    constexpr BaseData(uint8_t phase, PhaseData data)
+        : BaseData() {
+        SetPhase(phase);
+        SetData(data);
+    }
+};
+
+};

--- a/src/common/fsm_base_types.hpp
+++ b/src/common/fsm_base_types.hpp
@@ -9,6 +9,7 @@
 
 #include <array>
 #include <stdint.h>
+#include <cstddef> //size_t
 
 namespace fsm {
 #pragma pack(push, 1) // must be packed to fit in variant8
@@ -34,6 +35,12 @@ public:
         : BaseData() {
         SetPhase(phase);
         SetData(data);
+    }
+    constexpr bool operator==(const BaseData &other) const {
+        return GetPhase() == other.GetPhase() && GetData() == other.GetData();
+    }
+    constexpr bool operator!=(const BaseData &other) const {
+        return !((*this) == other);
     }
 };
 static_assert(sizeof(BaseData) == BaseDataSZ, "Wrong size of BaseData");

--- a/src/common/fsm_base_types.hpp
+++ b/src/common/fsm_base_types.hpp
@@ -11,23 +11,32 @@
 #include <stdint.h>
 
 namespace fsm {
+#pragma pack(push, 1) // must be packed to fit in variant8
 
-using PhaseData = std::array<uint8_t, 5>;
+static const size_t BaseDataSZ = 5;
+using PhaseData = std::array<uint8_t, BaseDataSZ - 1>;
 
-struct BaseData {
-    std::array<uint8_t, 6> phase_and_data;
-    constexpr uint8_t GetPhase() const { return phase_and_data[0]; }
-    constexpr const uint8_t *Get_pData() const { return phase_and_data.cbegin() + 1; }
-    constexpr void SetPhase(uint8_t phase) { phase_and_data[0] = phase; }
-    void SetData(PhaseData data) { std::copy(data.begin(), data.end(), phase_and_data.begin() + 1); } // std::copy is not const expr until C++20
+class BaseData {
+
+    PhaseData data;
+    uint8_t phase;
+
+public:
+    constexpr uint8_t GetPhase() const { return phase; }
+    constexpr PhaseData GetData() const { return data; }
+    constexpr void SetPhase(uint8_t ph) { phase = ph; }
+    constexpr void SetData(PhaseData dt) { data = dt; }
 
     constexpr BaseData()
-        : phase_and_data({ {} }) {}
+        : data({ {} })
+        , phase(0) {}
     constexpr BaseData(uint8_t phase, PhaseData data)
         : BaseData() {
         SetPhase(phase);
         SetData(data);
     }
 };
+static_assert(sizeof(BaseData) == BaseDataSZ, "Wrong size of BaseData");
 
+#pragma pack(pop)
 };

--- a/src/common/fsm_progress_type.hpp
+++ b/src/common/fsm_progress_type.hpp
@@ -1,0 +1,33 @@
+/**
+ * @file fsm_progress_type.hpp
+ * @author Radek Vana
+ * @brief progress data to be passed between threads
+ * meant to be used with DialogStateful and its children (on GUI side)
+ * usually using FSM_notifier on server side, but can be used directly too
+ * @date 2021-03-03
+ */
+
+#pragma once
+
+#include "fsm_base_types.hpp"
+
+struct ProgressSerializer {
+    uint8_t progress;
+
+    constexpr ProgressSerializer(uint8_t progress = 0)
+        : progress(progress) {}
+
+    constexpr ProgressSerializer(fsm::PhaseData new_data)
+        : ProgressSerializer() {
+        Deserialize(new_data);
+    }
+
+    constexpr fsm::PhaseData Serialize() const {
+        fsm::PhaseData ret = { { progress } };
+        return ret;
+    }
+
+    constexpr void Deserialize(fsm::PhaseData new_data) {
+        progress = new_data[0];
+    }
+};

--- a/src/common/fsm_progress_type.hpp
+++ b/src/common/fsm_progress_type.hpp
@@ -30,4 +30,12 @@ struct ProgressSerializer {
     constexpr void Deserialize(fsm::PhaseData new_data) {
         progress = new_data[0];
     }
+
+    constexpr bool operator==(const ProgressSerializer &other) const {
+        return progress == other.progress;
+    }
+
+    constexpr bool operator!=(const ProgressSerializer &other) const {
+        return !((*this) == other);
+    }
 };

--- a/src/common/fsm_types.cpp
+++ b/src/common/fsm_types.cpp
@@ -1,0 +1,126 @@
+/**
+ * @file fsm_types.cpp
+ * @author Radek Vana
+ * @date 2021-02-18
+ */
+
+#include "fsm_types.hpp"
+using namespace fsm;
+
+void Queue::PushCreate(ClientFSM type, uint8_t data) {
+    if (type == ClientFSM::_none)
+        return;
+    pushCreate(create_t(type, data));
+}
+
+// queue must be empty or last command must be destroy
+// no need to check size queue behavior does not allow push more than 3 items
+void Queue::pushCreate(create_t create) {
+    if ((count == 0) || (Back().GetCommand() == ClientFSM_Command::destroy)) {
+        push(variant_t(create));
+    }
+}
+
+void Queue::PushDestroy(ClientFSM type) {
+    if (type == ClientFSM::_none)
+        return;
+    pushDestroy(destroy_t(type));
+}
+
+// clear all commands and push destroy
+// except when queue contains create, type does not matter - because sequence create-destroy can never be stored in queue
+void Queue::pushDestroy(destroy_t destroy) {
+    if ((count == 1) && (queue[0].GetCommand() == ClientFSM_Command::destroy)) {
+        return; //do not modify stored destroy
+    }
+
+    if ((count > 0) && (queue[0].GetCommand() == ClientFSM_Command::create)) {
+        clear();
+        return;
+    }
+
+    if ((count > 1) && (queue[1].GetCommand() == ClientFSM_Command::create)) {
+        count = 1; // there is old destroy command in queue, leave it
+        return;
+    }
+
+    clear();
+    push(variant_t(destroy));
+}
+
+void Queue::PushChange(ClientFSM type, uint8_t phase, uint8_t progress_tot, uint8_t progress) {
+    if (type == ClientFSM::_none)
+        return;
+    pushChange(change_t(type, phase, progress_tot, progress));
+}
+
+// must be empty or last command must create or change
+// if openned ClientFSM must match
+// no need to check size queue behavior does not allow push more than 3 items
+void Queue::pushChange(change_t change) {
+    if (count == 0) {
+        push(variant_t(change));
+        return;
+    }
+
+    if (Back().GetType() == change.type.GetType()) {
+        if (Back().GetCommand() == ClientFSM_Command::create) {
+            push(variant_t(change));
+            return;
+        }
+
+        if (Back().GetCommand() == ClientFSM_Command::change) {
+            --count; // last is change of same type, must rewrite it
+            push(variant_t(change));
+            return;
+        }
+    }
+}
+
+void Queue::push(variant_t v) {
+    if (count < queue.size()) {
+        queue[count] = v;
+        ++count;
+    }
+}
+
+variant_t Queue::Front() const {
+    if (count == 0)
+        return variant_t();
+    return queue[0];
+}
+
+variant_t Queue::Back() const {
+    if (count == 0)
+        return variant_t();
+    return queue[count - 1];
+}
+
+void Queue::Pop() {
+    if (count == 0)
+        return;
+
+    count -= 1;
+    for (size_t i = 1; i <= count; ++i) {
+        queue[i - 1] = queue[i];
+    }
+}
+
+void Queue::Push(variant_t v) {
+    if (v.GetType() == ClientFSM::_none)
+        return;
+
+    switch (v.GetCommand()) {
+    case ClientFSM_Command::create:
+        pushCreate(v.create);
+        break;
+    case ClientFSM_Command::destroy:
+        pushDestroy(v.destroy);
+        break;
+    case ClientFSM_Command::change:
+        pushChange(v.change);
+        break;
+    default:
+        break;
+    }
+}

--- a/src/common/fsm_types.cpp
+++ b/src/common/fsm_types.cpp
@@ -48,10 +48,10 @@ void Queue::pushDestroy(destroy_t destroy) {
     push(variant_t(destroy));
 }
 
-void Queue::PushChange(ClientFSM type, uint8_t phase, uint8_t progress_tot, uint8_t progress) {
+void Queue::PushChange(ClientFSM type, BaseData data) {
     if (type == ClientFSM::_none)
         return;
-    pushChange(change_t(type, phase, progress_tot, progress));
+    pushChange(change_t(type, data));
 }
 
 // must be empty or last command must create or change

--- a/src/common/fsm_types.hpp
+++ b/src/common/fsm_types.hpp
@@ -58,14 +58,17 @@ union variant_t {
         uint16_t u16;
     };
     constexpr variant_t()
-        : u32(0) {} //ClientFSM_Command::none
+        : u32(0) //contains ClientFSM_Command::none
+        , u16(0) {}
     constexpr variant_t(uint32_t u32, uint16_t u16)
         : u32(u32)
         , u16(u16) {}
-    constexpr variant_t(create_t create)
-        : create(create) {}
-    constexpr variant_t(destroy_t destroy)
-        : destroy(destroy) {}
+    constexpr variant_t(create_t create_)
+        : variant_t() // avoid uninitialized warning when accessing u16
+    { create = create_; }
+    constexpr variant_t(destroy_t destroy_)
+        : variant_t() // avoid uninitialized warning when accessing u16
+    { destroy = destroy_; }
     constexpr variant_t(change_t change)
         : change(change) {}
     constexpr ClientFSM_Command GetCommand() const { return create.type.GetCommand(); }

--- a/src/common/fsm_types.hpp
+++ b/src/common/fsm_types.hpp
@@ -1,0 +1,108 @@
+/**
+ * @file fsm_types.hpp
+ * @author Radek Vana
+ * @brief smart queue for fsm, stores and keeps only actual requests
+ * @date 2021-02-18
+ */
+
+#pragma once
+
+#include "client_fsm_types.h"
+#include <stdint.h>
+#include <array>
+
+namespace fsm {
+
+struct type_t {
+    uint8_t command_and_type;
+    constexpr type_t(ClientFSM_Command command, ClientFSM type)
+        : command_and_type(uint8_t(type) | uint8_t(command)) {}
+    constexpr ClientFSM_Command GetCommand() const { return ClientFSM_Command(command_and_type & uint8_t(ClientFSM_Command::_mask)); }
+    constexpr ClientFSM GetType() const { return ClientFSM(command_and_type & (~uint8_t(ClientFSM_Command::_mask))); }
+};
+
+struct create_t {
+    type_t type;
+    uint8_t data;
+    constexpr create_t(ClientFSM type_, uint8_t data)
+        : type(type_t(ClientFSM_Command::create, type_))
+        , data(data) {}
+};
+
+struct destroy_t {
+    type_t type;
+    constexpr destroy_t(ClientFSM type_)
+        : type(type_t(ClientFSM_Command::destroy, type_)) {}
+};
+
+struct change_t {
+    type_t type;
+    uint8_t phase;
+    uint8_t progress_tot;
+    uint8_t progress;
+    constexpr change_t(ClientFSM type_, uint8_t phase, uint8_t progress_tot, uint8_t progress)
+        : type(type_t(ClientFSM_Command::change, type_))
+        , phase(phase)
+        , progress_tot(progress_tot)
+        , progress(progress) {}
+};
+
+union variant_t {
+    create_t create;
+    destroy_t destroy;
+    change_t change;
+    uint32_t data;
+    constexpr variant_t()
+        : data(0) {} //ClientFSM_Command::none
+    constexpr variant_t(create_t create)
+        : create(create) {}
+    constexpr variant_t(destroy_t destroy)
+        : destroy(destroy) {}
+    constexpr variant_t(change_t change)
+        : change(change) {}
+    constexpr variant_t(uint32_t data)
+        : data(data) {}
+    constexpr ClientFSM_Command GetCommand() const { return create.type.GetCommand(); }
+    constexpr ClientFSM GetType() const { return create.type.GetType(); }
+};
+static_assert(int(ClientFSM_Command::none) == 0, "ClientFSM_Command::none must equal zero or fix variant_t::variant_t() ctor");
+
+// Smart queue, discards events which can be discarded (no longer important events - if new event is inserted)
+// for instance destroy, erases all other events in buffer, because they are no longer important (but nothing can erase destroy)
+// merges multiple events into one ...
+// but can never loose important item
+// Originally wanted to store store openend state
+// but it is dangerous - causing 1 information stored on multiple places
+// wrong data input, can modify type (ClientFSM) of stored destroy command
+class Queue {
+protected:
+    std::array<variant_t, 3> queue;
+    uint8_t count;
+
+    constexpr void clear() { count = 0; }
+    constexpr void clear_last() {
+        if (count)
+            --count;
+    }
+
+    //this functions do not check validity of given argument !!! (public ones do)
+    void push(variant_t v); // this method is called by specific ones (pushCreate ...)
+    void pushCreate(create_t create);
+    void pushDestroy(destroy_t destroy);
+    void pushChange(change_t change);
+
+public:
+    constexpr Queue()
+        : queue({ variant_t(0), variant_t(0), variant_t(0) })
+        , count(0) {}
+
+    variant_t Front() const; //returns ClientFSM_Command::none on empty
+    variant_t Back() const;  //returns ClientFSM_Command::none on empty
+    void Push(variant_t v);  // this method calls specific ones (PushCreate ...)
+    void Pop();
+    void PushCreate(ClientFSM type, uint8_t data);
+    void PushDestroy(ClientFSM type);
+    void PushChange(ClientFSM type, uint8_t phase, uint8_t progress_tot, uint8_t progress);
+};
+
+}; //namespace fsm

--- a/src/common/fsm_types.hpp
+++ b/src/common/fsm_types.hpp
@@ -10,6 +10,7 @@
 #include "client_fsm_types.h"
 #include <stdint.h>
 #include <array>
+#include "fsm_base_types.hpp"
 
 namespace fsm {
 
@@ -37,14 +38,19 @@ struct destroy_t {
 
 struct change_t {
     type_t type;
-    uint8_t phase;
-    uint8_t progress_tot;
-    uint8_t progress;
-    constexpr change_t(ClientFSM type_, uint8_t phase, uint8_t progress_tot, uint8_t progress)
+    BaseData data;
+    constexpr change_t(ClientFSM type_, BaseData data)
         : type(type_t(ClientFSM_Command::change, type_))
-        , phase(phase)
-        , progress_tot(progress_tot)
-        , progress(progress) {}
+        , data(data) {}
+    constexpr change_t(ClientFSM type_, uint32_t u32, uint16_t u16)
+        : type(type_t(ClientFSM_Command::change, type_)) {
+        SetU32(u32); //data[0-3]
+        SetU16(u16); //data[4-5]
+    }
+    constexpr uint32_t GetU32() const { return *(reinterpret_cast<const uint32_t *>(data.phase_and_data.begin())); }     //data[0-3]
+    constexpr uint32_t GetU16() const { return *(reinterpret_cast<const uint16_t *>(data.phase_and_data.begin() + 4)); } //data[4-5]
+    constexpr void SetU32(uint32_t data_) { *(reinterpret_cast<uint32_t *>(data.phase_and_data.begin())) = data_; }      //data[0-3]
+    constexpr void SetU16(uint16_t data_) { *(reinterpret_cast<uint16_t *>(data.phase_and_data.begin() + 4)) = data_; }  //data[4-5]
 };
 
 union variant_t {
@@ -102,7 +108,7 @@ public:
     void Pop();
     void PushCreate(ClientFSM type, uint8_t data);
     void PushDestroy(ClientFSM type);
-    void PushChange(ClientFSM type, uint8_t phase, uint8_t progress_tot, uint8_t progress);
+    void PushChange(ClientFSM type, BaseData data);
 };
 
 }; //namespace fsm

--- a/src/common/include/print_processor.hpp
+++ b/src/common/include/print_processor.hpp
@@ -8,11 +8,9 @@
 #pragma once
 
 #include <stdint.h>
-
-namespace {
 #include "marlin_client.h"
-};
 #include "filament_sensor.hpp"
+#include "fsm_types.hpp"
 
 class PrintProcessor {
     //called when Serial print screen is opened
@@ -20,13 +18,16 @@ class PrintProcessor {
     //todo should I block ClientFSM::Serial_printing?
     //this code did not work in last builds and no one reported problem with octoscreen
     //I fear enabling it could break something
-    static void fsm_create_cb(ClientFSM fsm, uint8_t data) {
-        if (/*fsm == ClientFSM::Serial_printing ||*/ fsm == ClientFSM::Load_unload)
-            FS_instance().IncEvLock();
-    }
-    static void fsm_destroy_cb(ClientFSM fsm) {
-        if (/*fsm == ClientFSM::Serial_printing ||*/ fsm == ClientFSM::Load_unload)
-            FS_instance().DecEvLock();
+    static void fsm_cb(uint32_t data) {
+        fsm::variant_t variant(data);
+        if (/*variant.GetType() == ClientFSM::Serial_printing ||*/ variant.GetType() == ClientFSM::Load_unload) {
+            if (variant.GetCommand() == ClientFSM_Command::create) {
+                FS_instance().IncEvLock();
+            }
+            if (variant.GetCommand() == ClientFSM_Command::destroy) {
+                FS_instance().DecEvLock();
+            }
+        }
     }
 
 public:
@@ -36,7 +37,6 @@ public:
     static inline bool IsAutoloadEnabled() { return marlin_vars()->fs_autoload_enabled; }
 
     static void Init() {
-        marlin_client_set_fsm_create_cb(fsm_create_cb);
-        marlin_client_set_fsm_destroy_cb(fsm_destroy_cb);
+        marlin_client_set_fsm_cb(fsm_cb);
     }
 };

--- a/src/common/include/print_processor.hpp
+++ b/src/common/include/print_processor.hpp
@@ -18,8 +18,8 @@ class PrintProcessor {
     //todo should I block ClientFSM::Serial_printing?
     //this code did not work in last builds and no one reported problem with octoscreen
     //I fear enabling it could break something
-    static void fsm_cb(uint32_t data) {
-        fsm::variant_t variant(data);
+    static void fsm_cb(uint32_t u32, uint16_t u16) {
+        fsm::variant_t variant(u32, u16);
         if (/*variant.GetType() == ClientFSM::Serial_printing ||*/ variant.GetType() == ClientFSM::Load_unload) {
             if (variant.GetCommand() == ClientFSM_Command::create) {
                 FS_instance().IncEvLock();

--- a/src/common/marlin_client.c
+++ b/src/common/marlin_client.c
@@ -793,7 +793,7 @@ static void _process_client_message(marlin_client_t *client, variant8_t msg) {
             break;
         case MARLIN_EVT_FSM:
             if (client->fsm_cb)
-                client->fsm_cb(variant8_get_ui32(msg));
+                client->fsm_cb(variant8_get_ui32(msg), variant8_get_usr16(msg));
             break;
         case MARLIN_EVT_Message: {
             variant8_t *pvar = &msg;

--- a/src/common/marlin_client.h
+++ b/src/common/marlin_client.h
@@ -40,11 +40,7 @@ extern int marlin_client_id(void);
 extern void marlin_client_wait_for_start_processing(void);
 
 //sets dialog callback, returns 1 on success
-extern int marlin_client_set_fsm_create_cb(fsm_create_t cb);
-//sets dialog callback, returns 1 on success
-extern int marlin_client_set_fsm_destroy_cb(fsm_destroy_t cb);
-//sets dialog callback, returns 1 on success
-extern int marlin_client_set_fsm_change_cb(fsm_change_t cb);
+extern int marlin_client_set_fsm_cb(fsm_cb_t cb);
 //sets dialog message, returns 1 on success
 extern int marlin_client_set_message_cb(message_cb_t cb);
 //sets dialog message, returns 1 on success

--- a/src/common/marlin_events.c
+++ b/src/common/marlin_events.c
@@ -30,9 +30,7 @@ const char *__evt_name[] = {
     "Message",
     "Warning",
     "Reheat",
-    "DialogOpen",
-    "DialogClose",
-    "DialogChange",
+    "DialogOpenCloseChange",
     "Acknowledge",
 };
 

--- a/src/common/marlin_events.h
+++ b/src/common/marlin_events.h
@@ -31,9 +31,7 @@ typedef enum {
     MARLIN_EVT_Message,             //
     MARLIN_EVT_Warning,             // important messages like fan error or heater timeout
     MARLIN_EVT_Reheat,              //
-    MARLIN_EVT_FSM_Create,          // create finite state machine in client
-    MARLIN_EVT_FSM_Destroy,         // destroy finite state machine in client
-    MARLIN_EVT_FSM_Change,          // change phase/state/progress in client fsm
+    MARLIN_EVT_FSM,                 // create/destroy finite state machine or change phase/state/progress in client
     MARLIN_EVT_Acknowledge,         // onAcknowledge - lowest priority
 
     MARLIN_EVT_MAX = MARLIN_EVT_Acknowledge
@@ -44,7 +42,7 @@ typedef enum {
 #define MARLIN_EVT_MSK_ALL   ((MARLIN_EVT_MSK(MARLIN_EVT_MAX + 1) - (uint64_t)1))
 
 static const uint64_t MARLIN_EVT_MSK_DEF = MARLIN_EVT_MSK_ALL - (MARLIN_EVT_MSK(MARLIN_EVT_PrinterKilled));
-static const uint64_t MARLIN_EVT_MSK_FSM = MARLIN_EVT_MSK(MARLIN_EVT_FSM_Create) | MARLIN_EVT_MSK(MARLIN_EVT_FSM_Destroy) | MARLIN_EVT_MSK(MARLIN_EVT_FSM_Change);
+static const uint64_t MARLIN_EVT_MSK_FSM = MARLIN_EVT_MSK(MARLIN_EVT_FSM);
 
 // commands
 enum {

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -1524,11 +1524,11 @@ void fsm_destroy(ClientFSM type) {
     _send_notify_event(MARLIN_EVT_FSM, 0, 0); // do not send data, _send_notify_event_to_client does not use them for this event
 }
 
-void _fsm_change(ClientFSM type, uint8_t phase, uint8_t progress_tot, uint8_t progress) {
-    DBG_FSM("fsm_change %d", int(type));
+void _fsm_change(ClientFSM type, fsm::BaseData data) {
+    DBG_FSM("fsm_change %d %d", int(type), data.GetPhase());
 
     for (size_t i = 0; i < MARLIN_MAX_CLIENTS; ++i) {
-        fsm_event_queues[i].PushChange(type, phase, progress_tot, progress);
+        fsm_event_queues[i].PushChange(type, data);
     }
     _send_notify_event(MARLIN_EVT_FSM, 0, 0); // do not send data, _send_notify_event_to_client does not use them for this event
 }
@@ -1587,7 +1587,7 @@ void FSM_notifier::SendNotification() {
     // after first sent, progress can only rise
     if ((s_data.last_progress_sent == uint8_t(-1)) || (progress > s_data.last_progress_sent)) {
         s_data.last_progress_sent = progress;
-        _fsm_change(s_data.type, s_data.phase, progress, 0);
+        _fsm_change(s_data.type, fsm::BaseData(s_data.phase, { { uint8_t(progress) } }));
     }
     activeInstance->postSendNotification();
 }

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -1587,7 +1587,8 @@ void FSM_notifier::SendNotification() {
     // after first sent, progress can only rise
     if ((s_data.last_progress_sent == uint8_t(-1)) || (progress > s_data.last_progress_sent)) {
         s_data.last_progress_sent = progress;
-        _fsm_change(s_data.type, fsm::BaseData(s_data.phase, { { uint8_t(progress) } }));
+        ProgressSerializer serializer(progress);
+        _fsm_change(s_data.type, fsm::BaseData(s_data.phase, serializer.Serialize()));
     }
     activeInstance->postSendNotification();
 }

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -751,7 +751,7 @@ static int _send_notify_event_to_client(int client_id, osMessageQId queue, MARLI
         fsm::variant_t variant = fsm_event_queues[client_id].Front();
         if (variant.GetCommand() == ClientFSM_Command::none)
             return true; // no event to send, return "sent" to erase send flag
-        msg = variant8_user(variant.data, 0, evt_id);
+        msg = variant8_user(variant.u32, variant.u16, evt_id);
     } break;
     default:
         msg = variant8_user(usr32, usr16, evt_id);

--- a/src/common/marlin_server.hpp
+++ b/src/common/marlin_server.hpp
@@ -3,6 +3,7 @@
 
 #include "marlin_server.h"
 #include "client_response.hpp"
+#include "fsm_types.hpp"
 
 /*****************************************************************************/
 //C++ only features
@@ -14,11 +15,11 @@ void fsm_create(ClientFSM type, uint8_t data = 0);
 void fsm_destroy(ClientFSM type);
 //notify all clients to change state of finit statemachine, must match fsm_change_t signature
 //can be called inside while, notification is send only when is different from previous one
-void _fsm_change(ClientFSM type, uint8_t phase, uint8_t progress_tot, uint8_t progress);
+void _fsm_change(ClientFSM type, fsm::BaseData data);
 
 template <class T>
-void fsm_change(ClientFSM type, T phase, uint8_t progress_tot, uint8_t progress) {
-    _fsm_change(type, GetPhaseIndex(phase), progress_tot, progress);
+void fsm_change(ClientFSM type, T phase, fsm::PhaseData data) {
+    _fsm_change(type, fsm::BaseData(GetPhaseIndex(phase), data));
 }
 
 //inherited class for server side to be able to work with server_side_encoded_response

--- a/src/common/marlin_server.hpp
+++ b/src/common/marlin_server.hpp
@@ -4,6 +4,7 @@
 #include "marlin_server.h"
 #include "client_response.hpp"
 #include "fsm_types.hpp"
+#include "fsm_progress_type.hpp"
 
 /*****************************************************************************/
 //C++ only features
@@ -137,8 +138,9 @@ public:
     }
 
     template <class T>
-    void Change(T phase, uint8_t progress_tot, uint8_t progress) const {
-        fsm_change(dialog, phase, progress_tot, progress);
+    void Change(T phase, uint8_t progress) const {
+        ProgressSerializer serializer(progress);
+        fsm_change(dialog, phase, serializer.Serialize());
     }
 
     ~FSM_Holder() {

--- a/src/common/marlin_server.hpp
+++ b/src/common/marlin_server.hpp
@@ -8,7 +8,7 @@
 //C++ only features
 
 //todo ensure signature match
-//notify all clients to create finit statemachine, must match fsm_create_t signature
+//notify all clients to create finit statemachine
 void fsm_create(ClientFSM type, uint8_t data = 0);
 //notify all clients to destroy finit statemachine, must match fsm_destroy_t signature
 void fsm_destroy(ClientFSM type);

--- a/src/common/selftest/selftest_MINI.h
+++ b/src/common/selftest/selftest_MINI.h
@@ -85,7 +85,7 @@ protected:
     void phaseStart();
     bool phaseFans(const selftest_fan_config_t &config_fan0, const selftest_fan_config_t &config_fan1);
     bool phaseHome();
-    bool phaseAxis(const selftest_axis_config_t &config_axis, CSelftestPart_Axis **ppaxis, uint16_t fsm_phase, uint8_t progress_add, uint8_t progress_mul);
+    bool phaseAxis(const selftest_axis_config_t &config_axis, CSelftestPart_Axis **ppaxis);
     bool phaseHeaters(const selftest_heater_config_t &config_nozzle, const selftest_heater_config_t &config_bed, CFanCtl &fan0, CFanCtl &fan1);
     void phaseFinish();
     bool phaseWait();

--- a/src/common/selftest_axis_type.hpp
+++ b/src/common/selftest_axis_type.hpp
@@ -1,0 +1,49 @@
+/**
+ * @file selftest_axis_type.hpp
+ * @author Radek Vana
+ * @brief selftest axis data to be passed between threads
+ * @date 2021-03-01
+ */
+
+#pragma once
+
+#include "fsm_base_types.hpp"
+#include "wizard_config.hpp" // SelftestSubtestState_t
+
+struct SelftestAxis_t {
+    uint8_t x_progress;
+    uint8_t y_progress;
+    uint8_t z_progress;
+    uint8_t tot_progress;
+    SelftestSubtestState_t x_state;
+    SelftestSubtestState_t y_state;
+    SelftestSubtestState_t z_state;
+
+    constexpr SelftestAxis_t(uint8_t x_progress = 0, uint8_t y_progress = 0,
+        uint8_t z_progress = 0, uint8_t tot_progress = 0,
+        SelftestSubtestState_t x_state = SelftestSubtestState_t::undef,
+        SelftestSubtestState_t y_state = SelftestSubtestState_t::undef,
+        SelftestSubtestState_t z_state = SelftestSubtestState_t::undef)
+        : x_progress(x_progress)
+        , y_progress(y_progress)
+        , z_progress(z_progress)
+        , tot_progress(tot_progress)
+        , x_state(x_state)
+        , y_state(y_state)
+        , z_state(z_state) {}
+
+    constexpr fsm::PhaseData Serialize() const {
+        fsm::PhaseData ret = { { x_progress, y_progress, z_progress, tot_progress, uint8_t(uint8_t(x_state) | (uint8_t(y_state) << 2) | (uint8_t(z_state) << 4)) } };
+        return ret;
+    }
+
+    constexpr void Deserialize(fsm::PhaseData new_data) {
+        x_progress = new_data[0];
+        y_progress = new_data[1];
+        z_progress = new_data[2];
+        tot_progress = new_data[3];
+        x_state = SelftestSubtestState_t(new_data[4] & 0x03);
+        y_state = SelftestSubtestState_t((new_data[4] >> 2) & 0x03);
+        z_state = SelftestSubtestState_t((new_data[4] >> 4) & 0x03);
+    }
+};

--- a/src/common/selftest_axis_type.hpp
+++ b/src/common/selftest_axis_type.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "fsm_base_types.hpp"
-#include "wizard_config.hpp" // SelftestSubtestState_t
+#include "selftest_sub_state.hpp"
 
 struct SelftestAxis_t {
     uint8_t x_progress;
@@ -46,5 +46,13 @@ struct SelftestAxis_t {
         x_state = SelftestSubtestState_t(new_data[3] & 0x03);
         y_state = SelftestSubtestState_t((new_data[3] >> 2) & 0x03);
         z_state = SelftestSubtestState_t((new_data[3] >> 4) & 0x03);
+    }
+
+    constexpr bool operator==(const SelftestAxis_t &other) const {
+        return (x_progress == other.x_progress) && (y_progress == other.y_progress) && (z_progress == other.z_progress) && (x_state == other.x_state) && (y_state == other.y_state) && (z_state == other.z_state);
+    }
+
+    constexpr bool operator!=(const SelftestAxis_t &other) const {
+        return !((*this) == other);
     }
 };

--- a/src/common/selftest_axis_type.hpp
+++ b/src/common/selftest_axis_type.hpp
@@ -14,26 +14,28 @@ struct SelftestAxis_t {
     uint8_t x_progress;
     uint8_t y_progress;
     uint8_t z_progress;
-    uint8_t tot_progress;
     SelftestSubtestState_t x_state;
     SelftestSubtestState_t y_state;
     SelftestSubtestState_t z_state;
 
-    constexpr SelftestAxis_t(uint8_t x_progress = 0, uint8_t y_progress = 0,
-        uint8_t z_progress = 0, uint8_t tot_progress = 0,
+    constexpr SelftestAxis_t(uint8_t x_progress = 0, uint8_t y_progress = 0, uint8_t z_progress = 0,
         SelftestSubtestState_t x_state = SelftestSubtestState_t::undef,
         SelftestSubtestState_t y_state = SelftestSubtestState_t::undef,
         SelftestSubtestState_t z_state = SelftestSubtestState_t::undef)
         : x_progress(x_progress)
         , y_progress(y_progress)
         , z_progress(z_progress)
-        , tot_progress(tot_progress)
         , x_state(x_state)
         , y_state(y_state)
         , z_state(z_state) {}
 
+    constexpr SelftestAxis_t(fsm::PhaseData new_data)
+        : SelftestAxis_t() {
+        Deserialize(new_data);
+    }
+
     constexpr fsm::PhaseData Serialize() const {
-        fsm::PhaseData ret = { { x_progress, y_progress, z_progress, tot_progress, uint8_t(uint8_t(x_state) | (uint8_t(y_state) << 2) | (uint8_t(z_state) << 4)) } };
+        fsm::PhaseData ret = { { x_progress, y_progress, z_progress, uint8_t(uint8_t(x_state) | (uint8_t(y_state) << 2) | (uint8_t(z_state) << 4)) } };
         return ret;
     }
 
@@ -41,9 +43,8 @@ struct SelftestAxis_t {
         x_progress = new_data[0];
         y_progress = new_data[1];
         z_progress = new_data[2];
-        tot_progress = new_data[3];
-        x_state = SelftestSubtestState_t(new_data[4] & 0x03);
-        y_state = SelftestSubtestState_t((new_data[4] >> 2) & 0x03);
-        z_state = SelftestSubtestState_t((new_data[4] >> 4) & 0x03);
+        x_state = SelftestSubtestState_t(new_data[3] & 0x03);
+        y_state = SelftestSubtestState_t((new_data[3] >> 2) & 0x03);
+        z_state = SelftestSubtestState_t((new_data[3] >> 4) & 0x03);
     }
 };

--- a/src/common/selftest_fans_type.hpp
+++ b/src/common/selftest_fans_type.hpp
@@ -1,0 +1,38 @@
+/**
+ * @file selftest_fans_type.hpp
+ * @author Radek Vana
+ * @brief selftest fans data to be passed between threads
+ * @date 2021-03-01
+ */
+
+#pragma once
+
+#include "fsm_base_types.hpp"
+#include "wizard_config.hpp" // SelftestSubtestState_t
+
+struct SelftestFans_t {
+    uint8_t print_fan_progress;  //fan0
+    uint8_t nozzle_fan_progress; //fan1
+    SelftestSubtestState_t print_fan_state;
+    SelftestSubtestState_t nozzle_fan_state;
+
+    constexpr SelftestFans_t(uint8_t prt_fan_prog = 0, uint8_t noz_fan_prog = 0,
+        SelftestSubtestState_t prt_fan_st = SelftestSubtestState_t::undef,
+        SelftestSubtestState_t noz_fan_st = SelftestSubtestState_t::undef)
+        : print_fan_progress(prt_fan_prog)
+        , nozzle_fan_progress(noz_fan_prog)
+        , print_fan_state(prt_fan_st)
+        , nozzle_fan_state(noz_fan_st) {}
+
+    constexpr fsm::PhaseData Serialize() const {
+        fsm::PhaseData ret = { { print_fan_progress, nozzle_fan_progress, uint8_t(print_fan_state), uint8_t(nozzle_fan_state), 0 } };
+        return ret;
+    }
+
+    constexpr void Deserialize(fsm::PhaseData new_data) {
+        print_fan_progress = new_data[0];
+        nozzle_fan_progress = new_data[1];
+        print_fan_state = SelftestSubtestState_t(new_data[2]);
+        nozzle_fan_state = SelftestSubtestState_t(new_data[3]);
+    }
+};

--- a/src/common/selftest_fans_type.hpp
+++ b/src/common/selftest_fans_type.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "fsm_base_types.hpp"
-#include "wizard_config.hpp" // SelftestSubtestState_t
+#include "selftest_sub_state.hpp"
 
 struct SelftestFans_t {
     uint8_t print_fan_progress;  //fan0
@@ -43,5 +43,13 @@ struct SelftestFans_t {
         tot_progress = new_data[2];
         print_fan_state = SelftestSubtestState_t(new_data[3] & 0x03);
         nozzle_fan_state = SelftestSubtestState_t((new_data[3] >> 2) & 0x03);
+    }
+
+    constexpr bool operator==(const SelftestFans_t &other) const {
+        return (print_fan_progress == other.print_fan_progress) && (nozzle_fan_progress == other.nozzle_fan_progress) && (tot_progress == other.tot_progress) && (print_fan_state == other.print_fan_state) && (nozzle_fan_state == other.nozzle_fan_state);
+    }
+
+    constexpr bool operator!=(const SelftestFans_t &other) const {
+        return !((*this) == other);
     }
 };

--- a/src/common/selftest_fans_type.hpp
+++ b/src/common/selftest_fans_type.hpp
@@ -13,26 +13,35 @@
 struct SelftestFans_t {
     uint8_t print_fan_progress;  //fan0
     uint8_t nozzle_fan_progress; //fan1
+    uint8_t tot_progress;
     SelftestSubtestState_t print_fan_state;
     SelftestSubtestState_t nozzle_fan_state;
 
-    constexpr SelftestFans_t(uint8_t prt_fan_prog = 0, uint8_t noz_fan_prog = 0,
+    constexpr SelftestFans_t(uint8_t prt_fan_prog = 0, uint8_t noz_fan_prog = 0, uint8_t tot_prog = 0,
         SelftestSubtestState_t prt_fan_st = SelftestSubtestState_t::undef,
         SelftestSubtestState_t noz_fan_st = SelftestSubtestState_t::undef)
         : print_fan_progress(prt_fan_prog)
         , nozzle_fan_progress(noz_fan_prog)
+        , tot_progress(tot_prog)
         , print_fan_state(prt_fan_st)
         , nozzle_fan_state(noz_fan_st) {}
 
+    constexpr SelftestFans_t(fsm::PhaseData new_data)
+        : SelftestFans_t() {
+        Deserialize(new_data);
+    }
+
     constexpr fsm::PhaseData Serialize() const {
-        fsm::PhaseData ret = { { print_fan_progress, nozzle_fan_progress, uint8_t(print_fan_state), uint8_t(nozzle_fan_state), 0 } };
+        fsm::PhaseData ret = { { print_fan_progress, nozzle_fan_progress, tot_progress,
+            uint8_t(uint8_t(print_fan_state) | (uint8_t(nozzle_fan_state) << 2)) } };
         return ret;
     }
 
     constexpr void Deserialize(fsm::PhaseData new_data) {
         print_fan_progress = new_data[0];
         nozzle_fan_progress = new_data[1];
-        print_fan_state = SelftestSubtestState_t(new_data[2]);
-        nozzle_fan_state = SelftestSubtestState_t(new_data[3]);
+        tot_progress = new_data[2];
+        print_fan_state = SelftestSubtestState_t(new_data[3] & 0x03);
+        nozzle_fan_state = SelftestSubtestState_t((new_data[3] >> 2) & 0x03);
     }
 };

--- a/src/common/selftest_heaters_type.hpp
+++ b/src/common/selftest_heaters_type.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "fsm_base_types.hpp"
-#include "wizard_config.hpp" // SelftestSubtestState_t
+#include "selftest_sub_state.hpp"
 
 struct SelftestHeaters_t {
     uint8_t noz_progress;
@@ -49,5 +49,13 @@ struct SelftestHeaters_t {
         noz_heat_state = SelftestSubtestState_t((new_data[2] >> 2) & 0x03);
         bed_prep_state = SelftestSubtestState_t(new_data[3] & 0x03);
         bed_heat_state = SelftestSubtestState_t((new_data[3] >> 2) & 0x03);
+    }
+
+    constexpr bool operator==(const SelftestHeaters_t &other) const {
+        return (noz_progress == other.noz_progress) && (bed_progress == other.bed_progress) && (noz_prep_state == other.noz_prep_state) && (noz_heat_state == other.noz_heat_state) && (bed_prep_state == other.bed_prep_state) && (bed_heat_state == other.bed_heat_state);
+    }
+
+    constexpr bool operator!=(const SelftestHeaters_t &other) const {
+        return !((*this) == other);
     }
 };

--- a/src/common/selftest_heaters_type.hpp
+++ b/src/common/selftest_heaters_type.hpp
@@ -1,0 +1,48 @@
+/**
+ * @file selftest_heaters_type.hpp
+ * @author Radek Vana
+ * @brief selftest fans data to be passed between threads
+ * @date 2021-03-01
+ */
+
+#pragma once
+
+#include "fsm_base_types.hpp"
+#include "wizard_config.hpp" // SelftestSubtestState_t
+
+struct SelftestHeaters_t {
+    uint8_t noz_progress;
+    uint8_t bed_progress;
+    SelftestSubtestState_t noz_prep_state;
+    SelftestSubtestState_t noz_heat_state;
+    SelftestSubtestState_t bed_prep_state;
+    SelftestSubtestState_t bed_heat_state;
+
+    constexpr SelftestHeaters_t(uint8_t noz_progress = 0, uint8_t bed_progress = 0,
+        SelftestSubtestState_t noz_prep_state = SelftestSubtestState_t::undef,
+        SelftestSubtestState_t noz_heat_state = SelftestSubtestState_t::undef,
+        SelftestSubtestState_t bed_prep_state = SelftestSubtestState_t::undef,
+        SelftestSubtestState_t bed_heat_state = SelftestSubtestState_t::undef)
+        : noz_progress(noz_progress)
+        , bed_progress(bed_progress)
+        , noz_prep_state(noz_prep_state)
+        , noz_heat_state(noz_heat_state)
+        , bed_prep_state(bed_prep_state)
+        , bed_heat_state(bed_heat_state) {}
+
+    constexpr fsm::PhaseData Serialize() const {
+        fsm::PhaseData ret = { { noz_progress, bed_progress,
+            uint8_t(uint8_t(noz_prep_state) | (uint8_t(noz_heat_state) << 2)),
+            uint8_t(uint8_t(bed_prep_state) | (uint8_t(bed_heat_state) << 2)) } };
+        return ret;
+    }
+
+    constexpr void Deserialize(fsm::PhaseData new_data) {
+        noz_progress = new_data[0];
+        bed_progress = new_data[1];
+        noz_prep_state = SelftestSubtestState_t(new_data[2] & 0x03);
+        noz_heat_state = SelftestSubtestState_t((new_data[2] >> 2) & 0x03);
+        bed_prep_state = SelftestSubtestState_t(new_data[3] & 0x03);
+        bed_heat_state = SelftestSubtestState_t((new_data[3] >> 2) & 0x03);
+    }
+};

--- a/src/common/selftest_heaters_type.hpp
+++ b/src/common/selftest_heaters_type.hpp
@@ -30,6 +30,11 @@ struct SelftestHeaters_t {
         , bed_prep_state(bed_prep_state)
         , bed_heat_state(bed_heat_state) {}
 
+    constexpr SelftestHeaters_t(fsm::PhaseData new_data)
+        : SelftestHeaters_t() {
+        Deserialize(new_data);
+    }
+
     constexpr fsm::PhaseData Serialize() const {
         fsm::PhaseData ret = { { noz_progress, bed_progress,
             uint8_t(uint8_t(noz_prep_state) | (uint8_t(noz_heat_state) << 2)),

--- a/src/gui/dialogs/DialogHandler.cpp
+++ b/src/gui/dialogs/DialogHandler.cpp
@@ -129,9 +129,11 @@ void DialogHandler::PreOpen(ClientFSM dialog, uint8_t data) {
 void DialogHandler::Loop() {
     fsm::variant_t variant = command_queue.Front();
 
-    if (variant.GetCommand() == ClientFSM_Command::none)
-        return; //no command in queue
+    // execute all commands - fewer redraws
+    while (variant.GetCommand() != ClientFSM_Command::none) {
+        command(variant);
+        command_queue.Pop(); //erase item from queue
 
-    command(variant);
-    command_queue.Pop(); //erase item from queue
+        variant = command_queue.Front();
+    }
 }

--- a/src/gui/dialogs/DialogHandler.cpp
+++ b/src/gui/dialogs/DialogHandler.cpp
@@ -78,7 +78,7 @@ void DialogHandler::close(fsm::destroy_t o) {
 
 void DialogHandler::change(fsm::change_t o) {
     if (ptr)
-        ptr->Change(o.phase, o.progress_tot, o.progress);
+        ptr->Change(o.data);
 }
 
 //*****************************************************************************

--- a/src/gui/dialogs/DialogHandler.cpp
+++ b/src/gui/dialogs/DialogHandler.cpp
@@ -88,8 +88,8 @@ DialogHandler &DialogHandler::Access() {
     return ret;
 }
 
-void DialogHandler::Command(uint32_t data) {
-    fsm::variant_t variant(data);
+void DialogHandler::Command(uint32_t u32, uint16_t u16) {
+    fsm::variant_t variant(u32, u16);
 
     // not sure about buffering ClientFSM_Command::change, it could work without it
     // but it is buffered too to be simpler
@@ -122,7 +122,8 @@ void DialogHandler::WaitUntilClosed(ClientFSM dialog, uint8_t data) {
 }
 
 void DialogHandler::PreOpen(ClientFSM dialog, uint8_t data) {
-    Command(fsm::variant_t(fsm::create_t(dialog, data)).data);
+    const fsm::variant_t var(fsm::create_t(dialog, data));
+    Command(var.u32, var.u16);
 }
 
 void DialogHandler::Loop() {

--- a/src/gui/dialogs/DialogHandler.cpp
+++ b/src/gui/dialogs/DialogHandler.cpp
@@ -28,10 +28,11 @@ static void OpenPrintScreen(ClientFSM dialog) {
 
 //*****************************************************************************
 //method definitions
-void DialogHandler::open(ClientFSM dialog, uint8_t data) {
+void DialogHandler::open(fsm::create_t o) {
     if (ptr)
         return; //the dialog is already openned
 
+    const ClientFSM dialog = o.type.GetType();
     //todo get_scr_printing_serial() is no dialog but screen ... change to dialog?
     // only ptr = dialog_creators[dialog](data); should remain
     switch (dialog) {
@@ -46,11 +47,13 @@ void DialogHandler::open(ClientFSM dialog, uint8_t data) {
         }
         break;
     default:
-        ptr = dialog_ctors[size_t(dialog)](data);
+        ptr = dialog_ctors[size_t(dialog)](o.data);
     }
 }
 
-void DialogHandler::close(ClientFSM dialog) {
+void DialogHandler::close(fsm::destroy_t o) {
+    const ClientFSM dialog = o.type.GetType();
+
     if (waiting_closed == dialog) {
         waiting_closed = ClientFSM::_none;
     } else {
@@ -73,13 +76,13 @@ void DialogHandler::close(ClientFSM dialog) {
     ptr = nullptr; //destroy current dialog
 }
 
-void DialogHandler::change(ClientFSM /*dialog*/, uint8_t phase, uint8_t progress_tot, uint8_t progress) {
+void DialogHandler::change(fsm::change_t o) {
     if (ptr)
-        ptr->Change(phase, progress_tot, progress);
+        ptr->Change(o.phase, o.progress_tot, o.progress);
 }
 
 void DialogHandler::wait_until_closed(ClientFSM dialog, uint8_t data) {
-    open(dialog, data);
+    open(fsm::create_t(dialog, data));
     waiting_closed = dialog;
     while (waiting_closed == dialog)
         gui_loop();
@@ -92,15 +95,44 @@ DialogHandler &DialogHandler::Access() {
     return ret;
 }
 
-void DialogHandler::Open(ClientFSM dialog, uint8_t data) {
-    Access().open(dialog, data);
+void DialogHandler::Command(uint32_t data) {
+    fsm::variant_t variant(data);
+
+    // not sure about buffering ClientFSM_Command::change, it could work without it
+    // but it is buffered too to be simpler
+    Access().command_queue.Push(variant);
 }
-void DialogHandler::Close(ClientFSM dialog) {
-    Access().close(dialog);
+
+void DialogHandler::command(fsm::variant_t variant) {
+    switch (variant.GetCommand()) {
+    case ClientFSM_Command::create:
+        open(variant.create);
+        break;
+    case ClientFSM_Command::destroy:
+        close(variant.destroy);
+        break;
+    case ClientFSM_Command::change:
+        change(variant.change);
+        break;
+    default:
+        break;
+    }
 }
-void DialogHandler::Change(ClientFSM dialog, uint8_t phase, uint8_t progress_tot, uint8_t progress) {
-    Access().change(dialog, phase, progress_tot, progress);
-}
+
 void DialogHandler::WaitUntilClosed(ClientFSM dialog, uint8_t data) {
     Access().wait_until_closed(dialog, data);
+}
+
+void DialogHandler::PreOpen(ClientFSM dialog, uint8_t data) {
+    Command(fsm::variant_t(fsm::create_t(dialog, data)).data);
+}
+
+void DialogHandler::Loop() {
+    fsm::variant_t variant = Access().command_queue.Front();
+
+    if (variant.GetCommand() == ClientFSM_Command::none)
+        return; //no command in queue
+
+    Access().command(variant);
+    Access().command_queue.Pop(); //erase item from queue
 }

--- a/src/gui/dialogs/DialogHandler.hpp
+++ b/src/gui/dialogs/DialogHandler.hpp
@@ -1,30 +1,35 @@
 #pragma once
 
 #include <stdint.h>
-#include "client_fsm_types.h"
+#include "fsm_types.hpp"
 #include "DialogFactory.hpp"
 
 class DialogHandler {
     static_unique_ptr<IDialogMarlin> ptr;
     DialogFactory::Ctors dialog_ctors;
     ClientFSM waiting_closed = ClientFSM::_none;
+    fsm::Queue command_queue;
 
     DialogHandler(DialogFactory::Ctors ctors)
         : dialog_ctors(ctors) {}
     DialogHandler(DialogHandler &) = delete;
 
-    void open(ClientFSM dialog, uint8_t data);
-    void close(ClientFSM dialog);
-    void change(ClientFSM dialog, uint8_t phase, uint8_t progress_tot, uint8_t progress);
-
+    void close(fsm::destroy_t o);
+    void change(fsm::change_t o);
+    void open(fsm::create_t o); //can be enforced (pre openned), unlike change/close
     void wait_until_closed(ClientFSM dialog, uint8_t data);
+    void command(fsm::variant_t variant);
 
 public:
     //accessor for static methods
     static DialogHandler &Access();
-    //static methods to be registerd as callbacks
-    static void Open(ClientFSM dialog, uint8_t data);
-    static void Close(ClientFSM dialog);
-    static void Change(ClientFSM dialog, uint8_t phase, uint8_t progress_tot, uint8_t progress);
-    static void WaitUntilClosed(ClientFSM dialog, uint8_t data); //opens dialog, waits until closed, auto loops
+    //static methods to be registered as callbacks
+    static void Command(uint32_t data);                  //marlin client is in C, so cannot pass fsm::variant_t
+    static void Loop();                                  //synchronization loop, call it outside event
+    static void PreOpen(ClientFSM dialog, uint8_t data); //can be enforced (pre openned), unlike change/close
+
+    // opens dialog, waits until closed, auto loops
+    // avoid calling multiple times inside one method (event), could cause dialog memory corruption
+    // TODO rewrite!!!
+    static void WaitUntilClosed(ClientFSM dialog, uint8_t data);
 };

--- a/src/gui/dialogs/DialogHandler.hpp
+++ b/src/gui/dialogs/DialogHandler.hpp
@@ -22,7 +22,7 @@ class DialogHandler {
 public:
     //accessor for static methods
     static DialogHandler &Access();
-    static void Command(uint32_t data);                  //static method to be registered as callback, marlin client is in C, so cannot pass fsm::variant_t
+    static void Command(uint32_t u32, uint16_t u16);     //static method to be registered as callback, marlin client is in C, so cannot pass fsm::variant_t
     static void PreOpen(ClientFSM dialog, uint8_t data); //can be enforced (pre openned), unlike change/close
 
     void Loop();                                          //synchronization loop, call it outside event

--- a/src/gui/dialogs/DialogHandler.hpp
+++ b/src/gui/dialogs/DialogHandler.hpp
@@ -17,19 +17,14 @@ class DialogHandler {
     void close(fsm::destroy_t o);
     void change(fsm::change_t o);
     void open(fsm::create_t o); //can be enforced (pre openned), unlike change/close
-    void wait_until_closed(ClientFSM dialog, uint8_t data);
     void command(fsm::variant_t variant);
 
 public:
     //accessor for static methods
     static DialogHandler &Access();
-    //static methods to be registered as callbacks
-    static void Command(uint32_t data);                  //marlin client is in C, so cannot pass fsm::variant_t
-    static void Loop();                                  //synchronization loop, call it outside event
+    static void Command(uint32_t data);                  //static method to be registered as callback, marlin client is in C, so cannot pass fsm::variant_t
     static void PreOpen(ClientFSM dialog, uint8_t data); //can be enforced (pre openned), unlike change/close
 
-    // opens dialog, waits until closed, auto loops
-    // avoid calling multiple times inside one method (event), could cause dialog memory corruption
-    // TODO rewrite!!!
-    static void WaitUntilClosed(ClientFSM dialog, uint8_t data);
+    void Loop();                                          //synchronization loop, call it outside event
+    void WaitUntilClosed(ClientFSM dialog, uint8_t data); // opens dialog, waits until closed, auto loops
 };

--- a/src/gui/dialogs/DialogSelftestAxis.cpp
+++ b/src/gui/dialogs/DialogSelftestAxis.cpp
@@ -1,6 +1,12 @@
 #include "DialogSelftestAxis.hpp"
 #include "i18n.h"
 #include "wizard_config.hpp"
+#include "selftest_axis_type.hpp"
+
+static constexpr size_t X_AXIS_PERCENT = 33;
+static constexpr size_t Y_AXIS_PERCENT = 33;
+static constexpr size_t Z_AXIS_PERCENT = 34;
+//would be cleaner to calculate total progress in main thread, but cannot pass so much data
 
 static constexpr size_t col_0 = WizardDefaults::MarginLeft;
 static constexpr size_t col_1 = WizardDefaults::status_icon_X_pos;
@@ -32,21 +38,15 @@ DialogSelftestAxis::DialogSelftestAxis()
     , icon_z_axis(this, { col_1, row_4 }) {
 }
 
-bool DialogSelftestAxis::change(uint8_t phs, uint8_t progress_tot, uint8_t progress_state) {
-    PhasesSelftestAxis test = GetEnumFromPhaseIndex<PhasesSelftestAxis>(phs);
-    SelftestSubtestState_t test_state = SelftestSubtestState_t(progress_state);
+bool DialogSelftestAxis::change(uint8_t phase, fsm::PhaseData data) {
+    SelftestAxis_t dt(data);
 
-    switch (test) {
-    case PhasesSelftestAxis::Xaxis:
-        icon_x_axis.SetState(test_state);
-        break;
-    case PhasesSelftestAxis::Yaxis:
-        icon_y_axis.SetState(test_state);
-        break;
-    case PhasesSelftestAxis::Zaxis:
-        icon_z_axis.SetState(test_state);
-        break;
-    }
-    progress.SetProgressPercent(progress_tot);
+    icon_x_axis.SetState(dt.x_state);
+    icon_y_axis.SetState(dt.y_state);
+    icon_z_axis.SetState(dt.z_state);
+    progress.SetProgressPercent(
+        (
+            dt.x_progress * X_AXIS_PERCENT + dt.y_progress * Y_AXIS_PERCENT + dt.z_progress * Z_AXIS_PERCENT)
+        / 100);
     return true;
 };

--- a/src/gui/dialogs/DialogSelftestAxis.hpp
+++ b/src/gui/dialogs/DialogSelftestAxis.hpp
@@ -15,7 +15,7 @@ class DialogSelftestAxis : public IDialogMarlin {
     WindowIcon_OkNg icon_z_axis;
 
 protected:
-    virtual bool change(uint8_t phs, uint8_t progress_tot, uint8_t progress) override;
+    virtual bool change(uint8_t phase, fsm::PhaseData data) override;
 
 public:
     DialogSelftestAxis();

--- a/src/gui/dialogs/DialogSelftestFans.cpp
+++ b/src/gui/dialogs/DialogSelftestFans.cpp
@@ -1,6 +1,7 @@
 #include "DialogSelftestFans.hpp"
 #include "i18n.h"
 #include "wizard_config.hpp"
+#include "selftest_fans_type.hpp"
 
 static constexpr size_t col_0 = WizardDefaults::MarginLeft;
 static constexpr size_t col_1 = WizardDefaults::status_icon_X_pos;
@@ -28,18 +29,11 @@ DialogSelftestFans::DialogSelftestFans()
     , icon_print_fan(this, { col_1, row_3 }) {
 }
 
-bool DialogSelftestFans::change(uint8_t phs, uint8_t progress_tot, uint8_t progress_state) {
-    PhasesSelftestFans test = GetEnumFromPhaseIndex<PhasesSelftestFans>(phs);
-    SelftestSubtestState_t test_state = SelftestSubtestState_t(progress_state);
+bool DialogSelftestFans::change(uint8_t phase, fsm::PhaseData data) {
+    SelftestFans_t dt(data);
 
-    switch (test) {
-    case PhasesSelftestFans::TestFan0:
-        icon_print_fan.SetState(test_state);
-        break;
-    case PhasesSelftestFans::TestFan1:
-        icon_hotend_fan.SetState(test_state);
-        break;
-    }
-    progress.SetProgressPercent(progress_tot);
+    icon_print_fan.SetState(dt.print_fan_state);
+    icon_hotend_fan.SetState(dt.nozzle_fan_state);
+    progress.SetProgressPercent(dt.tot_progress);
     return true;
 };

--- a/src/gui/dialogs/DialogSelftestFans.hpp
+++ b/src/gui/dialogs/DialogSelftestFans.hpp
@@ -13,7 +13,7 @@ class DialogSelftestFans : public IDialogMarlin {
     WindowIcon_OkNg icon_print_fan;
 
 protected:
-    virtual bool change(uint8_t phs, uint8_t progress_tot, uint8_t progress) override;
+    virtual bool change(uint8_t phase, fsm::PhaseData data) override;
 
 public:
     DialogSelftestFans();

--- a/src/gui/dialogs/DialogSelftestTemp.cpp
+++ b/src/gui/dialogs/DialogSelftestTemp.cpp
@@ -1,6 +1,7 @@
 #include "DialogSelftestTemp.hpp"
 #include "i18n.h"
 #include "wizard_config.hpp"
+#include "selftest_heaters_type.hpp"
 
 static constexpr size_t icon_w = 20 + WizardDefaults::MarginRight;
 static constexpr size_t text_w = WizardDefaults::X_space - icon_w;
@@ -44,27 +45,16 @@ DialogSelftestTemp::DialogSelftestTemp()
     , icon_bed_heat(this, { col_1, row_bed_3 }) {
 }
 
-bool DialogSelftestTemp::change(uint8_t phs, uint8_t progress_tot, uint8_t progress_state) {
-    PhasesSelftestHeat test = GetEnumFromPhaseIndex<PhasesSelftestHeat>(phs);
-    SelftestSubtestState_t test_state = SelftestSubtestState_t(progress_state);
+bool DialogSelftestTemp::change(uint8_t phase, fsm::PhaseData data) {
+    SelftestHeaters_t dt(data);
 
-    switch (test) {
-    case PhasesSelftestHeat::noz_prep:
-        icon_noz_prep.SetState(test_state);
-        progress_noz.SetProgressPercent(progress_tot);
-        break;
-    case PhasesSelftestHeat::noz_heat:
-        icon_noz_heat.SetState(test_state);
-        progress_noz.SetProgressPercent(progress_tot);
-        break;
-    case PhasesSelftestHeat::bed_prep:
-        icon_bed_prep.SetState(test_state);
-        progress_bed.SetProgressPercent(progress_tot);
-        break;
-    case PhasesSelftestHeat::bed_heat:
-        icon_bed_heat.SetState(test_state);
-        progress_bed.SetProgressPercent(progress_tot);
-        break;
-    }
+    icon_noz_prep.SetState(dt.noz_prep_state);
+    icon_noz_heat.SetState(dt.noz_heat_state);
+    icon_bed_prep.SetState(dt.bed_prep_state);
+    icon_bed_heat.SetState(dt.bed_heat_state);
+
+    progress_noz.SetProgressPercent(dt.noz_progress);
+    progress_bed.SetProgressPercent(dt.bed_progress);
+
     return true;
 };

--- a/src/gui/dialogs/DialogSelftestTemp.hpp
+++ b/src/gui/dialogs/DialogSelftestTemp.hpp
@@ -21,7 +21,7 @@ class DialogSelftestTemp : public IDialogMarlin {
     WindowIcon_OkNg icon_bed_heat;
 
 protected:
-    virtual bool change(uint8_t phs, uint8_t progress_tot, uint8_t progress) override;
+    virtual bool change(uint8_t phase, fsm::PhaseData data) override;
 
 public:
     DialogSelftestTemp();

--- a/src/gui/dialogs/DialogStateful.cpp
+++ b/src/gui/dialogs/DialogStateful.cpp
@@ -44,7 +44,7 @@ IDialogStateful::IDialogStateful(string_view_utf8 name)
     label.SetAlignment(Align_t::CenterTop());
 }
 
-bool IDialogStateful::change(uint8_t phs, uint8_t progress_tot, uint8_t /*progr*/) {
+bool IDialogStateful::change(uint8_t phs, fsm::PhaseData data) {
     if (!can_change(phs))
         return false;
     if (phase != phs) {
@@ -53,7 +53,7 @@ bool IDialogStateful::change(uint8_t phs, uint8_t progress_tot, uint8_t /*progr*
         phaseEnter();
     }
 
-    progress.SetValue(progress_tot <= 100 ? progress_tot : 0);
+    progress.SetValue(data[1] <= 100 ? data[1] : 0); //TODO
     //Invalidate();
     return true;
 }

--- a/src/gui/dialogs/DialogStateful.cpp
+++ b/src/gui/dialogs/DialogStateful.cpp
@@ -2,6 +2,7 @@
 #include "guitypes.hpp"
 #include "i18n.h"
 #include "resource.h" //IDR_FNT_BIG
+#include "fsm_progress_type.hpp"
 
 static const constexpr int PROGRESS_BAR_X_PAD = 10;
 static const constexpr int PROGRESS_BAR_Y_PAD = 30;
@@ -53,7 +54,8 @@ bool IDialogStateful::change(uint8_t phs, fsm::PhaseData data) {
         phaseEnter();
     }
 
-    progress.SetValue(data[1] <= 100 ? data[1] : 0); //TODO
+    ProgressSerializer serializer(data);
+    progress.SetValue(serializer.progress);
     //Invalidate();
     return true;
 }

--- a/src/gui/dialogs/DialogStateful.hpp
+++ b/src/gui/dialogs/DialogStateful.hpp
@@ -8,6 +8,7 @@
 #include "i18n.h"
 #include "window_text.hpp"
 #include "window_progress.hpp"
+#include "fsm_types.hpp"
 
 // function pointer for onEnter & onExit callbacks
 using change_state_cb_t = void (*)();
@@ -17,7 +18,7 @@ protected:
     virtual bool change(uint8_t phs, uint8_t progress_tot, uint8_t progress) = 0;
 
 public:
-    bool Change(uint8_t phs, uint8_t progress_tot, uint8_t progress) { return change(phs, progress_tot, progress); }
+    bool Change(fsm::BaseData data) { return change(data.GetPhase(), data.phase_and_data[1], data.phase_and_data[2]); }
     IDialogMarlin(Rect16 rc = GuiDefaults::RectScreenBody)
         : IDialog(rc) {}
 };

--- a/src/gui/dialogs/DialogStateful.hpp
+++ b/src/gui/dialogs/DialogStateful.hpp
@@ -15,10 +15,10 @@ using change_state_cb_t = void (*)();
 
 class IDialogMarlin : public IDialog {
 protected:
-    virtual bool change(uint8_t phs, uint8_t progress_tot, uint8_t progress) = 0;
+    virtual bool change(uint8_t phase, fsm::PhaseData data) = 0;
 
 public:
-    bool Change(fsm::BaseData data) { return change(data.GetPhase(), data.phase_and_data[1], data.phase_and_data[2]); }
+    bool Change(fsm::BaseData data) { return change(data.GetPhase(), data.GetData()); }
     IDialogMarlin(Rect16 rc = GuiDefaults::RectScreenBody)
         : IDialog(rc) {}
 };
@@ -52,7 +52,7 @@ protected:
     // must be virtual because of `states` list is in template protected
     virtual void phaseEnter() = 0;
     virtual void phaseExit() = 0;
-    virtual bool change(uint8_t phs, uint8_t progress_tot, uint8_t progress) override;
+    virtual bool change(uint8_t phase, fsm::PhaseData data) override;
 
 public:
     IDialogStateful(string_view_utf8 name);

--- a/src/gui/dialogs/window_dlg_calib_z.cpp
+++ b/src/gui/dialogs/window_dlg_calib_z.cpp
@@ -19,6 +19,6 @@ dlg_result_t gui_dlg_calib_z(void) {
 
     marlin_gcode("G162 Z");
     // create blocking dialog
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::G162, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::G162, 0);
     return dlg_result_t::ok;
 }

--- a/src/gui/dialogs/window_dlg_calib_z.cpp
+++ b/src/gui/dialogs/window_dlg_calib_z.cpp
@@ -19,6 +19,6 @@ dlg_result_t gui_dlg_calib_z(void) {
 
     marlin_gcode("G162 Z");
     // create blocking dialog
-    DialogHandler::WaitUntilClosed(ClientFSM::G162, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::G162, 0);
     return dlg_result_t::ok;
 }

--- a/src/gui/dialogs/window_dlg_load_unload.cpp
+++ b/src/gui/dialogs/window_dlg_load_unload.cpp
@@ -7,6 +7,7 @@
 #include "window_dlg_load_unload.hpp"
 #include "marlin_client.h"
 #include "gui.hpp" // gui_loop
+#include "DialogHandler.hpp"
 
 namespace PreheatStatus {
 
@@ -20,6 +21,7 @@ Result DialogBlocking(PreheatMode mode, RetAndCool_t retAndCool) {
     Dialog(mode, retAndCool);
     PreheatStatus::Result ret;
     while ((ret = PreheatStatus::ConsumeResult()) == PreheatStatus::Result::DidNotFinish) {
+        DialogHandler::Access().Loop(); // fsm events .. to be able to change state
         gui_loop();
     }
     return ret;

--- a/src/gui/dialogs/window_dlg_preheat.cpp
+++ b/src/gui/dialogs/window_dlg_preheat.cpp
@@ -57,6 +57,6 @@ IWinMenuContainer *DialogMenuPreheat::newContainer(PreheatData type) {
     return new (&container_mem_space) NsPreheat::MenuContainer;
 }
 
-bool DialogMenuPreheat::change(uint8_t phs, uint8_t progress_tot, uint8_t progress) {
+bool DialogMenuPreheat::change(uint8_t phs, fsm::PhaseData data) {
     return true;
 }

--- a/src/gui/dialogs/window_dlg_preheat.hpp
+++ b/src/gui/dialogs/window_dlg_preheat.hpp
@@ -109,5 +109,5 @@ public:
     DialogMenuPreheat(string_view_utf8 name, PreheatData type);
 
 protected:
-    virtual bool change(uint8_t phs, uint8_t progress_tot, uint8_t progress) override;
+    virtual bool change(uint8_t phase, fsm::PhaseData data) override;
 };

--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -152,9 +152,7 @@ void gui_run(void) {
     gui_marlin_vars->media_SFN_path = gui_media_SFN_path;
 
     DialogHandler::Access(); //to create class NOW, not at first call of one of callback
-    marlin_client_set_fsm_create_cb(DialogHandler::Open);
-    marlin_client_set_fsm_destroy_cb(DialogHandler::Close);
-    marlin_client_set_fsm_change_cb(DialogHandler::Change);
+    marlin_client_set_fsm_cb(DialogHandler::Command);
     marlin_client_set_message_cb(MsgCircleBuffer_cb);
     marlin_client_set_warning_cb(Warning_cb);
     marlin_client_set_startup_cb(Startup_cb);
@@ -215,6 +213,7 @@ void gui_run(void) {
     uint32_t progr100 = 100;
     Screens::Access()->WindowEvent(GUI_event_t::GUI_STARTUP, (void *)progr100);
     while (1) {
+        DialogHandler::Loop();
         Screens::Access()->Loop();
         gui_loop();
     }

--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -213,7 +213,7 @@ void gui_run(void) {
     uint32_t progr100 = 100;
     Screens::Access()->WindowEvent(GUI_event_t::GUI_STARTUP, (void *)progr100);
     while (1) {
-        DialogHandler::Loop();
+        DialogHandler::Access().Loop();
         Screens::Access()->Loop();
         gui_loop();
     }

--- a/src/gui/wizard/firstlay.cpp
+++ b/src/gui/wizard/firstlay.cpp
@@ -139,7 +139,7 @@ WizardState_t StateFnc_FIRSTLAY_MSBX_START_PRINT() {
 //and it would block dialog opening
 //checking marlin_update_vars(MARLIN_VAR_MSK(MARLIN_VAR_GQUEUE))->gqueue and calling gui_loop() does not help
 WizardState_t StateFnc_FIRSTLAY_PRINT() {
-    DialogHandler::Open(ClientFSM::FirstLayer, 0); //open screen now, it would auto open later (on G26)
+    DialogHandler::PreOpen(ClientFSM::FirstLayer, 0); //open screen now, it would auto open later (on G26)
 
     const int temp_nozzle_preheat = int(Filaments::PreheatTemp);
     const int temp_nozzle = std::max(int(marlin_vars()->display_nozzle), int(Filaments::Current().nozzle));

--- a/src/gui/wizard/selftest.cpp
+++ b/src/gui/wizard/selftest.cpp
@@ -11,31 +11,31 @@
 
 WizardState_t StateFnc_SELFTEST_FAN() {
     marlin_test_start(stmFans);
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestFans, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestFans, 0);
     return WizardState_t::next;
 }
 
 WizardState_t StateFnc_SELFTEST_X() {
     marlin_test_start(stmXAxis);
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
     return WizardState_t::next;
 }
 
 WizardState_t StateFnc_SELFTEST_Y() {
     marlin_test_start(stmYAxis);
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
     return WizardState_t::next;
 }
 
 WizardState_t StateFnc_SELFTEST_Z() {
     marlin_test_start(stmZAxis);
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
     return WizardState_t::next;
 }
 
 WizardState_t StateFnc_SELFTEST_XYZ() {
     marlin_test_start(stmXYZAxis);
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
     return WizardState_t::next;
 }
 
@@ -63,6 +63,6 @@ WizardState_t StateFnc_SELFTEST_RESULT() {
 
 WizardState_t StateFnc_SELFTEST_TEMP() {
     marlin_test_start(stmHeaters);
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestHeat, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestHeat, 0);
     return WizardState_t::next;
 }

--- a/src/gui/wizard/selftest.cpp
+++ b/src/gui/wizard/selftest.cpp
@@ -11,31 +11,31 @@
 
 WizardState_t StateFnc_SELFTEST_FAN() {
     marlin_test_start(stmFans);
-    DialogHandler::WaitUntilClosed(ClientFSM::SelftestFans, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestFans, 0);
     return WizardState_t::next;
 }
 
 WizardState_t StateFnc_SELFTEST_X() {
     marlin_test_start(stmXAxis);
-    DialogHandler::WaitUntilClosed(ClientFSM::SelftestAxis, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
     return WizardState_t::next;
 }
 
 WizardState_t StateFnc_SELFTEST_Y() {
     marlin_test_start(stmYAxis);
-    DialogHandler::WaitUntilClosed(ClientFSM::SelftestAxis, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
     return WizardState_t::next;
 }
 
 WizardState_t StateFnc_SELFTEST_Z() {
     marlin_test_start(stmZAxis);
-    DialogHandler::WaitUntilClosed(ClientFSM::SelftestAxis, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
     return WizardState_t::next;
 }
 
 WizardState_t StateFnc_SELFTEST_XYZ() {
     marlin_test_start(stmXYZAxis);
-    DialogHandler::WaitUntilClosed(ClientFSM::SelftestAxis, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
     return WizardState_t::next;
 }
 
@@ -63,6 +63,6 @@ WizardState_t StateFnc_SELFTEST_RESULT() {
 
 WizardState_t StateFnc_SELFTEST_TEMP() {
     marlin_test_start(stmHeaters);
-    DialogHandler::WaitUntilClosed(ClientFSM::SelftestHeat, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestHeat, 0);
     return WizardState_t::next;
 }

--- a/src/gui/wizard/selftest_sub_state.hpp
+++ b/src/gui/wizard/selftest_sub_state.hpp
@@ -1,0 +1,14 @@
+/**
+ * @file selftest_sub_state.hpp
+ * @author Radek Vana
+ * @date 2021-03-03
+ */
+
+#pragma once
+
+enum class SelftestSubtestState_t : uint8_t { //it is passed as uint8_t between threads
+    undef,
+    ok,
+    not_good,
+    running
+};

--- a/src/gui/wizard/wizard_config.hpp
+++ b/src/gui/wizard/wizard_config.hpp
@@ -1,13 +1,7 @@
 // wizard_config.hpp
 #pragma once
+#include "selftest_sub_state.hpp"
 #include "eeprom.h" // SelftestResult_Passed, SelftestResult_Failed
-
-enum class SelftestSubtestState_t : uint8_t { //it is passed as uint8_t between threads
-    undef,
-    ok,
-    not_good,
-    running
-};
 
 constexpr SelftestSubtestState_t SelftestStateFromEeprom(uint8_t state) {
     switch (state) {

--- a/src/guiapi/src/MItem_tools.cpp
+++ b/src/guiapi/src/MItem_tools.cpp
@@ -119,7 +119,7 @@ MI_TEST_FANS::MI_TEST_FANS()
 
 void MI_TEST_FANS::click(IWindowMenu & /*window_menu*/) {
     marlin_test_start(stmFans);
-    DialogHandler::WaitUntilClosed(ClientFSM::SelftestFans, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestFans, 0);
 }
 
 /*****************************************************************************/
@@ -130,7 +130,7 @@ MI_TEST_XYZ::MI_TEST_XYZ()
 
 void MI_TEST_XYZ::click(IWindowMenu & /*window_menu*/) {
     marlin_test_start(stmXYZAxis);
-    DialogHandler::WaitUntilClosed(ClientFSM::SelftestAxis, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
 }
 
 /*****************************************************************************/
@@ -141,7 +141,7 @@ MI_TEST_HEAT::MI_TEST_HEAT()
 
 void MI_TEST_HEAT::click(IWindowMenu & /*window_menu*/) {
     marlin_test_start(stmHeaters);
-    DialogHandler::WaitUntilClosed(ClientFSM::SelftestHeat, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestHeat, 0);
 }
 
 /*****************************************************************************/
@@ -152,7 +152,7 @@ MI_ADVANCED_FAN_TEST::MI_ADVANCED_FAN_TEST()
 
 void MI_ADVANCED_FAN_TEST::click(IWindowMenu & /*window_menu*/) {
     marlin_test_start(stmFans_fine);
-    DialogHandler::WaitUntilClosed(ClientFSM::SelftestFans, 0);
+    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestFans, 0);
 }
 
 /*****************************************************************************/

--- a/src/guiapi/src/MItem_tools.cpp
+++ b/src/guiapi/src/MItem_tools.cpp
@@ -119,7 +119,7 @@ MI_TEST_FANS::MI_TEST_FANS()
 
 void MI_TEST_FANS::click(IWindowMenu & /*window_menu*/) {
     marlin_test_start(stmFans);
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestFans, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestFans, 0);
 }
 
 /*****************************************************************************/
@@ -130,7 +130,7 @@ MI_TEST_XYZ::MI_TEST_XYZ()
 
 void MI_TEST_XYZ::click(IWindowMenu & /*window_menu*/) {
     marlin_test_start(stmXYZAxis);
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestAxis, 0);
 }
 
 /*****************************************************************************/
@@ -141,7 +141,7 @@ MI_TEST_HEAT::MI_TEST_HEAT()
 
 void MI_TEST_HEAT::click(IWindowMenu & /*window_menu*/) {
     marlin_test_start(stmHeaters);
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestHeat, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestHeat, 0);
 }
 
 /*****************************************************************************/
@@ -152,7 +152,7 @@ MI_ADVANCED_FAN_TEST::MI_ADVANCED_FAN_TEST()
 
 void MI_ADVANCED_FAN_TEST::click(IWindowMenu & /*window_menu*/) {
     marlin_test_start(stmFans_fine);
-    DialogHandler::DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestFans, 0);
+    DialogHandler::Access().WaitUntilClosed(ClientFSM::SelftestFans, 0);
 }
 
 /*****************************************************************************/

--- a/src/marlin_stubs/M50.cpp
+++ b/src/marlin_stubs/M50.cpp
@@ -28,7 +28,8 @@ void PrusaGcodeSuite::M50() {
         axis_test = fan_axis_test = true;
     }
 
-    {
+    //what is this? some kind of test code?
+    /*{
         FSM_Holder D(ClientFSM::SelftestFans, 0); //create dialog and destroy it at the end of scope
         fsm_change(ClientFSM::SelftestFans, PhasesSelftestFans::TestFan0, 0, uint8_t(SelftestSubtestState_t::running));
         do_blocking_move_to_z(10, feedRate_t(NOZZLE_PARK_Z_FEEDRATE));
@@ -37,7 +38,7 @@ void PrusaGcodeSuite::M50() {
         do_blocking_move_to_z(0, feedRate_t(NOZZLE_PARK_Z_FEEDRATE));
         fsm_change(ClientFSM::SelftestFans, PhasesSelftestFans::TestFan1, 100, uint8_t(SelftestSubtestState_t::not_good));
         do_blocking_move_to_z(10, feedRate_t(NOZZLE_PARK_Z_FEEDRATE));
-    }
+    }*/
     {
         FSM_Holder D(ClientFSM::SelftestAxis, 0);
         const float target_Z = 20;

--- a/src/marlin_stubs/M50.cpp
+++ b/src/marlin_stubs/M50.cpp
@@ -28,17 +28,6 @@ void PrusaGcodeSuite::M50() {
         axis_test = fan_axis_test = true;
     }
 
-    //what is this? some kind of test code?
-    /*{
-        FSM_Holder D(ClientFSM::SelftestFans, 0); //create dialog and destroy it at the end of scope
-        fsm_change(ClientFSM::SelftestFans, PhasesSelftestFans::TestFan0, 0, uint8_t(SelftestSubtestState_t::running));
-        do_blocking_move_to_z(10, feedRate_t(NOZZLE_PARK_Z_FEEDRATE));
-        fsm_change(ClientFSM::SelftestFans, PhasesSelftestFans::TestFan0, 30, uint8_t(SelftestSubtestState_t::ok));
-        fsm_change(ClientFSM::SelftestFans, PhasesSelftestFans::TestFan1, 80, uint8_t(SelftestSubtestState_t::running));
-        do_blocking_move_to_z(0, feedRate_t(NOZZLE_PARK_Z_FEEDRATE));
-        fsm_change(ClientFSM::SelftestFans, PhasesSelftestFans::TestFan1, 100, uint8_t(SelftestSubtestState_t::not_good));
-        do_blocking_move_to_z(10, feedRate_t(NOZZLE_PARK_Z_FEEDRATE));
-    }*/
     {
         FSM_Holder D(ClientFSM::SelftestAxis, 0);
         const float target_Z = 20;

--- a/src/marlin_stubs/include/pause_stubbed.hpp
+++ b/src/marlin_stubs/include/pause_stubbed.hpp
@@ -51,7 +51,7 @@ protected:
     };
 
     PausePrivatePhase();
-    void setPhase(PhasesLoadUnload ph, uint8_t progress_tot = 0);
+    void setPhase(PhasesLoadUnload ph, uint8_t progress = 0);
     PhasesLoadUnload getPhase() const;
 
     // auto restores temp turned off by safety timer,

--- a/src/marlin_stubs/pause/pause.cpp
+++ b/src/marlin_stubs/pause/pause.cpp
@@ -78,9 +78,10 @@ PausePrivatePhase::PausePrivatePhase()
     , nozzle_restore_temp(NAN)
     , bed_restore_temp(NAN) {}
 
-void PausePrivatePhase::setPhase(PhasesLoadUnload ph, uint8_t progress_tot) {
+void PausePrivatePhase::setPhase(PhasesLoadUnload ph, uint8_t progress) {
     phase = ph;
-    fsm_change(ClientFSM::Load_unload, phase, { { progress_tot } });
+    ProgressSerializer serializer(progress);
+    fsm_change(ClientFSM::Load_unload, phase, serializer.Serialize());
 }
 
 PhasesLoadUnload PausePrivatePhase::getPhase() const { return phase; }

--- a/src/marlin_stubs/pause/pause.cpp
+++ b/src/marlin_stubs/pause/pause.cpp
@@ -80,7 +80,7 @@ PausePrivatePhase::PausePrivatePhase()
 
 void PausePrivatePhase::setPhase(PhasesLoadUnload ph, uint8_t progress_tot) {
     phase = ph;
-    fsm_change(ClientFSM::Load_unload, phase, progress_tot, progress_tot == 100 ? 100 : 0);
+    fsm_change(ClientFSM::Load_unload, phase, { { progress_tot } });
 }
 
 PhasesLoadUnload PausePrivatePhase::getPhase() const { return phase; }

--- a/tests/unit/common/CMakeLists.txt
+++ b/tests/unit/common/CMakeLists.txt
@@ -1,33 +1,35 @@
+add_executable(
+  support_utils_tests ${CMAKE_CURRENT_SOURCE_DIR}/support_utils_lib_test.cpp
+                      ${CMAKE_SOURCE_DIR}/src/common/support_utils_lib.cpp
+  )
+target_include_directories(support_utils_tests PUBLIC ${CMAKE_SOURCE_DIR}/src/common)
 
-add_executable(support_utils_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/support_utils_lib_test.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/support_utils_lib.cpp
-)
-target_include_directories(support_utils_tests PUBLIC
-    ${CMAKE_SOURCE_DIR}/src/common
-)
+add_executable(
+  variant8_tests
+  ${CMAKE_SOURCE_DIR}/tests/unit/test_main.cpp ${CMAKE_SOURCE_DIR}/src/common/variant8.cpp
+  ${CMAKE_SOURCE_DIR}/tests/stubs/malloc_stub.cpp ${CMAKE_CURRENT_SOURCE_DIR}/variant8_tests.cpp
+  )
+target_include_directories(
+  variant8_tests PUBLIC ${CMAKE_SOURCE_DIR}/tests/stubs ${CMAKE_SOURCE_DIR}/src
+  )
 
-add_executable(variant8_tests
-    ${CMAKE_SOURCE_DIR}/tests/unit/test_main.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/variant8.cpp
-    ${CMAKE_SOURCE_DIR}/tests/stubs/malloc_stub.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/variant8_tests.cpp
-)
-target_include_directories(variant8_tests PUBLIC
-    ${CMAKE_SOURCE_DIR}/tests/stubs
-    ${CMAKE_SOURCE_DIR}/src
-)
+add_executable(
+  str_utils_tests
+  ${CMAKE_CURRENT_SOURCE_DIR}/str_utils_test.cpp ${CMAKE_SOURCE_DIR}/src/common/str_utils.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/str_utils.hpp
+  )
+target_include_directories(
+  str_utils_tests PUBLIC # ${CMAKE_SOURCE_DIR}/src/common
+                         ${CMAKE_SOURCE_DIR}/src
+  )
 
-add_executable(str_utils_tests
-    ${CMAKE_CURRENT_SOURCE_DIR}/str_utils_test.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/str_utils.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/str_utils.hpp
-)
-target_include_directories(str_utils_tests PUBLIC
-#    ${CMAKE_SOURCE_DIR}/src/common
-    ${CMAKE_SOURCE_DIR}/src
-)
+add_executable(
+  fsm_types_test ${CMAKE_CURRENT_SOURCE_DIR}/fsm_types_test.cpp
+                 ${CMAKE_SOURCE_DIR}/src/common/fsm_types.cpp
+  )
+target_include_directories(fsm_types_test PUBLIC ${CMAKE_SOURCE_DIR}/src/common)
 
 add_catch_test(support_utils_tests)
 add_catch_test(variant8_tests)
 add_catch_test(str_utils_tests)
+add_catch_test(fsm_types_test)

--- a/tests/unit/common/CMakeLists.txt
+++ b/tests/unit/common/CMakeLists.txt
@@ -29,7 +29,18 @@ add_executable(
   )
 target_include_directories(fsm_types_test PUBLIC ${CMAKE_SOURCE_DIR}/src/common)
 
+add_executable(
+  fsm_serializers_test ${CMAKE_CURRENT_SOURCE_DIR}/fsm_serializers_test.cpp
+                       ${CMAKE_SOURCE_DIR}/src/common/fsm_types.cpp
+  )
+target_include_directories(
+  fsm_serializers_test
+  PUBLIC ${CMAKE_SOURCE_DIR}/src/common
+  PUBLIC ${CMAKE_SOURCE_DIR}/src/gui/wizard
+  )
+
 add_catch_test(support_utils_tests)
 add_catch_test(variant8_tests)
 add_catch_test(str_utils_tests)
 add_catch_test(fsm_types_test)
+add_catch_test(fsm_serializers_test)

--- a/tests/unit/common/fsm_serializers_test.cpp
+++ b/tests/unit/common/fsm_serializers_test.cpp
@@ -1,0 +1,149 @@
+/**
+ * @file fsm_serializers_test.cpp
+ * @author Radek Vana
+ * @brief Unit tests for fsm types, especially fsm::Queue
+ * @date 2021-02-22
+ */
+
+//#define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
+#include "catch2/catch.hpp"
+
+#include "fsm_types.hpp"
+#include "fsm_progress_type.hpp"
+#include "selftest_axis_type.hpp"
+#include "selftest_fans_type.hpp"
+#include "selftest_heaters_type.hpp"
+
+using namespace fsm;
+
+template <class OBJ>
+void serialize_deserialize(OBJ cl) {
+    auto serialized = cl.Serialize();
+
+    OBJ ctor_tst(serialized);
+    OBJ deserialize_tst;
+    deserialize_tst.Deserialize(serialized);
+
+    REQUIRE(ctor_tst == cl);
+    REQUIRE(deserialize_tst == cl);
+}
+
+static constexpr int repeat_count = 4; // must be int, RangeGenerator takes template parameters
+template <class T>
+using Array = std::array<T, repeat_count>;
+
+/*****************************************************************************/
+//tests
+TEST_CASE("ProgressSerializer", "[fsm]") {
+    uint8_t progress = GENERATE(0, 1, 5, 0xFF);
+
+    ProgressSerializer cl(progress);
+    REQUIRE(cl.progress == progress);
+
+    serialize_deserialize(cl);
+
+    SECTION("equality") {
+        uint8_t progress2 = GENERATE(0, 1, 55, 0xFF);
+        ProgressSerializer cl2(progress2);
+
+        //progeses with equal data are equal
+        REQUIRE((cl == cl2) == (progress == progress2));
+    }
+}
+
+TEST_CASE("SelftestAxis_t", "[fsm]") {
+
+    int cycle = GENERATE(range(0, repeat_count - 1));
+
+    Array<uint8_t> x_progress = { { 0, 100, 22, 25 } };
+    Array<uint8_t> y_progress = { { 0, 100, 33, 35 } };
+    Array<uint8_t> z_progress = { { 0, 100, 11, 66 } };
+    Array<SelftestSubtestState_t> x_state = { { SelftestSubtestState_t::undef, SelftestSubtestState_t::ok, SelftestSubtestState_t::not_good, SelftestSubtestState_t::running } };
+    Array<SelftestSubtestState_t> y_state = { { SelftestSubtestState_t::undef, SelftestSubtestState_t::not_good, SelftestSubtestState_t::ok, SelftestSubtestState_t::running } };
+    Array<SelftestSubtestState_t> z_state = { { SelftestSubtestState_t::undef, SelftestSubtestState_t::undef, SelftestSubtestState_t::running, SelftestSubtestState_t::running } };
+
+    SelftestAxis_t cl(x_progress[cycle], y_progress[cycle], z_progress[cycle],
+        x_state[cycle], y_state[cycle], z_state[cycle]);
+
+    REQUIRE(cl.x_progress == x_progress[cycle]);
+    REQUIRE(cl.y_progress == y_progress[cycle]);
+    REQUIRE(cl.z_progress == z_progress[cycle]);
+    REQUIRE(cl.x_state == x_state[cycle]);
+    REQUIRE(cl.y_state == y_state[cycle]);
+    REQUIRE(cl.z_state == z_state[cycle]);
+
+    serialize_deserialize(cl);
+
+    SECTION("equality") {
+        int cycle2 = GENERATE(range(0, repeat_count - 1));
+        SelftestAxis_t cl2(x_progress[cycle2], y_progress[cycle2], z_progress[cycle2],
+            x_state[cycle2], y_state[cycle2], z_state[cycle2]);
+
+        //progeses with equal data are equal
+        REQUIRE((cl == cl2) == (cycle == cycle2));
+    }
+}
+
+TEST_CASE("SelftestFans_t", "[fsm]") {
+
+    int cycle = GENERATE(range(0, repeat_count - 1));
+
+    Array<uint8_t> print_fan_progress = { { 0, 100, 22, 25 } };
+    Array<uint8_t> nozzle_fan_progress = { { 0, 100, 33, 35 } };
+    Array<uint8_t> tot_progress = { { 0, 100, 11, 66 } };
+    Array<SelftestSubtestState_t> print_fan_state = { { SelftestSubtestState_t::undef, SelftestSubtestState_t::ok, SelftestSubtestState_t::not_good, SelftestSubtestState_t::running } };
+    Array<SelftestSubtestState_t> nozzle_fan_state = { { SelftestSubtestState_t::undef, SelftestSubtestState_t::not_good, SelftestSubtestState_t::ok, SelftestSubtestState_t::running } };
+
+    SelftestFans_t cl(print_fan_progress[cycle], nozzle_fan_progress[cycle], tot_progress[cycle],
+        print_fan_state[cycle], nozzle_fan_state[cycle]);
+
+    REQUIRE(cl.print_fan_progress == print_fan_progress[cycle]);
+    REQUIRE(cl.nozzle_fan_progress == nozzle_fan_progress[cycle]);
+    REQUIRE(cl.tot_progress == tot_progress[cycle]);
+    REQUIRE(cl.print_fan_state == print_fan_state[cycle]);
+    REQUIRE(cl.nozzle_fan_state == nozzle_fan_state[cycle]);
+
+    serialize_deserialize(cl);
+
+    SECTION("equality") {
+        int cycle2 = GENERATE(range(0, repeat_count - 1));
+        SelftestFans_t cl2(print_fan_progress[cycle2], nozzle_fan_progress[cycle2], tot_progress[cycle2],
+            print_fan_state[cycle2], nozzle_fan_state[cycle2]);
+
+        //progeses with equal data are equal
+        REQUIRE((cl == cl2) == (cycle == cycle2));
+    }
+}
+
+TEST_CASE("SelftestHeaters_t", "[fsm]") {
+
+    int cycle = GENERATE(range(0, repeat_count - 1));
+
+    Array<uint8_t> noz_progress = { { 0, 100, 22, 25 } };
+    Array<uint8_t> bed_progress = { { 0, 100, 33, 35 } };
+    Array<SelftestSubtestState_t> noz_prep_state = { { SelftestSubtestState_t::undef, SelftestSubtestState_t::ok, SelftestSubtestState_t::not_good, SelftestSubtestState_t::running } };
+    Array<SelftestSubtestState_t> noz_heat_state = { { SelftestSubtestState_t::undef, SelftestSubtestState_t::not_good, SelftestSubtestState_t::ok, SelftestSubtestState_t::running } };
+    Array<SelftestSubtestState_t> bed_prep_state = { { SelftestSubtestState_t::undef, SelftestSubtestState_t::undef, SelftestSubtestState_t::running, SelftestSubtestState_t::running } };
+    Array<SelftestSubtestState_t> bed_heat_state = { { SelftestSubtestState_t::undef, SelftestSubtestState_t::running, SelftestSubtestState_t::undef, SelftestSubtestState_t::running } };
+
+    SelftestHeaters_t cl(noz_progress[cycle], bed_progress[cycle], noz_prep_state[cycle],
+        noz_heat_state[cycle], bed_prep_state[cycle], bed_heat_state[cycle]);
+
+    REQUIRE(cl.noz_progress == noz_progress[cycle]);
+    REQUIRE(cl.bed_progress == bed_progress[cycle]);
+    REQUIRE(cl.noz_prep_state == noz_prep_state[cycle]);
+    REQUIRE(cl.noz_heat_state == noz_heat_state[cycle]);
+    REQUIRE(cl.bed_prep_state == bed_prep_state[cycle]);
+    REQUIRE(cl.bed_heat_state == bed_heat_state[cycle]);
+
+    serialize_deserialize(cl);
+
+    SECTION("equality") {
+        int cycle2 = GENERATE(range(0, repeat_count - 1));
+        SelftestHeaters_t cl2(noz_progress[cycle2], bed_progress[cycle2], noz_prep_state[cycle2],
+            noz_heat_state[cycle2], bed_prep_state[cycle2], bed_heat_state[cycle2]);
+
+        //progeses with equal data are equal
+        REQUIRE((cl == cl2) == (cycle == cycle2));
+    }
+}

--- a/tests/unit/common/fsm_types_test.cpp
+++ b/tests/unit/common/fsm_types_test.cpp
@@ -76,52 +76,32 @@ public:
 
 /*****************************************************************************/
 //tests
-TEST_CASE("fsm::type_t", "[fsm]") {
-    test_type_all_commands(ClientFSM(0));
-    test_type_all_commands(ClientFSM::_none); // _none != 0
-    test_type_all_commands(ClientFSM::Load_unload);
-}
+TEST_CASE("fsm::type_t, create_t, destroy_t, change_t, variant_t", "[fsm]") {
+    ClientFSM generator_client = GENERATE(ClientFSM(0), ClientFSM::_none, ClientFSM::Load_unload); // _none != 0 , it is last
 
-TEST_CASE("fsm::create_t", "[fsm]") {
-    test_create(ClientFSM(0), 0x00);
-    test_create(ClientFSM(0), 0xAB);
-    test_create(ClientFSM(0), 0xFF);
+    SECTION("type_t") {
+        test_type_all_commands(generator_client);
+    }
 
-    // _none != 0
-    test_create(ClientFSM::_none, 0x00);
-    test_create(ClientFSM::_none, 0xAB);
-    test_create(ClientFSM::_none, 0xFF);
+    SECTION("create_t") {
+        uint8_t generator_data = GENERATE(0x00, 0xAB, 0xFF);
+        test_create(generator_client, generator_data);
+    }
 
-    test_create(ClientFSM::Load_unload, 0x00);
-    test_create(ClientFSM::Printing, 0xAB);
-    test_create(ClientFSM::FirstLayer, 0xFF);
-}
+    SECTION("destroy_t") {
+        test_destroy(generator_client);
+    }
 
-TEST_CASE("fsm::destroy_t", "[fsm]") {
-    test_destroy(ClientFSM(0));
-    test_destroy(ClientFSM::_none); // _none != 0
-    test_destroy(ClientFSM::Load_unload);
-}
+    SECTION("change_t") {
+        uint8_t generator_phase = GENERATE(0x00, 0xAB, 0xFF);
+        PhaseData generator_phaseData = GENERATE(PhaseData({ 0x00, 0x00, 0x00, 0x00 }), PhaseData({ { 0x12, 0x23, 0x34, 0x56 } }), PhaseData({ { 0xFF, 0xFF, 0xFF, 0xFF } }));
 
-TEST_CASE("fsm::change_t", "[fsm]") {
-    test_change(ClientFSM(0), BaseData(0x00, { { 0x00, 0x00, 0x00, 0x00 } }));
-    test_change(ClientFSM(0), BaseData(0xAB, { { 0x12, 0x23, 0x34, 0x56 } }));
-    test_change(ClientFSM(0), BaseData(0xFF, { { 0xFF, 0xFF, 0xFF, 0xFF } }));
+        test_change(generator_client, BaseData(generator_phase, generator_phaseData));
+    }
 
-    // _none != 0
-    test_change(ClientFSM::_none, BaseData(0x00, { { 0x00, 0x00, 0x00, 0x00 } }));
-    test_change(ClientFSM::_none, BaseData(0x12, { { 0x23, 0x34, 0x56, 0x78 } }));
-    test_change(ClientFSM::_none, BaseData(0xFF, { { 0xFF, 0xFF, 0xFF, 0xFF } }));
-
-    test_change(ClientFSM::Load_unload, BaseData(0x00, { { 0x00, 0x00, 0x00, 0x00 } }));
-    test_change(ClientFSM::Printing, BaseData(0x0F, { { 0x34, 0x56, 0x12, 0x23 } }));
-    test_change(ClientFSM::FirstLayer, BaseData(0xFF, { { 0xFF, 0xFF, 0xFF, 0xFF } }));
-}
-
-TEST_CASE("fsm::variant_t", "[fsm]") {
-    test_variant(ClientFSM(0));
-    test_variant(ClientFSM::_none); // _none != 0
-    test_variant(ClientFSM::Load_unload);
+    SECTION("variant_t") {
+        test_variant(generator_client);
+    }
 }
 
 TEST_CASE("Equality of BaseData", "[fsm]") {

--- a/tests/unit/common/fsm_types_test.cpp
+++ b/tests/unit/common/fsm_types_test.cpp
@@ -1,0 +1,329 @@
+/**
+ * @file fsm_types_test.cpp
+ * @author Radek Vana
+ * @brief Unit tests for fsm types, especially fsm::Queue
+ * @date 2021-02-22
+ */
+
+//#define CATCH_CONFIG_MAIN // This tells Catch to provide a main() - only do this in one cpp file
+#include "catch2/catch.hpp"
+
+#include "fsm_types.hpp"
+
+void test_type(ClientFSM_Command command, ClientFSM type) {
+    fsm::type_t tst(command, type);
+    REQUIRE(command == tst.GetCommand());
+    REQUIRE(type == tst.GetType());
+}
+
+void test_type_all_commands(ClientFSM type) {
+    test_type(ClientFSM_Command::none, type);
+    test_type(ClientFSM_Command::create, type);
+    test_type(ClientFSM_Command::destroy, type);
+    test_type(ClientFSM_Command::change, type);
+}
+
+void test_create(ClientFSM type, uint8_t data) {
+    fsm::create_t tst(type, data);
+
+    REQUIRE(tst.type.GetCommand() == ClientFSM_Command::create);
+    REQUIRE(tst.type.GetType() == type);
+    REQUIRE(tst.data == data);
+}
+
+void test_destroy(ClientFSM type) {
+    fsm::destroy_t tst(type);
+
+    REQUIRE(tst.type.GetCommand() == ClientFSM_Command::destroy);
+    REQUIRE(tst.type.GetType() == type);
+}
+
+void test_change(ClientFSM type, uint8_t phase, uint8_t progress_tot, uint8_t progress) {
+    fsm::change_t tst(type, phase, progress_tot, progress);
+
+    REQUIRE(tst.type.GetCommand() == ClientFSM_Command::change);
+    REQUIRE(tst.type.GetType() == type);
+    REQUIRE(tst.phase == phase);
+    REQUIRE(tst.progress_tot == progress_tot);
+    REQUIRE(tst.progress == progress);
+}
+
+void test_variant(ClientFSM type) {
+    fsm::variant_t tst_create(fsm::create_t(type, 0));
+    fsm::variant_t tst_destroy(fsm::destroy_t({ type }));
+    fsm::variant_t tst_change(fsm::change_t(type, 0, 0, 0));
+
+    REQUIRE(tst_create.GetCommand() == ClientFSM_Command::create);
+    REQUIRE(tst_create.GetType() == type);
+
+    REQUIRE(tst_destroy.GetCommand() == ClientFSM_Command::destroy);
+    REQUIRE(tst_destroy.GetType() == type);
+
+    REQUIRE(tst_change.GetCommand() == ClientFSM_Command::change);
+    REQUIRE(tst_change.GetType() == type);
+}
+
+class MockQueue : public fsm::Queue {
+public:
+    uint8_t GetCount() const { return count; }
+
+    void TestEmpty() {
+        REQUIRE(GetCount() == 0);
+        REQUIRE(Front().GetCommand() == ClientFSM_Command::none);
+        REQUIRE(Back().GetCommand() == ClientFSM_Command::none);
+    }
+};
+
+/*****************************************************************************/
+//tests
+TEST_CASE("fsm::type_t", "[fsm_type]") {
+    test_type_all_commands(ClientFSM(0));
+    test_type_all_commands(ClientFSM::_none); // _none != 0
+    test_type_all_commands(ClientFSM::Load_unload);
+}
+
+TEST_CASE("fsm::create_t", "[fsm_create]") {
+    test_create(ClientFSM(0), 0x00);
+    test_create(ClientFSM(0), 0xAB);
+    test_create(ClientFSM(0), 0xFF);
+
+    // _none != 0
+    test_create(ClientFSM::_none, 0x00);
+    test_create(ClientFSM::_none, 0xAB);
+    test_create(ClientFSM::_none, 0xFF);
+
+    test_create(ClientFSM::Load_unload, 0x00);
+    test_create(ClientFSM::Printing, 0xAB);
+    test_create(ClientFSM::FirstLayer, 0xFF);
+}
+
+TEST_CASE("fsm::destroy_t", "[fsm_destroy]") {
+    test_destroy(ClientFSM(0));
+    test_destroy(ClientFSM::_none); // _none != 0
+    test_destroy(ClientFSM::Load_unload);
+}
+
+TEST_CASE("fsm::change_t", "[fsm_change]") {
+    test_change(ClientFSM(0), 0x00, 0x00, 0x00);
+    test_change(ClientFSM(0), 0xAB, 0x12, 0x23);
+    test_change(ClientFSM(0), 0xFF, 0xFF, 0xFF);
+
+    // _none != 0
+    test_change(ClientFSM::_none, 0x00, 0x00, 0x00);
+    test_change(ClientFSM::_none, 0x01, 0x02, 0x03);
+    test_change(ClientFSM::_none, 0xFF, 0xFF, 0xFF);
+
+    test_change(ClientFSM::Load_unload, 0x00, 0x00, 0x00);
+    test_change(ClientFSM::Printing, 0x00, 0x01, 0xFF);
+    test_change(ClientFSM::FirstLayer, 0xFF, 0xFF, 0xFF);
+}
+
+TEST_CASE("fsm::variant_t", "[fsm_variant]") {
+    test_variant(ClientFSM(0));
+    test_variant(ClientFSM::_none); // _none != 0
+    test_variant(ClientFSM::Load_unload);
+}
+
+TEST_CASE("fsm::Queue", "[fsm_Queue]") {
+    MockQueue q;
+    fsm::variant_t front = q.Front();
+    fsm::variant_t back = q.Back();
+
+    SECTION("Empty queue") {
+        q.TestEmpty();
+    }
+
+    SECTION("Pass without queing") {
+        q.TestEmpty();
+
+        const uint8_t data = 3;
+        q.PushCreate(ClientFSM::Preheat, data);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::create);
+        REQUIRE(front.GetType() == ClientFSM::Preheat);
+        REQUIRE(front.create.data == data);
+        q.Pop();
+        q.TestEmpty();
+
+        const uint8_t phase = 0x21;
+        const uint8_t progress_tot = 0x32;
+        const uint8_t progress = 0x45;
+        q.PushChange(ClientFSM::Preheat, phase, progress_tot, progress);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::change);
+        REQUIRE(front.GetType() == ClientFSM::Preheat);
+        REQUIRE(front.change.phase == phase);
+        REQUIRE(front.change.progress_tot == progress_tot);
+        REQUIRE(front.change.progress == progress);
+        q.Pop();
+        q.TestEmpty();
+
+        q.PushDestroy(ClientFSM::Preheat);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::destroy);
+        REQUIRE(front.GetType() == ClientFSM::Preheat);
+        q.Pop();
+        q.TestEmpty();
+    }
+
+    SECTION("Multiple destroy") {
+        q.TestEmpty();
+
+        q.PushDestroy(ClientFSM::Preheat);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::destroy);
+        REQUIRE(front.GetType() == ClientFSM::Preheat);
+
+        q.PushDestroy(ClientFSM::Load_unload);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::destroy);
+        REQUIRE(front.GetType() == ClientFSM::Preheat); // new destroy command cannot rewrite old one
+
+        q.Pop();
+        q.TestEmpty();
+    }
+
+    SECTION("Multiple create") {
+        q.TestEmpty();
+
+        const uint8_t data = 0x25;
+        q.PushCreate(ClientFSM::Preheat, data);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::create);
+        REQUIRE(front.GetType() == ClientFSM::Preheat);
+        REQUIRE(front.create.data == data);
+
+        //insertion must fail
+        const uint8_t data2 = 0xAA;
+        q.PushCreate(ClientFSM::Load_unload, data2);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::create);
+        REQUIRE(front.GetType() == ClientFSM::Preheat); // old one
+        REQUIRE(front.create.data == data);             // old one
+
+        q.Pop();
+        q.TestEmpty();
+    }
+
+    SECTION("Multiple change") {
+        q.TestEmpty();
+
+        const uint8_t phase = 0x21;
+        const uint8_t progress_tot = 0x32;
+        const uint8_t progress = 0x45;
+        q.PushChange(ClientFSM::Preheat, phase, progress_tot, progress);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::change);
+        REQUIRE(front.GetType() == ClientFSM::Preheat);
+        REQUIRE(front.change.phase == phase);
+        REQUIRE(front.change.progress_tot == progress_tot);
+        REQUIRE(front.change.progress == progress);
+
+        //insertion must fail .. wrong type
+        const uint8_t phase2 = 0x12;
+        const uint8_t progress_tot2 = 0x23;
+        const uint8_t progress2 = 0x5A;
+        q.PushChange(ClientFSM::Load_unload, phase2, progress_tot2, progress2);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::change);
+        REQUIRE(front.GetType() == ClientFSM::Preheat);     //old one
+        REQUIRE(front.change.phase == phase);               //old one
+        REQUIRE(front.change.progress_tot == progress_tot); //old one
+        REQUIRE(front.change.progress == progress);         //old one
+
+        //insertion must rewrite last one .. same type
+        q.PushChange(ClientFSM::Preheat, phase2, progress_tot2, progress2);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::change);
+        REQUIRE(front.GetType() == ClientFSM::Preheat);      //new one (but same as old one)
+        REQUIRE(front.change.phase == phase2);               //new one
+        REQUIRE(front.change.progress_tot == progress_tot2); //new one
+        REQUIRE(front.change.progress == progress2);         //new one
+
+        q.Pop();
+        q.TestEmpty();
+    }
+
+    SECTION("Multiple max queue length") {
+        q.TestEmpty();
+
+        //destroy
+        q.PushDestroy(ClientFSM::Preheat);
+        back = q.Back();
+        REQUIRE(q.GetCount() == 1);
+        REQUIRE(back.GetCommand() == ClientFSM_Command::destroy);
+        REQUIRE(back.GetType() == ClientFSM::Preheat);
+
+        //create
+        const uint8_t data = 0x25;
+        q.PushCreate(ClientFSM::Preheat, data);
+        back = q.Back();
+        REQUIRE(q.GetCount() == 2);
+        REQUIRE(back.GetCommand() == ClientFSM_Command::create);
+        REQUIRE(back.GetType() == ClientFSM::Preheat);
+        REQUIRE(back.create.data == data);
+
+        //change
+        const uint8_t phase = 0x21;
+        const uint8_t progress_tot = 0x32;
+        const uint8_t progress = 0x45;
+        q.PushChange(ClientFSM::Preheat, phase, progress_tot, progress);
+        back = q.Back();
+        REQUIRE(q.GetCount() == 3);
+        REQUIRE(back.GetCommand() == ClientFSM_Command::change);
+        REQUIRE(back.GetType() == ClientFSM::Preheat);
+        REQUIRE(back.change.phase == phase);
+        REQUIRE(back.change.progress_tot == progress_tot);
+        REQUIRE(back.change.progress == progress);
+
+        /*
+        //insertion must rewrite last change .. same type
+        q.PushChange(ClientFSM::Preheat, phase2, progress_tot2, progress2);
+        front = q.Front();
+        back = q.Back();
+        REQUIRE(q.GetCount() == 3);
+        REQUIRE(back.data == front.data);
+        REQUIRE(front.GetCommand() == ClientFSM_Command::change);
+        REQUIRE(front.GetType() == ClientFSM::Preheat);      //new one (but same as old one)
+        REQUIRE(front.change.phase == phase2);               //new one
+        REQUIRE(front.change.progress_tot == progress_tot2); //new one
+        REQUIRE(front.change.progress == progress2);         //new one
+*/
+        q.Pop();
+        REQUIRE(q.GetCount() == 2);
+        q.Pop();
+        REQUIRE(q.GetCount() == 1);
+        q.Pop();
+        q.TestEmpty();
+    }
+}

--- a/utils/dumpread/src/dump_marlinapi.c
+++ b/utils/dumpread/src/dump_marlinapi.c
@@ -94,9 +94,6 @@ void dump_marlinapi_print(dump_t *pd, mapfile_t *pm) {
         printf(" .resume_nozzle_temp = %f\n", pmarlin_server->resume_nozzle_temp);
         printf(" .resume_fan_speed = %u\n", pmarlin_server->resume_fan_speed);
         printf(" .paused_ticks = %u\n", pmarlin_server->paused_ticks);
-        printf(" .fsmCreate = %u\n", pmarlin_server->fsmCreate);
-        printf(" .fsmDestroy = %u\n", pmarlin_server->fsmDestroy);
-        printf(" .fsmChange = %u\n", pmarlin_server->fsmChange);
     }
 
     marlin_client_t *pmarlin_client = 0;
@@ -119,9 +116,7 @@ void dump_marlinapi_print(dump_t *pd, mapfile_t *pm) {
                     printf("   [%u][%u] = %f\n", x, y, pmarlin_client[c].mesh.z[x + y * pmarlin_client[c].mesh.xc]);
             printf("  .command = 0x%08x (%u)\n", pmarlin_client[c].command, pmarlin_client[c].command);
             printf("  .reheating = %u\n", pmarlin_client[c].reheating);
-            printf("  .fsm_create_cb = 0x%08x\n", pmarlin_client[c].fsm_create_cb);
-            printf("  .fsm_destroy_cb = 0x%08x\n", pmarlin_client[c].fsm_destroy_cb);
-            printf("  .fsm_change_cb = 0x%08x\n", pmarlin_client[c].fsm_change_cb);
+            printf("  .fsm_cb = 0x%08x\n", pmarlin_client[c].fsm_cb);
         }
     }
 

--- a/utils/dumpread/src/dump_marlinapi.h
+++ b/utils/dumpread/src/dump_marlinapi.h
@@ -97,9 +97,6 @@ typedef struct _marlin_server_t {
     float resume_nozzle_temp;                        // resume nozzle temperature
     uint8_t resume_fan_speed;                        // resume fan speed
     uint32_t paused_ticks;                           // tick count in moment when printing paused
-    uint32_t fsmCreate;                              // fsm create ui32 argument for resend
-    uint32_t fsmDestroy;                             // fsm destroy ui32 argument for resend
-    uint32_t fsmChange;                              // fsm change ui32 argument for resend
 } marlin_server_t;
 
 typedef struct _marlin_client_t {
@@ -111,12 +108,10 @@ typedef struct _marlin_client_t {
     uint32_t ack;        // cached ack value from last Acknowledge event
     uint16_t last_count; // number of messages received in last client loop
     uint64_t errors;
-    marlin_mesh_t mesh;      // meshbed leveling
-    uint32_t command;        // processed command (G28,G29,M701,M702,M600)
-    uint8_t reheating;       // reheating in progress
-    uint32_t fsm_create_cb;  // to register callback for screen creation (M876), callback ensures M876 is processed asap, so there is no need for queue
-    uint32_t fsm_destroy_cb; // to register callback for screen destruction
-    uint32_t fsm_change_cb;  // to register callback for change of state
+    marlin_mesh_t mesh; // meshbed leveling
+    uint32_t command;   // processed command (G28,G29,M701,M702,M600)
+    uint8_t reheating;  // reheating in progress
+    uint32_t fsm_cb;    // to register callback for screen creation (M876), callback ensures M876 is processed asap, so there is no need for queue
 } marlin_client_t;
 
 #pragma pack(pop)


### PR DESCRIPTION
Buffered events on marlin_server side.
No FSM event can be lost. New event cannot change event order. But higer priority event can clear events with same or higer priority. This is very important, because marlin can wait user click and GUI must know which buttons it should show.

Events on GUI side must be buffered too.
To prevent closing dialog inside gui_event - this is causing BSOD. 

Entire FSM event logic is changed.
Create/change/Destroy callbacks had to be merged into one. To enforce FSM event order.

BFW-1764