### PR TITLE
consume knob capture events

### DIFF
--- a/src/gui/dialogs/DialogTimed.cpp
+++ b/src/gui/dialogs/DialogTimed.cpp
@@ -32,7 +32,7 @@ void DialogTimed::windowEvent(EventLock /*has private ctor*/, window_t *sender, 
     }
 
     if (IsVisible()) {
-        if (GUI_event_IsCaptureEv(event) || GUI_event_IsKnob(event)) { // this window must be captured
+        if (GUI_event_IsCaptureEv(event)) { // this window must be captured
             Hide();
             time_of_last_action = now;
             return; // event consumed

--- a/src/guiapi/include/window_event.hpp
+++ b/src/guiapi/include/window_event.hpp
@@ -39,8 +39,8 @@ constexpr bool GUI_event_IsKnob(GUI_event_t event) {
 
 constexpr bool GUI_event_IsCaptureEv(GUI_event_t event) {
     switch (event) {
-    case GUI_event_t::BTN_DN:
-    case GUI_event_t::BTN_UP:
+    case GUI_event_t::ENC_DN:
+    case GUI_event_t::ENC_UP:
     case GUI_event_t::CLICK:
     case GUI_event_t::HOLD:
         return true;

--- a/src/guiapi/src/window_frame.cpp
+++ b/src/guiapi/src/window_frame.cpp
@@ -430,7 +430,7 @@ bool window_frame_t::IsChildCaptured() const {
 bool window_frame_t::CaptureNormalWindow(window_t &win) {
     if (win.GetParent() != this || win.GetType() != win_type_t::normal)
         return false;
-    window_t *last_captured = getCapturedNormalWin(); //recursive !!! GetCapturedWindow();
+    window_t *last_captured = getCapturedNormalWin();
     if (last_captured) {
         last_captured->WindowEvent(this, GUI_event_t::CAPT_0, 0); //will not resend event to anyone
     }


### PR DESCRIPTION
consume knob capture events in timed dialog, to avoid extra click when it is closed
BFW-1799