### PR TITLE
GUI: Seperate progress bar and progress percentage

### DIFF
--- a/src/gui/ScreenFirstLayer.cpp
+++ b/src/gui/ScreenFirstLayer.cpp
@@ -11,7 +11,7 @@
 ScreenFirstLayer::ScreenFirstLayer()
     : IScreenPrinting(_(caption))
     , text(this, Rect16(WizardDefaults::MarginLeft, 40, GuiDefaults::RectScreen.Width() - WizardDefaults::MarginLeft * 2, 150), is_multiline::yes, is_closed_on_click_t::no, _(text_str))
-    , progress(this, { WizardDefaults::MarginLeft, 190 + 30 }, HasNumber_t::no)
+    , progress(this, Rect16(WizardDefaults::MarginLeft, 190 + 30, GuiDefaults::RectScreen.Width() - 2 * WizardDefaults::MarginLeft, 8))
     , live_z(this, { int16_t(WizardDefaults::MarginLeft), 190 }, rect.Width() - WizardDefaults::MarginLeft * 2) {
     CaptureNormalWindow(live_z);
     live_z.Idle();

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -116,7 +116,8 @@ void screen_printing_data_t::stopAction() {
 screen_printing_data_t::screen_printing_data_t()
     : AddSuperWindow<ScreenPrintingModel>(_(caption))
     , w_filename(this, Rect16(10, 33, 220, 29))
-    , w_progress(this, { 10, 70 }, HasNumber_t::yes)
+    , w_progress(this, Rect16(10, 70, GuiDefaults::RectScreen.Width() - 2 * 10, 16))
+    , w_progress_txt(this, Rect16(10, 86, GuiDefaults::RectScreen.Width() - 2 * 10, 30))
     , w_time_label(this, Rect16(10, 128, 101, 20), is_multiline::no)
     , w_time_value(this, Rect16(10, 148, 101, 20), is_multiline::no)
     , w_etime_label(this, Rect16(130, 128, 101, 20), is_multiline::no)
@@ -162,6 +163,11 @@ screen_printing_data_t::screen_printing_data_t()
     w_time_value.SetPadding({ 0, 2, 0, 2 });
     // this MakeRAM is safe - text_time_dur is allocated in RAM for the lifetime of pw
     w_time_value.SetText(string_view_utf8::MakeRAM((const uint8_t *)text_time_dur.data()));
+
+    w_progress_txt.font = resource_font(IDR_FNT_BIG);
+    w_progress_txt.SetAlignment(Align_t::Center());
+    w_progress_txt.SetValue(0);
+    w_progress_txt.SetFormat("%d%%");
 
     initAndSetIconAndLabel(btn_tune, res_tune);
     initAndSetIconAndLabel(btn_pause, res_pause);
@@ -223,6 +229,13 @@ void screen_printing_data_t::windowEvent(EventLock /*has private ctor*/, window_
     if (!marlin_vars()->media_inserted && p_state == printing_state_t::PRINTED) {
         Screens::Access()->Close();
         return;
+    }
+
+    if (marlin_vars()->sd_percent_done != w_progress_txt.value) {
+        if (marlin_vars()->sd_percent_done > 0 && marlin_vars()->sd_percent_done <= 100) {
+            w_progress_txt.SetValue(marlin_vars()->sd_percent_done);
+            w_progress_txt.Invalidate();
+        }
     }
 
     /// -- check when media is or isn't inserted

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -117,7 +117,7 @@ screen_printing_data_t::screen_printing_data_t()
     : AddSuperWindow<ScreenPrintingModel>(_(caption))
     , w_filename(this, Rect16(10, 33, 220, 29))
     , w_progress(this, Rect16(10, 70, GuiDefaults::RectScreen.Width() - 2 * 10, 16))
-    , w_progress_txt(this, Rect16(10, 86, GuiDefaults::RectScreen.Width() - 2 * 10, 30))
+    , w_progress_txt(this, Rect16(10, 86, GuiDefaults::RectScreen.Width() - 2 * 10, 30), 0)
     , w_time_label(this, Rect16(10, 128, 101, 20), is_multiline::no)
     , w_time_value(this, Rect16(10, 148, 101, 20), is_multiline::no)
     , w_etime_label(this, Rect16(130, 128, 101, 20), is_multiline::no)
@@ -167,6 +167,7 @@ screen_printing_data_t::screen_printing_data_t()
     w_progress_txt.font = resource_font(IDR_FNT_BIG);
     w_progress_txt.SetAlignment(Align_t::Center());
     w_progress_txt.SetValue(0);
+    w_progress_txt.PrintAsInt();
     w_progress_txt.SetFormat("%d%%");
 
     initAndSetIconAndLabel(btn_tune, res_tune);

--- a/src/gui/screen_printing.hpp
+++ b/src/gui/screen_printing.hpp
@@ -45,6 +45,7 @@ class screen_printing_data_t : public AddSuperWindow<ScreenPrintingModel> {
 
     window_roll_text_t w_filename;
     WindowPrintProgress w_progress;
+    window_numb_t w_progress_txt;
     window_text_t w_time_label;
     window_text_t w_time_value;
     window_text_t w_etime_label;

--- a/src/gui/window_print_progress.cpp
+++ b/src/gui/window_print_progress.cpp
@@ -7,24 +7,9 @@
 /*****************************************************************************/
 //WindowPrintProgress
 #include "marlin_client.h"
-WindowPrintProgress::WindowPrintProgress(window_t *parent, point_i16_t position, HasNumber_t hasNum)
-    : AddSuperWindow<window_progress_t>(parent, Rect16(position.x, position.y, GuiDefaults::RectScreen.Width() - (2 * position.x), hasNum == HasNumber_t::yes ? 50 : 8),
-        hasNum == HasNumber_t::yes ? 16 : 8, hasNum == HasNumber_t::yes ? COLOR_ORANGE : COLOR_LIME)
-    , last_sd_percent_done(-1) {
-    SetFont(resource_font(IDR_FNT_BIG));
-}
-
-void WindowPrintProgress::update_progress(uint8_t percent, uint16_t print_speed) {
-    SetNumbColor((percent <= 100) && (print_speed == 100) ? GuiDefaults::COLOR_VALUE_VALID : GuiDefaults::COLOR_VALUE_INVALID);
-    SetValue(percent);
-}
+WindowPrintProgress::WindowPrintProgress(window_t *parent, Rect16 rect)
+    : AddSuperWindow<window_numberless_progress_t>(parent, rect) {}
 
 void WindowPrintProgress::windowEvent(EventLock /*has private ctor*/, window_t *sender, GUI_event_t event, void *param) {
-    if (event == GUI_event_t::LOOP) {
-        if (marlin_vars()->sd_percent_done != last_sd_percent_done) {
-            update_progress(marlin_vars()->sd_percent_done, marlin_vars()->print_speed);
-            last_sd_percent_done = marlin_vars()->sd_percent_done;
-        }
-    }
     SuperWindowEvent(sender, event, param);
 }

--- a/src/gui/window_print_progress.cpp
+++ b/src/gui/window_print_progress.cpp
@@ -8,8 +8,17 @@
 //WindowPrintProgress
 #include "marlin_client.h"
 WindowPrintProgress::WindowPrintProgress(window_t *parent, Rect16 rect)
-    : AddSuperWindow<window_numberless_progress_t>(parent, rect) {}
+    : AddSuperWindow<window_numberless_progress_t>(parent, rect)
+    , last_sd_percent_done(-1) {
+    SetColor(COLOR_ORANGE);
+}
 
 void WindowPrintProgress::windowEvent(EventLock /*has private ctor*/, window_t *sender, GUI_event_t event, void *param) {
+    if (event == GUI_event_t::LOOP) {
+        if (marlin_vars()->sd_percent_done != last_sd_percent_done) {
+            SetProgressPercent(marlin_vars()->sd_percent_done);
+            last_sd_percent_done = marlin_vars()->sd_percent_done;
+        }
+    }
     SuperWindowEvent(sender, event, param);
 }

--- a/src/gui/window_print_progress.hpp
+++ b/src/gui/window_print_progress.hpp
@@ -12,12 +12,11 @@ enum class HasNumber_t {
     yes
 };
 
-class WindowPrintProgress : public AddSuperWindow<window_progress_t> {
-    int8_t last_sd_percent_done;
+class WindowPrintProgress : public AddSuperWindow<window_numberless_progress_t> {
     void update_progress(uint8_t percent, uint16_t print_speed);
 
 public:
-    WindowPrintProgress(window_t *parent, point_i16_t position, HasNumber_t hasNum);
+    WindowPrintProgress(window_t *parent, Rect16 rect);
 
 protected:
     void windowEvent(EventLock /*has private ctor*/, window_t *sender, GUI_event_t event, void *param) override;

--- a/src/gui/window_print_progress.hpp
+++ b/src/gui/window_print_progress.hpp
@@ -13,6 +13,7 @@ enum class HasNumber_t {
 };
 
 class WindowPrintProgress : public AddSuperWindow<window_numberless_progress_t> {
+    int8_t last_sd_percent_done;
     void update_progress(uint8_t percent, uint16_t print_speed);
 
 public:


### PR DESCRIPTION
WindowPrintProgress now uses window_numberless_progress_t as a base class. Progress percentages on printing screen are handled separately with window_numb_t.