### PR TITLE
v4.3.2: Fix CDC BSOD and refactor the CDC interface

### DIFF
--- a/include/usb_device/usb_device.h
+++ b/include/usb_device/usb_device.h
@@ -90,6 +90,7 @@ extern "C" {
 /** USB Device initialization function. */
 void MX_USB_DEVICE_Init(void);
 
+extern USBD_HandleTypeDef hUsbDeviceFS;
 /**
   * @}
   */

--- a/include/usb_device/usbd_cdc_if.h
+++ b/include/usb_device/usbd_cdc_if.h
@@ -1,158 +1,39 @@
-/**
-  ******************************************************************************
-  * @file           : usbd_cdc_if.h
-  * @version        : v1.0_Cube
-  * @brief          : Header for usbd_cdc_if.c file.
-  ******************************************************************************
-  * This notice applies to any and all portions of this file
-  * that are not between comment pairs USER CODE BEGIN and
-  * USER CODE END. Other portions of this file, whether
-  * inserted by the user or by software development tools
-  * are owned by their respective copyright owners.
-  *
-  * Copyright (c) 2019 STMicroelectronics International N.V.
-  * All rights reserved.
-  *
-  * Redistribution and use in source and binary forms, with or without
-  * modification, are permitted, provided that the following conditions are met:
-  *
-  * 1. Redistribution of source code must retain the above copyright notice,
-  *    this list of conditions and the following disclaimer.
-  * 2. Redistributions in binary form must reproduce the above copyright notice,
-  *    this list of conditions and the following disclaimer in the documentation
-  *    and/or other materials provided with the distribution.
-  * 3. Neither the name of STMicroelectronics nor the names of other
-  *    contributors to this software may be used to endorse or promote products
-  *    derived from this software without specific written permission.
-  * 4. This software, including modifications and/or derivative works of this
-  *    software, must execute solely and exclusively on microcontroller or
-  *    microprocessor devices manufactured by or for STMicroelectronics.
-  * 5. Redistribution and use of this software other than as permitted under
-  *    this license is void and will automatically terminate your rights under
-  *    this license.
-  *
-  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT
-  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-  * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
-  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
-  * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
+#pragma once
 
-/* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef __USBD_CDC_IF_H__
-    #define __USBD_CDC_IF_H__
-
-    #ifdef __cplusplus
+#ifdef __cplusplus
 extern "C" {
-    #endif
+#endif
 
-    /* Includes ------------------------------------------------------------------*/
-    #include "usbd_cdc.h"
+#include <stdbool.h>
+#include "usbd_cdc.h"
 
-/* USER CODE BEGIN INCLUDE */
+#ifdef USE_USB_FS
+    #define CDC_DATA_MAX_PACKET_SIZE CDC_DATA_FS_MAX_PACKET_SIZE
+#else
+    #define CDC_DATA_MAX_PACKET_SIZE CDC_DATA_HS_MAX_PACKET_SIZE
+#endif
 
-/* USER CODE END INCLUDE */
+enum {
+    /// Receive data size
+    USBD_CDC_RX_DATA_SIZE = 0,
+    /// Transmit buffef size (we need a space for one packet)
+    USBD_CDC_TX_DATA_SIZE = CDC_DATA_MAX_PACKET_SIZE,
+};
 
-/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
-  * @brief For Usb device.
-  * @{
-  */
+_Static_assert(USBD_CDC_TX_DATA_SIZE >= CDC_DATA_MAX_PACKET_SIZE, "tx buffer should hold at least 1 full usb packet");
 
-/** @defgroup USBD_CDC_IF USBD_CDC_IF
-  * @brief Usb VCP device module
-  * @{
-  */
+/// USB Device CDC Interface
+extern USBD_CDC_ItfTypeDef usbd_cdc_if;
 
-/** @defgroup USBD_CDC_IF_Exported_Defines USBD_CDC_IF_Exported_Defines
-  * @brief Defines.
-  * @{
-  */
-/* USER CODE BEGIN EXPORTED_DEFINES */
+/// Check whether the interface has been initialized
+bool usbd_cdc_is_ready();
 
-/* USER CODE END EXPORTED_DEFINES */
+/// Send data over the CDC interface
+uint8_t usbd_cdc_transmit(uint8_t *buffer, uint32_t length);
 
-/**
-  * @}
-  */
+/// Register a function to be called with received data
+void usbd_cdc_register_receive_fn(void (*receive_fn)(uint8_t *buffer, uint32_t length));
 
-/** @defgroup USBD_CDC_IF_Exported_Types USBD_CDC_IF_Exported_Types
-  * @brief Types.
-  * @{
-  */
-
-/* USER CODE BEGIN EXPORTED_TYPES */
-
-/* USER CODE END EXPORTED_TYPES */
-
-/**
-  * @}
-  */
-
-/** @defgroup USBD_CDC_IF_Exported_Macros USBD_CDC_IF_Exported_Macros
-  * @brief Aliases.
-  * @{
-  */
-
-/* USER CODE BEGIN EXPORTED_MACRO */
-
-/* USER CODE END EXPORTED_MACRO */
-
-/**
-  * @}
-  */
-
-/** @defgroup USBD_CDC_IF_Exported_Variables USBD_CDC_IF_Exported_Variables
-  * @brief Public variables.
-  * @{
-  */
-
-/** CDC Interface callback. */
-extern USBD_CDC_ItfTypeDef USBD_Interface_fops_FS;
-
-/* USER CODE BEGIN EXPORTED_VARIABLES */
-
-/* USER CODE END EXPORTED_VARIABLES */
-
-/**
-  * @}
-  */
-
-/** @defgroup USBD_CDC_IF_Exported_FunctionsPrototype USBD_CDC_IF_Exported_FunctionsPrototype
-  * @brief Public functions declaration.
-  * @{
-  */
-
-uint8_t CDC_Transmit_FS(uint8_t *Buf, uint16_t Len);
-
-/* USER CODE BEGIN EXPORTED_FUNCTIONS */
-
-/* USER CODE END EXPORTED_FUNCTIONS */
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-    #ifdef __cplusplus
+#ifdef __cplusplus
 }
-    #endif
-
-#endif /* __USBD_CDC_IF_H__ */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+#endif

--- a/lib/Arduino_Core_A3ides/cores/arduino/USBSerial.cpp
+++ b/lib/Arduino_Core_A3ides/cores/arduino/USBSerial.cpp
@@ -3,7 +3,7 @@
 #include "USBSerial.h"
 #include "stm32f4xx_hal.h"
 #include "cmsis_os.h"
-#include "usbd_def.h"
+#include "usbd_cdc_if.h"
 
 #define USBSERIAL_OBUF_SIZE 256
 #define USBSERIAL_IBUF_SIZE 256
@@ -11,10 +11,6 @@
 #define USBSERIAL_MAX_FAIL  10
 
 extern "C" {
-
-extern USBD_HandleTypeDef hUsbDeviceFS;
-extern uint8_t CDC_Transmit_FS(uint8_t *Buf, uint16_t Len);
-extern int usbd_cdc_initialized;
 
 int USBSerial_failcount = 0;
 
@@ -29,10 +25,10 @@ uint32_t ibufw = 0;                 //input buffer write index
 void usb_cdc_tx_buffer(void) {
     uint8_t ret;
     int retry = USBSERIAL_RETRY;
-    if (hUsbDeviceFS.pClassData && usbd_cdc_initialized) // end-point connected
+    if (usbd_cdc_is_ready()) // end-point connected
     {
         while (retry) {
-            ret = CDC_Transmit_FS(obuff, obufc);
+            ret = usbd_cdc_transmit(obuff, obufc);
             if (ret == USBD_OK)
                 break;
             osDelay(1);
@@ -41,7 +37,7 @@ void usb_cdc_tx_buffer(void) {
         if (retry == 0) {
             USBSerial_failcount++;
             if (USBSerial_failcount > USBSERIAL_MAX_FAIL) { //disable usb_cdc, reset fail counter
-                usbd_cdc_initialized = 0;
+                usbd_cdc_if.DeInit();
                 USBSerial_failcount = 0;
             }
         }

--- a/src/common/appmain.cpp
+++ b/src/common/appmain.cpp
@@ -14,6 +14,7 @@
 #include "gpio.h"
 #include "sound.hpp"
 #include "language_eeprom.hpp"
+#include "usbd_cdc_if.h"
 
 #ifdef SIM_HEATER
     #include "sim_heater.h"
@@ -59,6 +60,7 @@ CFanCtl fanctl1 = CFanCtl(
 //#define DBG(...)  //disable debug
 
 extern void USBSerial_put_rx_data(uint8_t *buffer, uint32_t length);
+extern void app_cdc_rx(uint8_t *buffer, uint32_t length);
 
 extern void reset_trinamic_drivers();
 
@@ -77,6 +79,9 @@ void app_setup(void) {
     } else {
         init_tmc_bare_minimum();
     }
+
+    // enable cdc
+    usbd_cdc_register_receive_fn(app_cdc_rx);
 
     setup();
 

--- a/src/usb_device.c
+++ b/src/usb_device.c
@@ -100,7 +100,7 @@ void MX_USB_DEVICE_Init(void) {
 
     USBD_RegisterClass(&hUsbDeviceFS, &USBD_CDC);
 
-    USBD_CDC_RegisterInterface(&hUsbDeviceFS, &USBD_Interface_fops_FS);
+    USBD_CDC_RegisterInterface(&hUsbDeviceFS, &usbd_cdc_if);
 
     USBD_Start(&hUsbDeviceFS);
 

--- a/src/usbd_cdc_if.c
+++ b/src/usbd_cdc_if.c
@@ -164,6 +164,7 @@ static int8_t CDC_Init_FS(void);
 static int8_t CDC_DeInit_FS(void);
 static int8_t CDC_Control_FS(uint8_t cmd, uint8_t *pbuf, uint16_t length);
 static int8_t CDC_Receive_FS(uint8_t *pbuf, uint32_t *Len);
+static int8_t CDC_Transmit_Cplt(uint8_t *Buf, uint32_t *Len, uint8_t epnum);
 
 /* USER CODE BEGIN PRIVATE_FUNCTIONS_DECLARATION */
 
@@ -177,7 +178,8 @@ USBD_CDC_ItfTypeDef USBD_Interface_fops_FS = {
     CDC_Init_FS,
     CDC_DeInit_FS,
     CDC_Control_FS,
-    CDC_Receive_FS
+    CDC_Receive_FS,
+    CDC_Transmit_Cplt,
 };
 
 /* Private functions ---------------------------------------------------------*/
@@ -330,6 +332,10 @@ uint8_t CDC_Transmit_FS(uint8_t *Buf, uint16_t Len) {
 }
 
 /* USER CODE BEGIN PRIVATE_FUNCTIONS_IMPLEMENTATION */
+
+int8_t CDC_Transmit_Cplt(uint8_t *Buf, uint32_t *Len, uint8_t epnum) {
+    return 0;
+}
 
 /* USER CODE END PRIVATE_FUNCTIONS_IMPLEMENTATION */
 

--- a/src/usbd_cdc_if.c
+++ b/src/usbd_cdc_if.c
@@ -1,243 +1,59 @@
-/**
-  ******************************************************************************
-  * @file           : usbd_cdc_if.c
-  * @version        : v1.0_Cube
-  * @brief          : Usb device for Virtual Com Port.
-  ******************************************************************************
-  * This notice applies to any and all portions of this file
-  * that are not between comment pairs USER CODE BEGIN and
-  * USER CODE END. Other portions of this file, whether
-  * inserted by the user or by software development tools
-  * are owned by their respective copyright owners.
-  *
-  * Copyright (c) 2019 STMicroelectronics International N.V.
-  * All rights reserved.
-  *
-  * Redistribution and use in source and binary forms, with or without
-  * modification, are permitted, provided that the following conditions are met:
-  *
-  * 1. Redistribution of source code must retain the above copyright notice,
-  *    this list of conditions and the following disclaimer.
-  * 2. Redistributions in binary form must reproduce the above copyright notice,
-  *    this list of conditions and the following disclaimer in the documentation
-  *    and/or other materials provided with the distribution.
-  * 3. Neither the name of STMicroelectronics nor the names of other
-  *    contributors to this software may be used to endorse or promote products
-  *    derived from this software without specific written permission.
-  * 4. This software, including modifications and/or derivative works of this
-  *    software, must execute solely and exclusively on microcontroller or
-  *    microprocessor devices manufactured by or for STMicroelectronics.
-  * 5. Redistribution and use of this software other than as permitted under
-  *    this license is void and will automatically terminate your rights under
-  *    this license.
-  *
-  * THIS SOFTWARE IS PROVIDED BY STMICROELECTRONICS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS, IMPLIED OR STATUTORY WARRANTIES, INCLUDING, BUT NOT
-  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-  * PARTICULAR PURPOSE AND NON-INFRINGEMENT OF THIRD PARTY INTELLECTUAL PROPERTY
-  * RIGHTS ARE DISCLAIMED TO THE FULLEST EXTENT PERMITTED BY LAW. IN NO EVENT
-  * SHALL STMICROELECTRONICS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-  * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-  * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  *
-  ******************************************************************************
-  */
-
-/* Includes ------------------------------------------------------------------*/
 #include "usbd_cdc_if.h"
+#include "usb_device.h"
 
-/* USER CODE BEGIN INCLUDE */
+/// Whether the CDC device is initialized
+static bool usbd_cdc_initialized = false;
 
-/* USER CODE END INCLUDE */
+static void (*cdc_receive_fn)(uint8_t *buffer, uint32_t length);
 
-/* Private typedef -----------------------------------------------------------*/
-/* Private define ------------------------------------------------------------*/
-/* Private macro -------------------------------------------------------------*/
+/// Received data over USB are stored in this buffer
+static uint8_t rx_buffer[USBD_CDC_RX_DATA_SIZE];
 
-/* USER CODE BEGIN PV */
-/* Private variables ---------------------------------------------------------*/
+/// Data to send over USB CDC are stored in this buffer
+static uint8_t tx_buffer[USBD_CDC_TX_DATA_SIZE];
 
-int usbd_cdc_initialized = 0;
+static int8_t cdc_init_fs();
+static int8_t cdc_deinit_fs();
+static int8_t cdc_control_fs(uint8_t cmd, uint8_t *buffer, uint16_t length);
+static int8_t cdc_receive_fs(uint8_t *buffer, uint32_t *length);
+static int8_t cdc_transmit_cplt(uint8_t *buffer, uint32_t *length, uint8_t epnum);
 
-extern void app_cdc_rx(uint8_t *buffer, uint32_t length);
-
-/* USER CODE END PV */
-
-/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
-  * @brief Usb device library.
-  * @{
-  */
-
-/** @addtogroup USBD_CDC_IF
-  * @{
-  */
-
-/** @defgroup USBD_CDC_IF_Private_TypesDefinitions USBD_CDC_IF_Private_TypesDefinitions
-  * @brief Private types.
-  * @{
-  */
-
-/* USER CODE BEGIN PRIVATE_TYPES */
-
-/* USER CODE END PRIVATE_TYPES */
-
-/**
-  * @}
-  */
-
-/** @defgroup USBD_CDC_IF_Private_Defines USBD_CDC_IF_Private_Defines
-  * @brief Private defines.
-  * @{
-  */
-
-/* USER CODE BEGIN PRIVATE_DEFINES */
-/* Define size for the receive and transmit buffer over CDC */
-/* It's up to user to redefine and/or remove those define */
-enum {
-    APP_RX_DATA_SIZE = 2048,
-    APP_TX_DATA_SIZE = 2048,
-};
-/* USER CODE END PRIVATE_DEFINES */
-
-/**
-  * @}
-  */
-
-/** @defgroup USBD_CDC_IF_Private_Macros USBD_CDC_IF_Private_Macros
-  * @brief Private macros.
-  * @{
-  */
-
-/* USER CODE BEGIN PRIVATE_MACRO */
-
-/* USER CODE END PRIVATE_MACRO */
-
-/**
-  * @}
-  */
-
-/** @defgroup USBD_CDC_IF_Private_Variables USBD_CDC_IF_Private_Variables
-  * @brief Private variables.
-  * @{
-  */
-/* Create buffer for reception and transmission           */
-/* It's up to user to redefine and/or remove those define */
-/** Received data over USB are stored in this buffer      */
-uint8_t UserRxBufferFS[APP_RX_DATA_SIZE];
-
-/** Data to send over USB CDC are stored in this buffer   */
-uint8_t UserTxBufferFS[APP_TX_DATA_SIZE];
-
-/* USER CODE BEGIN PRIVATE_VARIABLES */
-
-/* USER CODE END PRIVATE_VARIABLES */
-
-/**
-  * @}
-  */
-
-/** @defgroup USBD_CDC_IF_Exported_Variables USBD_CDC_IF_Exported_Variables
-  * @brief Public variables.
-  * @{
-  */
-
-extern USBD_HandleTypeDef hUsbDeviceFS;
-
-/* USER CODE BEGIN EXPORTED_VARIABLES */
-
-/* USER CODE END EXPORTED_VARIABLES */
-
-/**
-  * @}
-  */
-
-/** @defgroup USBD_CDC_IF_Private_FunctionPrototypes USBD_CDC_IF_Private_FunctionPrototypes
-  * @brief Private functions declaration.
-  * @{
-  */
-
-static int8_t CDC_Init_FS(void);
-static int8_t CDC_DeInit_FS(void);
-static int8_t CDC_Control_FS(uint8_t cmd, uint8_t *pbuf, uint16_t length);
-static int8_t CDC_Receive_FS(uint8_t *pbuf, uint32_t *Len);
-static int8_t CDC_Transmit_Cplt(uint8_t *Buf, uint32_t *Len, uint8_t epnum);
-
-/* USER CODE BEGIN PRIVATE_FUNCTIONS_DECLARATION */
-
-/* USER CODE END PRIVATE_FUNCTIONS_DECLARATION */
-
-/**
-  * @}
-  */
-
-USBD_CDC_ItfTypeDef USBD_Interface_fops_FS = {
-    CDC_Init_FS,
-    CDC_DeInit_FS,
-    CDC_Control_FS,
-    CDC_Receive_FS,
-    CDC_Transmit_Cplt,
+/// USB CDC Interface
+USBD_CDC_ItfTypeDef usbd_cdc_if = {
+    cdc_init_fs,
+    cdc_deinit_fs,
+    cdc_control_fs,
+    cdc_receive_fs,
+    cdc_transmit_cplt,
 };
 
-/* Private functions ---------------------------------------------------------*/
-/**
-  * @brief  Initializes the CDC media low layer over the FS USB IP
-  * @retval USBD_OK if all operations are OK else USBD_FAIL
-  */
-static int8_t CDC_Init_FS(void) {
-    /* USER CODE BEGIN 3 */
-    /* Set Application Buffers */
-    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, UserTxBufferFS, 0);
-    USBD_CDC_SetRxBuffer(&hUsbDeviceFS, UserRxBufferFS);
+/// Initialize the CDC media low layer over the FS USB IP
+static int8_t cdc_init_fs() {
+    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, tx_buffer, 0);
+    USBD_CDC_SetRxBuffer(&hUsbDeviceFS, rx_buffer);
     usbd_cdc_initialized = 1;
-    return (USBD_OK);
-    /* USER CODE END 3 */
+    return USBD_OK;
 }
 
-/**
-  * @brief  DeInitializes the CDC media low layer
-  * @retval USBD_OK if all operations are OK else USBD_FAIL
-  */
-static int8_t CDC_DeInit_FS(void) {
-    /* USER CODE BEGIN 4 */
+/// DeInitializes the CDC media low layer
+static int8_t cdc_deinit_fs() {
     usbd_cdc_initialized = 0;
-    return (USBD_OK);
-    /* USER CODE END 4 */
+    return USBD_OK;
 }
 
-/**
-  * @brief  Manage the CDC class requests
-  * @param  cmd: Command code
-  * @param  pbuf: Buffer containing command data (request parameters)
-  * @param  length: Number of data to be sent (in bytes)
-  * @retval Result of the operation: USBD_OK if all operations are OK else USBD_FAIL
-  */
-static int8_t CDC_Control_FS(uint8_t cmd, uint8_t *pbuf, uint16_t length) {
-    /* USER CODE BEGIN 5 */
+/// Manage the CDC class requests
+static int8_t cdc_control_fs(uint8_t cmd, uint8_t *buffer, uint16_t length) {
     switch (cmd) {
     case CDC_SEND_ENCAPSULATED_COMMAND:
-
         break;
-
     case CDC_GET_ENCAPSULATED_RESPONSE:
-
         break;
-
     case CDC_SET_COMM_FEATURE:
-
         break;
-
     case CDC_GET_COMM_FEATURE:
-
         break;
-
     case CDC_CLEAR_COMM_FEATURE:
-
         break;
-
         /*******************************************************************************/
         /* Line Coding Structure                                                       */
         /*-----------------------------------------------------------------------------*/
@@ -256,95 +72,72 @@ static int8_t CDC_Control_FS(uint8_t cmd, uint8_t *pbuf, uint16_t length) {
         /* 6      | bDataBits  |   1   | Number Data bits (5, 6, 7, 8 or 16).          */
         /*******************************************************************************/
     case CDC_SET_LINE_CODING:
-
         break;
-
     case CDC_GET_LINE_CODING:
-        pbuf[0] = 0x20; // bits/second 115200
-        pbuf[1] = 0xc2;
-        pbuf[2] = 0x01;
-        pbuf[3] = 0x00;
-        pbuf[4] = 0x00; // 1 stop bit
-        pbuf[5] = 0x00; // parity none
-        pbuf[6] = 0x08; // 8 data bits
+        buffer[0] = 0x20; // bits/second 115200
+        buffer[1] = 0xc2;
+        buffer[2] = 0x01;
+        buffer[3] = 0x00;
+        buffer[4] = 0x00; // 1 stop bit
+        buffer[5] = 0x00; // parity none
+        buffer[6] = 0x08; // 8 data bits
         break;
-
     case CDC_SET_CONTROL_LINE_STATE:
         usbd_cdc_initialized = 1; //hack, we need enable usbd_cdc on reconnect
         break;
-
     case CDC_SEND_BREAK:
         break;
-
     default:
         break;
     }
 
-    return (USBD_OK);
-    /* USER CODE END 5 */
+    return USBD_OK;
 }
 
-/**
-  * @brief  Data received over USB OUT endpoint are sent over CDC interface
-  *         through this function.
-  *
-  *         @note
-  *         This function will block any OUT packet reception on USB endpoint
-  *         untill exiting this function. If you exit this function before transfer
-  *         is complete on CDC interface (ie. using DMA controller) it will result
-  *         in receiving more data while previous ones are still not sent.
-  *
-  * @param  Buf: Buffer of data to be received
-  * @param  Len: Number of data received (in bytes)
-  * @retval Result of the operation: USBD_OK if all operations are OK else USBD_FAIL
-  */
-static int8_t CDC_Receive_FS(uint8_t *Buf, uint32_t *Len) {
-    /* USER CODE BEGIN 6 */
-    app_cdc_rx(Buf, *Len);
-    USBD_CDC_SetRxBuffer(&hUsbDeviceFS, &Buf[0]);
+/// Data received over USB OUT endpoint are sent over CDC interface
+/// through this function.
+static int8_t cdc_receive_fs(uint8_t *buffer, uint32_t *length) {
+    // process the data
+    if (cdc_receive_fn)
+        cdc_receive_fn(buffer, *length);
+
+    // prepare the interface for next packet
+    USBD_CDC_SetRxBuffer(&hUsbDeviceFS, rx_buffer);
     USBD_CDC_ReceivePacket(&hUsbDeviceFS);
-    return (USBD_OK);
-    /* USER CODE END 6 */
+
+    return USBD_OK;
 }
 
-/**
-  * @brief  CDC_Transmit_FS
-  *         Data to send over USB IN endpoint are sent over CDC interface
-  *         through this function.
-  *         @note
-  *
-  *
-  * @param  Buf: Buffer of data to be sent
-  * @param  Len: Number of data to be sent (in bytes)
-  * @retval USBD_OK if all operations are OK else USBD_FAIL or USBD_BUSY
-  */
-uint8_t CDC_Transmit_FS(uint8_t *Buf, uint16_t Len) {
-    uint8_t result = USBD_OK;
-    /* USER CODE BEGIN 7 */
+/// Data to send over USB IN endpoint are sent over CDC interface
+/// through this function.
+uint8_t usbd_cdc_transmit(uint8_t *buffer, uint32_t length) {
     USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef *)hUsbDeviceFS.pClassData;
-    if (hcdc->TxState != 0) {
+
+    // fail if busy
+    if (hcdc->TxState != 0)
         return USBD_BUSY;
+    // fail if the data to transmit are longer then one packet
+    if (length > CDC_DATA_MAX_PACKET_SIZE) {
+        return USBD_FAIL;
     }
-    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, Buf, Len);
-    result = USBD_CDC_TransmitPacket(&hUsbDeviceFS);
-    /* USER CODE END 7 */
-    return result;
+
+    // copy the packet to our tx buffer
+    memcpy(tx_buffer, buffer, length);
+
+    // send the packet
+    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, tx_buffer, length);
+    return USBD_CDC_TransmitPacket(&hUsbDeviceFS);
 }
 
-/* USER CODE BEGIN PRIVATE_FUNCTIONS_IMPLEMENTATION */
-
-int8_t CDC_Transmit_Cplt(uint8_t *Buf, uint32_t *Len, uint8_t epnum) {
+/// Callback on transmit complete
+int8_t cdc_transmit_cplt(uint8_t *Buf, uint32_t *Len, uint8_t epnum) {
     return 0;
 }
 
-/* USER CODE END PRIVATE_FUNCTIONS_IMPLEMENTATION */
+void usbd_cdc_register_receive_fn(void (*receive_fn)(uint8_t *buffer, uint32_t length)) {
+    cdc_receive_fn = receive_fn;
+}
 
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+bool usbd_cdc_is_ready() {
+    return hUsbDeviceFS.pClassData && usbd_cdc_initialized;
+}


### PR DESCRIPTION
Originally, my intention today was to fix the CDC BSOD only. However, when I dug into the implementation we used, it was a 🤯 moment.

The STM's generated implementation, which our version was based on, was super sketchy. For example, it defines excessively large buffers which it doesn't use. Another issue is that sending data over the CDC interface could result in data corruption. Considering that almost every line of the implementation had some issue, I decided to create a new custom implementation.

1. It fixes the BSOD. It was caused by the update of the STM32 HAL Library in commit 5346d4ba73e0261. As mentioned in release notes, a new member to the `USBD_CDC_ItfTypeDef` structure was introduced, but our code did not define it.
2. It saves more than 3 kilobytes of RAM.
3. It fixes possible corruption of data being sent over the CDC interface.
4. It provides a new cleaner implementation of the `usbd_cdc_if.h/c`. However, this PR does not aim to cleanup implementation of the USBSerial class or other related modules.