### PR TITLE
Simplify mapping Marlin pins to hwio.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,7 @@ target_sources(
           src/common/diag.cpp
           src/common/eeprom.cpp
           src/common/eeprom_loadsave.c
+          src/common/MarlinPin.cpp
           src/common/marlin_vars.c
           src/common/media.cpp
           src/common/Pin.cpp

--- a/lib/Arduino_Core_A3ides/cores/arduino/wiring_digital.h
+++ b/lib/Arduino_Core_A3ides/cores/arduino/wiring_digital.h
@@ -14,8 +14,6 @@ extern void digitalWrite(uint32_t marlinPin, uint32_t dwVal);
 
 extern int digitalRead(uint32_t marlinPin);
 
-extern void digitalToggle(uint32_t ulPin);
-
 #ifdef __cplusplus
 }
 #endif

--- a/lib/Arduino_Core_A3ides/cores/arduino/wiring_digital.h
+++ b/lib/Arduino_Core_A3ides/cores/arduino/wiring_digital.h
@@ -10,9 +10,9 @@ extern "C" {
 
 extern void pinMode(uint32_t dwPin, uint32_t dwMode);
 
-extern void digitalWrite(uint32_t dwPin, uint32_t dwVal);
+extern void digitalWrite(uint32_t marlinPin, uint32_t dwVal);
 
-extern int digitalRead(uint32_t ulPin);
+extern int digitalRead(uint32_t marlinPin);
 
 extern void digitalToggle(uint32_t ulPin);
 

--- a/src/common/MarlinPin.cpp
+++ b/src/common/MarlinPin.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file
+ * @date May 12, 2021
+ * @author Marek Bel
+ */
+#include "MarlinPin.hpp"
+#include "hwio_pindef.h"
+#include <stdint.h>
+#include <type_traits>
+
+namespace buddy::hw {
+
+/**
+ * @brief Convert IoPort and IoPin pair into marlinPin (uint32_t)
+ *
+ * @param port
+ * @param pin
+ * @return marlinPin unsigned number used to identify pin inside Marlin
+ */
+static constexpr uint32_t toMarlinPin(IoPort port, IoPin pin) {
+    return (MARLIN_PORT_PIN(static_cast<uint32_t>(port), static_cast<uint32_t>(pin)));
+}
+
+/**
+ * @brief Exist mapping between marlinPin and physical Buddy Pin?
+ *
+ * @param marlinPin
+ * @retval true marlinPin exists in PIN_TABLE
+ * @retval false marlinPin does not exists in PIN_TABLE
+ */
+bool physicalPinExist(uint32_t marlinPin) {
+#define ALL_PHYSICAL_PINS(TYPE, NAME, PORTPIN, PARAMETERS) case toMarlinPin(PORTPIN):
+    switch (marlinPin) {
+        PIN_TABLE(ALL_PHYSICAL_PINS)
+        return true;
+    default:
+        return false;
+    }
+#undef ALL_PHYSICAL_PINS
+}
+
+/**
+ * @brief Exist mapping between marlinPin and physical Buddy OutputPin?
+ *
+ * @param marlinPin
+ * @retval true marlinPin is OutputPin in PIN_TABLE
+ * @retval false marlinPin is not OutputPin in PIN_TABLE
+ */
+bool isOutputPin(uint32_t marlinPin) {
+#define ALL_OUTPUT_PINS(TYPE, NAME, PORTPIN, PARAMETERS) \
+    case toMarlinPin(PORTPIN):                           \
+        return (std::is_same_v<TYPE, OutputPin>);
+
+    switch (marlinPin) {
+        PIN_TABLE(ALL_OUTPUT_PINS)
+    default:
+        return false;
+    }
+#undef ALL_OUTPUT_PINS
+}
+
+} //namespace buddy::hw

--- a/src/common/MarlinPin.hpp
+++ b/src/common/MarlinPin.hpp
@@ -14,7 +14,7 @@
  * Obey naming convention MARLIN_PORT_\<PIN_NAME\> MARLIN_PIN_NR_\<PIN_NAME\>
  * @par Example
  * @code
- * //inside hwio_pindef_\<printer\>.h
+ * //inside hwio_pindef.h
  * #define MARLIN_PORT_E0_DIR   MARLIN_PORT_B
  * #define MARLIN_PIN_NR_E0_DIR MARLIN_PIN_NR_8
  * //inside PIN_TABLE
@@ -67,3 +67,8 @@ static_assert(buddy::hw::IoPort::F == static_cast<buddy::hw::IoPort>(MARLIN_PORT
 static_assert(buddy::hw::IoPin::p0 == static_cast<buddy::hw::IoPin>(MARLIN_PIN_NR_0), "Marlin pin doesn't match Buddy IoPin.");
 static_assert(buddy::hw::IoPin::p1 == static_cast<buddy::hw::IoPin>(MARLIN_PIN_NR_1), "Marlin pin doesn't match Buddy IoPin.");
 static_assert(buddy::hw::IoPin::p15 == static_cast<buddy::hw::IoPin>(MARLIN_PIN_NR_15), "Marlin pin doesn't match Buddy IoPin.");
+
+namespace buddy::hw {
+bool physicalPinExist(uint32_t marlinPin);
+bool isOutputPin(uint32_t marlinPin);
+}

--- a/src/common/MarlinPin.hpp
+++ b/src/common/MarlinPin.hpp
@@ -51,6 +51,7 @@
 #define MARLIN_PORT_D 3
 #define MARLIN_PORT_E 4
 #define MARLIN_PORT_F 5
+#define MARLIN_PORT_V 7
 
 #define MARLIN_PORT_PIN(port, pin) ((16 * (port)) + (pin))
 

--- a/src/common/Pin.cpp
+++ b/src/common/Pin.cpp
@@ -5,7 +5,8 @@
  */
 
 #include "Pin.hpp"
-using namespace buddy::hw;
+
+namespace buddy::hw {
 
 void InputPin::configure(Pull pull) const {
     GPIO_InitTypeDef GPIO_InitStruct = { 0 };
@@ -31,3 +32,4 @@ void OutputInputPin::enableInput(Pull pull) const {
     GPIO_InitStruct.Pull = static_cast<uint32_t>(pull);
     HAL_GPIO_Init(getHalPort(), &GPIO_InitStruct);
 }
+} //namespace buddy::hw

--- a/src/common/Pin.hpp
+++ b/src/common/Pin.hpp
@@ -288,4 +288,5 @@ public:
 private:
     const OutputInputPin &m_outputInputPin;
 };
+
 } // namespace buddy::hw

--- a/src/common/hwio_a3ides_2209_02.cpp
+++ b/src/common/hwio_a3ides_2209_02.cpp
@@ -643,11 +643,6 @@ void digitalWrite(uint32_t marlinPin, uint32_t ulVal) {
     }
 }
 
-void digitalToggle(uint32_t ulPin) {
-    digitalWrite(ulPin, !digitalRead(ulPin));
-    // TODO test me
-}
-
 uint32_t analogRead(uint32_t ulPin) {
     if (HAL_ADC_Initialized) {
         switch (ulPin) {

--- a/src/common/hwio_a3ides_2209_02.cpp
+++ b/src/common/hwio_a3ides_2209_02.cpp
@@ -1,5 +1,7 @@
-//----------------------------------------------------------------------------//
-// hwio_a3ides.c - hardware input output abstraction for a3ides board
+/**
+ * @file
+ * @brief hardware input output abstraction for Buddy board
+ */
 
 #include <inttypes.h>
 
@@ -17,20 +19,25 @@
 #include "bsod.h"
 #include "main.h"
 #include "fanctl.h"
+#include "MarlinPin.hpp"
 
-//hwio arduino wrapper errors
+/**
+ * @brief hwio Marlin wrapper errors
+ */
 enum {
-    HWIO_ERR_UNINI_DIG_RD = 0x01,
-    HWIO_ERR_UNINI_DIG_WR,
-    HWIO_ERR_UNINI_ANA_RD,
-    HWIO_ERR_UNINI_ANA_WR,
-    HWIO_ERR_UNDEF_DIG_RD,
-    HWIO_ERR_UNDEF_DIG_WR,
-    HWIO_ERR_UNDEF_ANA_RD,
-    HWIO_ERR_UNDEF_ANA_WR,
+    HWIO_ERR_UNINI_DIG_RD = 0x01, //!< uninitialized digital read
+    HWIO_ERR_UNINI_DIG_WR,        //!< uninitialized digital write
+    HWIO_ERR_UNINI_ANA_RD,        //!< uninitialized analog read
+    HWIO_ERR_UNINI_ANA_WR,        //!< uninitialized analog write
+    HWIO_ERR_UNDEF_DIG_RD,        //!< undefined pin digital read
+    HWIO_ERR_UNDEF_DIG_WR,        //!< undefined pin digital write
+    HWIO_ERR_UNDEF_ANA_RD,        //!< undefined pin analog write
+    HWIO_ERR_UNDEF_ANA_WR,        //!< undefined pin analog write
 };
 
-// a3ides analog input pins
+/**
+ * @brief analog input pins
+ */
 const uint32_t _adc_pin32[] = {
     MARLIN_PIN(HW_IDENTIFY),
     MARLIN_PIN(TEMP_BED),
@@ -38,13 +45,20 @@ const uint32_t _adc_pin32[] = {
     MARLIN_PIN(TEMP_HEATBREAK),
     MARLIN_PIN(TEMP_0), // THERM0 (nozzle)
 };
-// a3ides analog input maximum values
+/**
+ * @brief analog input maximum values
+ */
 const int _adc_max[] = { 4095, 4095, 4095, 4095, 4095 };
 static const size_t _ADC_CNT = sizeof(_adc_pin32) / sizeof(uint32_t);
-//sampled analog inputs
+
+/**
+ * @brief sampled analog inputs
+ */
 int _adc_val[] = { 0, 0, 0, 0, 0 };
 
-// a3ides analog output pins
+/**
+ * @brief analog output pins
+ */
 const uint32_t _dac_pin32[] = {};
 // a3ides analog output maximum values
 const int _dac_max[] = { 0 };
@@ -550,75 +564,83 @@ void hwio_arduino_error(int err, uint32_t pin32) {
     bsod(text);
 }
 
-//--------------------------------------
-// Arduino digital/analog wrapper functions
-
-int digitalRead(uint32_t ulPin) {
-    if (HAL_GPIO_Initialized) {
-        switch (ulPin) {
-        case MARLIN_PIN(Z_MIN):
-        case MARLIN_PIN(E0_DIAG):
-        case MARLIN_PIN(Y_DIAG):
-        case MARLIN_PIN(X_DIAG):
-        case MARLIN_PIN(Z_DIAG):
-        case MARLIN_PIN(Z_DIR):
-            return gpio_get(ulPin);
-        default:
-            hwio_arduino_error(HWIO_ERR_UNDEF_DIG_RD, ulPin); //error: undefined pin digital read
+/**
+ * @brief Read digital pin to be used from Marlin
+ *
+ * Use MARLIN_PIN macro when handling special cases (virtual pins)
+ * @example @code
+ * case MARLIN_PIN(Z_MIN):
+ * @endcode
+ *
+ * @todo Bypass electric signal when reading output pin
+ */
+int digitalRead(uint32_t marlinPin) {
+#if _DEBUG
+    if (!HAL_GPIO_Initialized) {
+        hwio_arduino_error(HWIO_ERR_UNINI_DIG_RD, marlinPin); //error: uninitialized digital read
+        return 0;
+    }
+#endif //_DEBUG
+    switch (marlinPin) {
+    default:
+#if _DEBUG
+        if (!buddy::hw::physicalPinExist(marlinPin)) {
+            hwio_arduino_error(HWIO_ERR_UNDEF_DIG_RD, marlinPin); //error: undefined pin digital read
+            return 0;
         }
-    } else
-        hwio_arduino_error(HWIO_ERR_UNINI_DIG_RD, ulPin); //error: uninitialized digital read
-    return 0;
+#endif //_DEBUG
+        return gpio_get(marlinPin);
+    }
 }
 
-void digitalWrite(uint32_t ulPin, uint32_t ulVal) {
-    if (HAL_GPIO_Initialized) {
-        switch (ulPin) {
-        case MARLIN_PIN(BED_HEAT):
-            _hwio_pwm_analogWrite_set_val(HWIO_PWM_HEATER_BED, ulVal ? _pwm_analogWrite_max[HWIO_PWM_HEATER_BED] : 0);
-            return;
-        case MARLIN_PIN(HEAT0):
-            _hwio_pwm_analogWrite_set_val(HWIO_PWM_HEATER_0, ulVal ? _pwm_analogWrite_max[HWIO_PWM_HEATER_0] : 0);
-            return;
-        case MARLIN_PIN(FAN1):
-            //hwio_fan_set_pwm(_FAN1, ulVal?255:0);
-            //_hwio_pwm_analogWrite_set_val(HWIO_PWM_FAN1, ulVal ? _pwm_analogWrite_max[HWIO_PWM_FAN1] : 0);
+/**
+ * @brief Write digital pin to be used from Marlin
+ *
+ * Use MARLIN_PIN macro when handling special cases (virtual pins)
+ * @example @code
+ * case MARLIN_PIN(FAN):
+ * @endcode
+ *
+ */
+void digitalWrite(uint32_t marlinPin, uint32_t ulVal) {
+#if _DEBUG
+    if (!HAL_GPIO_Initialized) {
+        hwio_arduino_error(HWIO_ERR_UNINI_DIG_WR, marlinPin); //error: uninitialized digital write
+        return;
+    }
+#endif //_DEBUG
+    switch (marlinPin) {
+    case MARLIN_PIN(BED_HEAT):
+        _hwio_pwm_analogWrite_set_val(HWIO_PWM_HEATER_BED, ulVal ? _pwm_analogWrite_max[HWIO_PWM_HEATER_BED] : 0);
+        return;
+    case MARLIN_PIN(HEAT0):
+        _hwio_pwm_analogWrite_set_val(HWIO_PWM_HEATER_0, ulVal ? _pwm_analogWrite_max[HWIO_PWM_HEATER_0] : 0);
+        return;
+    case MARLIN_PIN(FAN1):
 #ifdef NEW_FANCTL
-            if (hwio_fan_control_enabled)
-                fanctl_set_pwm(1, ulVal ? (100 * 50 / 255) : 0);
+        if (hwio_fan_control_enabled)
+            fanctl_set_pwm(1, ulVal ? (100 * 50 / 255) : 0);
 #else  //NEW_FANCTL
-            _hwio_pwm_analogWrite_set_val(HWIO_PWM_FAN1, ulVal ? 100 : 0);
+        _hwio_pwm_analogWrite_set_val(HWIO_PWM_FAN1, ulVal ? 100 : 0);
 #endif //NEW_FANCTL
-            return;
-        case MARLIN_PIN(FAN):
+        return;
+    case MARLIN_PIN(FAN):
 #ifdef NEW_FANCTL
-            if (hwio_fan_control_enabled)
-                fanctl_set_pwm(0, ulVal ? 50 : 0);
+        if (hwio_fan_control_enabled)
+            fanctl_set_pwm(0, ulVal ? 50 : 0);
 #else  //NEW_FANCTL
-            _hwio_pwm_analogWrite_set_val(HWIO_PWM_FAN, ulVal ? _pwm_analogWrite_max[HWIO_PWM_FAN] : 0);
+        _hwio_pwm_analogWrite_set_val(HWIO_PWM_FAN, ulVal ? _pwm_analogWrite_max[HWIO_PWM_FAN] : 0);
 #endif //NEW_FANCTL
+        return;
+    default:
+#if _DEBUG
+        if (!buddy::hw::isOutputPin(marlinPin)) {
+            hwio_arduino_error(HWIO_ERR_UNDEF_DIG_WR, marlinPin); //error: undefined pin digital write
             return;
-        case MARLIN_PIN(X_DIR):
-        case MARLIN_PIN(X_STEP):
-        case MARLIN_PIN(Z_ENA):
-        case MARLIN_PIN(X_ENA):
-        case MARLIN_PIN(Z_STEP):
-        case MARLIN_PIN(E0_DIR):
-        case MARLIN_PIN(E0_STEP):
-        case MARLIN_PIN(E0_ENA):
-        case MARLIN_PIN(Y_DIR):
-        case MARLIN_PIN(Y_STEP):
-#if (MARLIN_PIN(X_ENA) != MARLIN_PIN(Y_ENA))
-        case MARLIN_PIN(Y_ENA):
-#endif
-        case MARLIN_PIN(Z_DIR):
-            gpio_set(ulPin, ulVal ? 1 : 0);
-            return;
-        default:
-            hwio_arduino_error(HWIO_ERR_UNDEF_DIG_WR, ulPin); //error: undefined pin digital write
         }
-    } else
-        hwio_arduino_error(HWIO_ERR_UNINI_DIG_WR, ulPin); //error: uninitialized digital write
+#endif //_DEBUG
+        gpio_set(marlinPin, ulVal ? 1 : 0);
+    }
 }
 
 void digitalToggle(uint32_t ulPin) {

--- a/src/common/hwio_pindef.h
+++ b/src/common/hwio_pindef.h
@@ -14,9 +14,6 @@
 #else
     #include "MarlinPin.hpp"
 
-    #define MARLIN_PORT_TEMP_BOARD   MARLIN_PORT_V
-    #define MARLIN_PIN_NR_TEMP_BOARD MARLIN_PIN_NR_0
-
     #define MARLIN_PORT_X_DIAG   MARLIN_PORT_E
     #define MARLIN_PIN_NR_X_DIAG MARLIN_PIN_NR_2
 


### PR DESCRIPTION
After this change, it is not needed to enumerate all ordinary IO pins
in hwio_a3ides_2209_02.cpp anymore.
Runtime sanity checks are preserved in DEBUG build.

Unrelated polishing added to this PR.