### PR TITLE
tests: Support 64-bit mode compilation

### DIFF
--- a/src/common/variant8.h
+++ b/src/common/variant8.h
@@ -39,7 +39,11 @@ enum {
     VARIANT8_ERR_OOFRNG,     // out of range (during conversion from bigger to lower range number)
 };
 
+#if INTPTR_MAX == INT32_MAX // 32 bit system
 typedef uint64_t variant8_t;
+#elif INTPTR_MAX == INT64_MAX // 64 bit system
+typedef unsigned __int128 variant8_t;
+#endif
 
 #ifdef __cplusplus
 

--- a/src/guiapi/src/window.cpp
+++ b/src/guiapi/src/window.cpp
@@ -403,15 +403,15 @@ bool window_t::EventEncoder(int diff) {
     if (diff == 0)
         return false;
 
-    Screens::Access()->ScreenEvent(nullptr, GUI_event_t::ENC_CHANGE, (void *)diff);
+    Screens::Access()->ScreenEvent(nullptr, GUI_event_t::ENC_CHANGE, (void *)(intptr_t)diff);
 
     if (!capture_ptr)
         return false;
 
     if (diff > 0) {
-        capture_ptr->WindowEvent(capture_ptr, GUI_event_t::ENC_UP, (void *)diff);
+        capture_ptr->WindowEvent(capture_ptr, GUI_event_t::ENC_UP, (void *)(intptr_t)diff);
     } else {
-        capture_ptr->WindowEvent(capture_ptr, GUI_event_t::ENC_DN, (void *)-diff);
+        capture_ptr->WindowEvent(capture_ptr, GUI_event_t::ENC_DN, (void *)(intptr_t)-diff);
     }
 
     Screens::Access()->ResetTimeout();

--- a/src/guiapi/src/window_frame.cpp
+++ b/src/guiapi/src/window_frame.cpp
@@ -209,7 +209,7 @@ void window_frame_t::draw() {
 }
 
 void window_frame_t::windowEvent(EventLock /*has private ctor*/, window_t *sender, GUI_event_t event, void *param) {
-    int dif = (int)param;
+    intptr_t dif = (intptr_t)param;
     window_t *pWin = GetFocusedWindow();
     if (!pWin || !pWin->IsChildOf(this))
         pWin = nullptr;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,9 +1,6 @@
 # first, let's create a symbolic target for all tests
 add_custom_target(tests)
 
-set(CMAKE_C_FLAGS -m32)
-set(CMAKE_CXX_FLAGS -m32)
-
 # include catch_discover_tests function from Catch2
 include(${Catch2_SOURCE_DIR}/contrib/Catch.cmake)
 

--- a/tests/unit/common/variant8_tests.cpp
+++ b/tests/unit/common/variant8_tests.cpp
@@ -2,6 +2,7 @@
 #include "catch2/catch.hpp"
 
 #include "common/variant8.h"
+#include <cstdint>
 #include <float.h>
 
 TEST_CASE("init & done", "[variant8]") {
@@ -162,7 +163,11 @@ TEST_CASE("size", "[variant8]") {
         CHECK(variant8_type_size(VARIANT8_UI32) == 4);
         CHECK(variant8_type_size(VARIANT8_I32) == 4);
         CHECK(variant8_type_size(VARIANT8_CHAR) == 1);
+#if INTPTR_MAX == INT32_MAX
         CHECK(variant8_type_size(VARIANT8_USER) == 7);
+#elif INTPTR_MAX == INT64_MAX
+        CHECK(variant8_type_size(VARIANT8_USER) == 15);
+#endif
         CHECK(variant8_type_size(VARIANT8_ERROR) == 0);
     };
 

--- a/tests/unit/gui/lazyfilelist/fatfs.cpp
+++ b/tests/unit/gui/lazyfilelist/fatfs.cpp
@@ -58,7 +58,7 @@ void MakeLFNSFN(FILINFO *fno, const char *lfn, size_t fileindex) {
     assert(fno);
     strncpy(fno->fname, lfn, sizeof(fno->fname));
     if (strlen(lfn) >= FF_SFN_BUF) {
-        snprintf(fno->altname, sizeof(fno->altname), "%-.6s~%02u.GCO", lfn, fileindex);
+        snprintf(fno->altname, sizeof(fno->altname), "%-.6s~%02u.GCO", lfn, (unsigned)fileindex);
     } else {
         fno->altname[0] = 0;
     }

--- a/tests/unit/system_test.cpp
+++ b/tests/unit/system_test.cpp
@@ -2,5 +2,4 @@
 
 TEST_CASE("type tests", "[system]") {
     REQUIRE(sizeof(uint64_t) == 8);
-    REQUIRE(sizeof(char *) == 4);
 }


### PR DESCRIPTION
The problem: it is hard to support the 32bit compilation on macOS, therefore running tests on this platform is problematic.

This PR removes the `-m32` flag when compiling tests and has necessary changes to make all the tests pass.

I like how the 32bit compilation mode takes us closer to the actual device the code is supposed to be running at. However, we currently don't have any locked environment like docker to easily run the tests within (where using -m32 wouldn't be a problem) so this seems to me like a good solution in order to support macOS.