### PR TITLE
GUI: wrong filament warning

### DIFF
--- a/src/gui/screen_print_preview.cpp
+++ b/src/gui/screen_print_preview.cpp
@@ -68,7 +68,7 @@ GCodeInfo::GCodeInfo() {
     memset(&file, 1, sizeof(FIL));
     file_opened = false;
     has_thumbnail = false;
-
+    filament_described = false;
     // try to open the file first
     if (!gcode_file_path || f_open(&file, gcode_file_path, FA_READ) != FR_OK) {
         return;
@@ -108,6 +108,7 @@ GCodeInfo::GCodeInfo() {
         } else if (name_equals("filament_type")) {
             snprintf(filament_type, sizeof(filament_type),
                 "%s", value_buffer);
+            filament_described = true;
         } else if (name_equals("filament used [mm]")) {
             sscanf(value_buffer, "%u", &filament_used_mm);
         } else if (name_equals("filament used [g]")) {
@@ -170,7 +171,7 @@ screen_print_preview_data_t::screen_print_preview_data_t()
     , back_label(this, Rect16(SCREEN_WIDTH - PADDING - 64, SCREEN_HEIGHT - PADDING - LINE_HEIGHT, 64, LINE_HEIGHT), is_multiline::no)
     , gcode(this)
     , redraw_thumbnail(gcode.has_thumbnail)
-    , ignore_wrong_filament(false) {
+    , ignore_wrong_filament(!gcode.filament_described) {
     marlin_set_print_speed(100);
 
     suppress_draw = false;

--- a/src/gui/screen_print_preview.hpp
+++ b/src/gui/screen_print_preview.hpp
@@ -39,6 +39,7 @@ struct GCodeInfo {
     bool has_thumbnail;
     char printing_time[16];
     char filament_type[8];
+    bool filament_described;
     unsigned filament_used_g;
     unsigned filament_used_mm;
     GCodeInfo();


### PR DESCRIPTION
BFW-1941
Disable warning when gcode is generated by another slicer (It doesn't contain "filament_type" coment)