### PR TITLE
Walkaround ESP UART DMA restart

### DIFF
--- a/lib/ESP/prusa/src/system/lwesp_ll_buddy.c
+++ b/lib/ESP/prusa/src/system/lwesp_ll_buddy.c
@@ -88,6 +88,9 @@ void StartUartBufferThread(void const *arg) {
                 old_pos = 0;
             }
         }
+
+        // FIXME: This should not be here - this is necessary to restart DMA transfers
+        // TODO: Start DMA receive on UART ready, not just all the time
         HAL_UART_Receive_DMA(&huart6, (uint8_t *)dma_buffer_rx, RX_BUFFER_LEN);
     }
 }


### PR DESCRIPTION
This fixes DMA just filling the buffer with some data and then stop
receiving. This is a dirty patch but lets the lwESP to initialize itself.