### PR TITLE
Bfw 1939 ini file changes

### DIFF
--- a/lib/WUI/wui.c
+++ b/lib/WUI/wui.c
@@ -78,7 +78,7 @@ void StartWebServerTask(void const *argument) {
     if (BUDDY_INI_OK == ini_load_file(&wui_eth_config)) {
         save_eth_params(&wui_eth_config);
     }
-    wui_eth_config.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
+    wui_eth_config.var_mask = ETHVAR_EEPROM_CONFIG;
     load_eth_params(&wui_eth_config);
     // mutex for passing marlin variables to tcp thread
     wui_thread_mutex_id = osMutexCreate(osMutex(wui_thread_mutex));

--- a/lib/WUI/wui.c
+++ b/lib/WUI/wui.c
@@ -10,6 +10,7 @@
 #include "wui_vars.h"
 #include "marlin_client.h"
 #include "wui_api.h"
+#include "ini_handler.h"
 #include "lwip.h"
 #include "ethernetif.h"
 #include <string.h>
@@ -74,7 +75,7 @@ static void update_eth_changes(void) {
 void StartWebServerTask(void const *argument) {
     // get settings from ini file
     osDelay(1000);
-    if (load_ini_file(&wui_eth_config)) {
+    if (BUDDY_INI_OK == ini_load_file(&wui_eth_config)) {
         save_eth_params(&wui_eth_config);
     }
     wui_eth_config.var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);

--- a/lib/inih/ini.c
+++ b/lib/inih/ini.c
@@ -25,8 +25,6 @@ https://github.com/benhoyt/inih
 #include <stdlib.h>
 #endif
 
-#define MAX_SECTION 50
-#define MAX_NAME 50
 
 /* Used by ini_parse_string() to keep track of string parsing state. */
 typedef struct {

--- a/lib/inih/ini.c
+++ b/lib/inih/ini.c
@@ -35,7 +35,7 @@ typedef struct {
 } ini_parse_string_ctx;
 
 /* Strip whitespace chars off end of given string, in place. Return s. */
-static char* rstrip(char* s)
+char* rstrip(char* s)
 {
     char* p = s + strlen(s);
     while (p > s && isspace((unsigned char)(*--p)))
@@ -44,7 +44,7 @@ static char* rstrip(char* s)
 }
 
 /* Return pointer to first non-whitespace char in given string. */
-static char* lskip(const char* s)
+char* lskip(const char* s)
 {
     while (*s && isspace((unsigned char)(*s)))
         s++;
@@ -54,7 +54,7 @@ static char* lskip(const char* s)
 /* Return pointer to first char (of chars) or inline comment in given string,
    or pointer to null at end of string if neither found. Inline comment must
    be prefixed by a whitespace character to register as a comment. */
-static char* find_chars_or_comment(const char* s, const char* chars)
+char* find_chars_or_comment(const char* s, const char* chars)
 {
 #if INI_ALLOW_INLINE_COMMENTS
     int was_space = 0;
@@ -72,7 +72,7 @@ static char* find_chars_or_comment(const char* s, const char* chars)
 }
 
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
-static char* strncpy0(char* dest, const char* src, size_t size)
+char* strncpy0(char* dest, const char* src, size_t size)
 {
     strncpy(dest, src, size - 1);
     dest[size - 1] = '\0';

--- a/lib/inih/ini.h
+++ b/lib/inih/ini.h
@@ -146,6 +146,9 @@ int ini_parse_string(const char* string, ini_handler handler, void* user);
 #define INI_ALLOW_NO_VALUE 0
 #endif
 
+#define MAX_SECTION         50
+#define MAX_NAME            50
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/inih/ini.h
+++ b/lib/inih/ini.h
@@ -36,6 +36,11 @@ typedef int (*ini_handler)(void* user, const char* section,
                            const char* name, const char* value);
 #endif
 
+char* rstrip(char* s);
+char* lskip(const char* s);
+char* find_chars_or_comment(const char* s, const char* chars);
+char* strncpy0(char* dest, const char* src, size_t size);
+
 /* Typedef for prototype of fgets-style reader function. */
 typedef char* (*ini_reader)(char* str, int num, void* stream);
 
@@ -95,7 +100,7 @@ int ini_parse_string(const char* string, ini_handler handler, void* user);
 #define INI_ALLOW_INLINE_COMMENTS 1
 #endif
 #ifndef INI_INLINE_COMMENT_PREFIXES
-#define INI_INLINE_COMMENT_PREFIXES ";"
+#define INI_INLINE_COMMENT_PREFIXES ";#"
 #endif
 
 /* Nonzero to use stack for line buffer, zero to use heap (malloc/free). */

--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -311,6 +311,23 @@ variant8_t eeprom_get_var(uint8_t id) {
     return var;
 }
 
+void eeprom_get_pchar_var(uint8_t id, char *buff, uint8_t buff_len) {
+    uint16_t addr;
+    uint16_t size;
+    if (id < EEPROM_VARCOUNT) {
+        eeprom_lock();
+        size = eeprom_var_size(id);
+        if (size <= buff_len) {
+            addr = eeprom_var_addr(id);
+            st25dv64k_user_read_bytes(addr, buff, size);
+        } else {
+            _dbg("error");
+            //TODO:error
+        }
+        eeprom_unlock();
+    }
+}
+
 void eeprom_set_var(uint8_t id, variant8_t var) {
     uint16_t addr;
     uint16_t size;
@@ -343,6 +360,19 @@ void eeprom_set_var(uint8_t id, variant8_t var) {
         }
         eeprom_unlock();
     }
+}
+
+void eeprom_set_pchar_var(uint8_t id, char *buff, uint8_t buff_len) {
+    uint16_t addr;
+    uint16_t size;
+    eeprom_lock();
+    size = eeprom_var_size(id);
+    if (size >= buff_len) {
+        addr = eeprom_var_addr(id);
+        st25dv64k_user_write_bytes(addr, buff, strlen(buff));
+        eeprom_update_crc32();
+    }
+    eeprom_unlock();
 }
 
 uint8_t eeprom_get_var_count(void) {

--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -362,16 +362,21 @@ void eeprom_set_var(uint8_t id, variant8_t var) {
     }
 }
 
-void eeprom_set_pchar_var(uint8_t id, char *buff, uint8_t buff_len) {
-    uint16_t addr;
-    uint16_t size;
+void eeprom_set_pchar_var(uint8_t id, char *buff, uint8_t data_len) {
+    uint16_t addr = eeprom_var_addr(id);
+    uint16_t size = eeprom_var_size(id);
+    uint16_t len = strlen(buff);
+    uint16_t copy_len = 0;
+
+    if (data_len > len)
+        copy_len = data_len;
+    else
+        copy_len = size;
     eeprom_lock();
-    size = eeprom_var_size(id);
-    if (size >= buff_len) {
-        addr = eeprom_var_addr(id);
-        st25dv64k_user_write_bytes(addr, buff, strlen(buff));
-        eeprom_update_crc32();
+    if (size >= copy_len) {
+        st25dv64k_user_write_bytes(addr, buff, copy_len);
     }
+    eeprom_update_crc32();
     eeprom_unlock();
 }
 

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -145,7 +145,13 @@ void eeprom_get_pchar_var(uint8_t id, char *buff, uint8_t buff_len);
 extern void eeprom_set_var(uint8_t id, variant8_t var);
 
 // set pchar variable to EEPROM
-extern void eeprom_set_pchar_var(uint8_t id, char *buff, uint8_t buff_len);
+//
+// \param [in] id           id of the parameter (eg. host name).
+// \param [in] buff         pointer to char array containing the parameter (array must be of
+//                          same size as parameter max length.
+// \param [in] data_len     number of bytes to write from buffer irrelevant of string length
+//                          (to fill remaining bytes with zeros).
+extern void eeprom_set_pchar_var(uint8_t id, char *buff, uint8_t data_len);
 
 // get number of variables
 extern uint8_t eeprom_get_var_count(void);

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -138,8 +138,14 @@ extern void eeprom_defaults(void);
 // get variable value as variant8
 extern variant8_t eeprom_get_var(uint8_t id);
 
+// get pchar variable with given char* buffer
+void eeprom_get_pchar_var(uint8_t id, char *buff, uint8_t buff_len);
+
 // set variable value as variant8
 extern void eeprom_set_var(uint8_t id, variant8_t var);
+
+// set pchar variable to EEPROM
+extern void eeprom_set_pchar_var(uint8_t id, char *buff, uint8_t buff_len);
 
 // get number of variables
 extern uint8_t eeprom_get_var_count(void);

--- a/src/common/ini_handler.c
+++ b/src/common/ini_handler.c
@@ -97,7 +97,7 @@ buddy_ini_error ini_save_file(const char *ini_save_str) {
 buddy_ini_error ini_load_file(void *user) {
     FIL fileObject;
     buddy_ini_error error = BUDDY_INI_OK;
-    char line[BUDDY_INI_LINE_SIZE];
+    char line[INI_MAX_LINE];
     char *start;
     char *end;
     char *name;
@@ -117,7 +117,7 @@ buddy_ini_error ini_load_file(void *user) {
 
     /* Scan through stream line by line */
     while ((f_eof(&fileObject) == 0) && (f_error(&fileObject) == 0)) {
-        if (NULL == f_gets(line, BUDDY_INI_LINE_SIZE, &fileObject)) {
+        if (NULL == f_gets(line, INI_MAX_LINE, &fileObject)) {
             f_close(&fileObject);
             return BUDDY_INI_FILE_READ;
         }

--- a/src/common/ini_handler.c
+++ b/src/common/ini_handler.c
@@ -20,10 +20,10 @@ static int ini_handler_func(void *user, const char *section, const char *name, c
     ETH_config_t *tmp_config = (ETH_config_t *)user;
 
     if (ini_string_match(section, "eth::ipv4", name, "type")) {
-        if (strncmp(value, "DHCP", 4) == 0 || strncmp(value, "dhcp", 4) == 0) {
+        if (strncmp(value, "DHCP", 4) == 0) {
             CHANGE_LAN_TO_DHCP(tmp_config->lan.flag);
             tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_LAN_FLAGS);
-        } else if (strncmp(value, "STATIC", 6) == 0 || strncmp(value, "static", 6) == 0) {
+        } else if (strncmp(value, "STATIC", 6) == 0) {
             CHANGE_LAN_TO_STATIC(tmp_config->lan.flag);
             tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_LAN_FLAGS);
         }

--- a/src/common/ini_handler.c
+++ b/src/common/ini_handler.c
@@ -131,26 +131,6 @@ buddy_ini_error ini_load_file(void *user) {
             skip_next_read = 1;
         }
 
-#if INI_ALLOW_REALLOC && !INI_USE_STACK
-        offset = strlen(line);
-        while (offset == max_line - 1 && line[offset - 1] != '\n') {
-            max_line *= 2;
-            if (max_line > INI_MAX_LINE)
-                max_line = INI_MAX_LINE;
-            new_line = realloc(line, max_line);
-            if (!new_line) {
-                free(line);
-                return -2;
-            }
-            line = new_line;
-            if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
-                break;
-            if (max_line >= INI_MAX_LINE)
-                break;
-            offset += strlen(line + offset);
-        }
-#endif
-
         lineno++;
 
         start = line;

--- a/src/common/ini_handler.c
+++ b/src/common/ini_handler.c
@@ -7,8 +7,9 @@
 #include "strings.h"
 
 #define MAX_UINT16 65535
+#define HANDLER    ini_handler_func
 
-static const char network_ini_file_name[] = "/lan_settings.ini"; //change -> change msgboxes in screen_lan_settings
+static const char ini_file_name[] = "/prusa_printer_settings.ini"; //change -> change msgboxes in screen_lan_settings
 
 static bool ini_string_match(const char *section, const char *section_var, const char *name, const char *name_var) {
     return strcmp(section_var, section) == 0 && strcmp(name_var, name) == 0;
@@ -18,44 +19,72 @@ static int ini_handler_func(void *user, const char *section, const char *name, c
 
     ETH_config_t *tmp_config = (ETH_config_t *)user;
 
-    if (ini_string_match(section, "lan_ip4", name, "type")) {
-        if (strncasecmp(value, "DHCP", 4) == 0) {
+    if (ini_string_match(section, "eth::ipv4", name, "type")) {
+        if (strncmp(value, "DHCP", 4) == 0 || strncmp(value, "dhcp", 4) == 0) {
             CHANGE_LAN_TO_DHCP(tmp_config->lan.flag);
             tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_LAN_FLAGS);
-        } else if (strncasecmp(value, "STATIC", 6) == 0) {
+        } else if (strncmp(value, "STATIC", 6) == 0 || strncmp(value, "static", 6) == 0) {
             CHANGE_LAN_TO_STATIC(tmp_config->lan.flag);
             tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_LAN_FLAGS);
         }
-    } else if (ini_string_match(section, "lan_ip4", name, "hostname")) {
+    } else if (ini_string_match(section, "network", name, "hostname")) {
         strlcpy(tmp_config->hostname, value, ETH_HOSTNAME_LEN + 1);
         tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_HOSTNAME);
-    } else if (ini_string_match(section, "lan_ip4", name, "address")) {
+    } else if (ini_string_match(section, "eth::ipv4", name, "addr")) {
         if (ip4addr_aton(value, &tmp_config->lan.addr_ip4)) {
             tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_LAN_ADDR_IP4);
         }
-    } else if (ini_string_match(section, "lan_ip4", name, "mask")) {
+    } else if (ini_string_match(section, "eth::ipv4", name, "mask")) {
         if (ip4addr_aton(value, &tmp_config->lan.msk_ip4)) {
             tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_LAN_MSK_IP4);
         }
-    } else if (ini_string_match(section, "lan_ip4", name, "gateway")) {
+    } else if (ini_string_match(section, "eth::ipv4", name, "gw")) {
         if (ip4addr_aton(value, &tmp_config->lan.gw_ip4)) {
             tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_LAN_GW_IP4);
         }
-    } else {
-        return 0; /* unknown section/name, error */
+    } else if (ini_string_match(section, "network", name, "dns4")) {
+
+        if (NULL != strchr(value, ':')) {
+            char *token;
+            char *rest = (char *)value;
+            for (int i = 0; i < 2; i++) {
+                token = strtok_r(rest, ";", &rest);
+                if (NULL != token) {
+                    switch (i) {
+                    case 0:
+                        if (ip4addr_aton(token, &tmp_config->dns1_ip4)) {
+                            tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_DNS1_IP4);
+                        }
+                        break;
+                    case 1:
+                        if (ip4addr_aton(token, &tmp_config->dns2_ip4)) {
+                            tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_DNS2_IP4);
+                        }
+                        break;
+                    default:
+                        break;
+                    }
+                }
+            }
+        } else {
+            if (ip4addr_aton(value, &tmp_config->dns1_ip4)) {
+                tmp_config->var_mask |= ETHVAR_MSK(ETHVAR_DNS1_IP4);
+            }
+        }
     }
+
     return 1;
 }
 
-uint8_t ini_save_file(const char *ini_save_str) {
+buddy_ini_error ini_save_file(const char *ini_save_str) {
 
     UINT ini_config_len = strlen(ini_save_str);
     UINT written_bytes = 0;
     FIL ini_file;
 
-    f_unlink(network_ini_file_name);
+    f_unlink(ini_file_name);
 
-    uint8_t i = f_open(&ini_file, network_ini_file_name, FA_WRITE | FA_CREATE_NEW);
+    uint8_t i = f_open(&ini_file, ini_file_name, FA_WRITE | FA_CREATE_NEW);
     uint8_t w = f_write(&ini_file, ini_save_str, ini_config_len, &written_bytes);
     uint8_t c = f_close(&ini_file);
 
@@ -65,21 +94,136 @@ uint8_t ini_save_file(const char *ini_save_str) {
     return 1;
 }
 
-uint8_t ini_load_file(void *user_struct) {
-    UINT written_bytes = 0;
-    FIL ini_file;
-    ini_file_str_t ini_str;
+buddy_ini_error ini_load_file(void *user) {
+    FIL fileObject;
+    buddy_ini_error error = BUDDY_INI_OK;
+    char line[BUDDY_INI_LINE_SIZE];
+    char *start;
+    char *end;
+    char *name;
+    char *value;
+    int lineno = 0;
+    uint8_t skip_next_read = 0;
 
-    uint8_t file_init = f_open(&ini_file, network_ini_file_name, FA_READ);
-    uint8_t file_read = f_read(&ini_file, &ini_str, MAX_INI_SIZE, &written_bytes);
-    uint8_t file_close = f_close(&ini_file);
+    char section[MAX_SECTION] = "";
+    char prev_name[MAX_NAME] = "";
 
-    if (file_init || file_read || file_close) {
-        return 0;
+    // read line by line and parse it
+    FRESULT res = f_open(&fileObject, ini_file_name, FA_READ);
+    if (res) {
+        f_close(&fileObject);
+        return BUDDY_INI_FILE_READ;
     }
 
-    if (ini_parse_string(ini_str, ini_handler_func, user_struct) < 0) {
-        return 0;
+    /* Scan through stream line by line */
+    while ((f_eof(&fileObject) == 0) && (f_error(&fileObject) == 0)) {
+        if (NULL == f_gets(line, BUDDY_INI_LINE_SIZE, &fileObject)) {
+            f_close(&fileObject);
+            return BUDDY_INI_FILE_READ;
+        }
+        // skip the processing if it is part of previous line
+        if (skip_next_read) {
+            skip_next_read = 0;
+            continue;
+        }
+        // check if the line was completely read
+        if (NULL == strchr(line, '\n')) {
+            skip_next_read = 1;
+        }
+
+#if INI_ALLOW_REALLOC && !INI_USE_STACK
+        offset = strlen(line);
+        while (offset == max_line - 1 && line[offset - 1] != '\n') {
+            max_line *= 2;
+            if (max_line > INI_MAX_LINE)
+                max_line = INI_MAX_LINE;
+            new_line = realloc(line, max_line);
+            if (!new_line) {
+                free(line);
+                return -2;
+            }
+            line = new_line;
+            if (reader(line + offset, (int)(max_line - offset), stream) == NULL)
+                break;
+            if (max_line >= INI_MAX_LINE)
+                break;
+            offset += strlen(line + offset);
+        }
+#endif
+
+        lineno++;
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF && (unsigned char)start[1] == 0xBB && (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = lskip(rstrip(start));
+
+        if (strchr(INI_START_COMMENT_PREFIXES, *start)) {
+            /* Start-of-line comment */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+            /* Non-blank line with leading whitespace, treat as continuation
+               of previous name's value (as per Python configparser). */
+            if (!HANDLER(user, section, prev_name, start) && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = find_chars_or_comment(start + 1, "]");
+            if (*end == ']') {
+                *end = '\0';
+                strncpy0(section, start + 1, sizeof(section));
+                *prev_name = '\0';
+#if INI_CALL_HANDLER_ON_NEW_SECTION
+                if (!HANDLER(user, section, NULL, NULL) && !error)
+                    error = lineno;
+#endif
+            } else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        } else if (*start) {
+            /* Not a comment, must be a name[=:]value pair */
+            end = find_chars_or_comment(start, "=:");
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = rstrip(start);
+                value = end + 1;
+#if INI_ALLOW_INLINE_COMMENTS
+                end = find_chars_or_comment(value, NULL);
+                if (*end)
+                    *end = '\0';
+#endif
+                value = lskip(value);
+                rstrip(value);
+
+                /* Valid name[=:]value pair found, call handler */
+                strncpy0(prev_name, name, sizeof(prev_name));
+                if (!HANDLER(user, section, name, value) && !error)
+                    error = lineno;
+            } else if (!error) {
+                /* No '=' or ':' found on name[=:]value line */
+#if INI_ALLOW_NO_VALUE
+                *end = '\0';
+                name = rstrip(start);
+                if (!HANDLER(user, section, name, NULL) && !error)
+                    error = lineno;
+#else
+                error = lineno;
+#endif
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
     }
-    return 1;
+    f_close(&fileObject);
+    return error;
 }

--- a/src/common/ini_handler.h
+++ b/src/common/ini_handler.h
@@ -8,10 +8,6 @@
 extern "C" {
 #endif //__cplusplus
 
-#define BUDDY_INI_LINE_SIZE 200 // maximum allowed chars in a single line
-#define MAX_SECTION         50
-#define MAX_NAME            50
-
 typedef enum {
     BUDDY_INI_OK = 0,
     BUDDY_INI_ERROR,

--- a/src/common/ini_handler.h
+++ b/src/common/ini_handler.h
@@ -7,8 +7,20 @@
 #ifdef __cplusplus
 extern "C" {
 #endif //__cplusplus
-uint8_t ini_save_file(const char *ini_save_str);
-uint8_t ini_load_file(void *user_struct);
+
+#define BUDDY_INI_LINE_SIZE 200 // maximum allowed chars in a single line
+#define MAX_SECTION         50
+#define MAX_NAME            50
+
+typedef enum {
+    BUDDY_INI_OK = 0,
+    BUDDY_INI_ERROR,
+    BUDDY_INI_FILE_READ
+} buddy_ini_error;
+
+buddy_ini_error ini_save_file(const char *ini_save_str);
+
+buddy_ini_error ini_load_file(void *user_struct);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/common/wui_api.c
+++ b/src/common/wui_api.c
@@ -24,10 +24,6 @@ static const uint32_t PRINTER_VERSION_ADDR = 0x08020030; // 1 B
 
 static bool sntp_time_init = false;
 
-uint32_t load_ini_file(ETH_config_t *config) {
-    return ini_load_file(config);
-}
-
 uint32_t save_eth_params(ETH_config_t *ethconfig) {
 
     if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_LAN_FLAGS)) {
@@ -36,6 +32,12 @@ uint32_t save_eth_params(ETH_config_t *ethconfig) {
     if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_LAN_ADDR_IP4)) {
         eeprom_set_var(EEVAR_LAN_IP4_ADDR, variant8_ui32(ethconfig->lan.addr_ip4.addr));
     }
+    if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_DNS1_IP4)) {
+        eeprom_set_var(EEVAR_LAN_IP4_DNS1, variant8_ui32(ethconfig->dns1_ip4.addr));
+    }
+    if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_DNS2_IP4)) {
+        eeprom_set_var(EEVAR_LAN_IP4_DNS2, variant8_ui32(ethconfig->dns2_ip4.addr));
+    }
     if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_LAN_MSK_IP4)) {
         eeprom_set_var(EEVAR_LAN_IP4_MSK, variant8_ui32(ethconfig->lan.msk_ip4.addr));
     }
@@ -43,9 +45,7 @@ uint32_t save_eth_params(ETH_config_t *ethconfig) {
         eeprom_set_var(EEVAR_LAN_IP4_GW, variant8_ui32(ethconfig->lan.gw_ip4.addr));
     }
     if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_HOSTNAME)) {
-        variant8_t hostname = variant8_pchar(ethconfig->hostname, 0, 0);
-        eeprom_set_var(EEVAR_LAN_HOSTNAME, hostname);
-        //variant8_done() is not called, variant_pchar with init flag 0 doesnt hold its memory
+        eeprom_set_pchar_var(EEVAR_LAN_HOSTNAME, ethconfig->hostname, ETH_HOSTNAME_LEN + 1);
     }
     if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_TIMEZONE)) {
         eeprom_set_var(EEVAR_TIMEZONE, variant8_i8(ethconfig->timezone));
@@ -62,6 +62,12 @@ uint32_t load_eth_params(ETH_config_t *ethconfig) {
     if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_LAN_ADDR_IP4)) {
         ethconfig->lan.addr_ip4.addr = variant8_get_ui32(eeprom_get_var(EEVAR_LAN_IP4_ADDR));
     }
+    if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_DNS1_IP4)) {
+        ethconfig->dns1_ip4.addr = variant8_get_ui32(eeprom_get_var(EEVAR_LAN_IP4_DNS1));
+    }
+    if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_DNS2_IP4)) {
+        ethconfig->dns2_ip4.addr = variant8_get_ui32(eeprom_get_var(EEVAR_LAN_IP4_DNS2));
+    }
     if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_LAN_MSK_IP4)) {
         ethconfig->lan.msk_ip4.addr = variant8_get_ui32(eeprom_get_var(EEVAR_LAN_IP4_MSK));
     }
@@ -69,10 +75,7 @@ uint32_t load_eth_params(ETH_config_t *ethconfig) {
         ethconfig->lan.gw_ip4.addr = variant8_get_ui32(eeprom_get_var(EEVAR_LAN_IP4_GW));
     }
     if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_HOSTNAME)) {
-        variant8_t hostname = eeprom_get_var(EEVAR_LAN_HOSTNAME);
-        variant8_t *pvar = &hostname;
-        strlcpy(ethconfig->hostname, variant8_get_pch(hostname), ETH_HOSTNAME_LEN + 1);
-        variant8_done(&pvar);
+        eeprom_get_pchar_var(EEVAR_LAN_HOSTNAME, ethconfig->hostname, ETH_HOSTNAME_LEN + 1);
     }
     if (ethconfig->var_mask & ETHVAR_MSK(ETHVAR_TIMEZONE)) {
         ethconfig->timezone = variant8_get_i8(eeprom_get_var(EEVAR_TIMEZONE));

--- a/src/gui/screen_menu_lan_settings.cpp
+++ b/src/gui/screen_menu_lan_settings.cpp
@@ -282,16 +282,16 @@ void ScreenMenuLanSettings::show_msg(Eth::Msg msg) {
         MsgBoxError(_("Please insert a USB drive and try again."), Responses_Ok);
         break;
     case Eth::Msg::SaveOK:
-        MsgBoxInfo(_("The settings have been saved successfully in the \"lan_settings.ini\" file."), Responses_Ok);
+        MsgBoxInfo(_("The settings have been saved successfully in the \"prusa_printer_settings.ini\" file."), Responses_Ok);
         break;
     case Eth::Msg::SaveNOK:
-        MsgBoxError(_("There was an error saving the settings in the \"lan_settings.ini\" file."), Responses_Ok);
+        MsgBoxError(_("There was an error saving the settings in the \"prusa_printer_settings.ini\" file."), Responses_Ok);
         break;
     case Eth::Msg::LoadOK:
         MsgBoxInfo(_("Settings successfully loaded"), Responses_Ok);
         break;
     case Eth::Msg::LoadNOK:
-        MsgBoxError(_("IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."), Responses_Ok);
+        MsgBoxError(_("IP addresses or parameters are not valid or the file \"prusa_printer_settings.ini\" is not in the root directory of the USB drive."), Responses_Ok);
         break;
     default:
         break;

--- a/src/gui/screen_menu_lan_settings.cpp
+++ b/src/gui/screen_menu_lan_settings.cpp
@@ -147,7 +147,7 @@ void Eth::LoadIni() {
         msg = Msg::NoUSB;
     } else {
         ETH_config_t ethconfig = {};
-        if (load_ini_file(&ethconfig)) {
+        if (BUDDY_INI_OK == ini_load_file(&ethconfig)) {
             save_eth_params(&ethconfig);
             set_eth_update_mask(ethconfig.var_mask);
             msg = Msg::LoadOK;

--- a/src/lang/po/Prusa-Firmware-Buddy.pot
+++ b/src/lang/po/Prusa-Firmware-Buddy.pot
@@ -375,7 +375,7 @@ msgstr ""
 
 #: src/gui/screen_menu_lan_settings.cpp:292
 msgid ""
-"IP addresses or parameters are not valid or the file \"lan_settings.ini\" is "
+"IP addresses or parameters are not valid or the file \"prusa_printer_settings.ini\" is "
 "not in the root directory of the USB drive."
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 
 #: src/gui/screen_menu_lan_settings.cpp:283
 msgid ""
-"The settings have been saved successfully in the \"lan_settings.ini\" file."
+"The settings have been saved successfully in the \"prusa_printer_settings.ini\" file."
 msgstr ""
 
 #: src/gui/wizard/screen_wizard.cpp:170
@@ -1024,7 +1024,7 @@ msgstr ""
 
 #: src/gui/screen_menu_lan_settings.cpp:286
 msgid ""
-"There was an error saving the settings in the \"lan_settings.ini\" file."
+"There was an error saving the settings in the \"prusa_printer_settings.ini\" file."
 msgstr ""
 
 #: src/gui/screen_print_preview.cpp:149

--- a/src/lang/po/cs/Prusa-Firmware-Buddy_cs.po
+++ b/src/lang/po/cs/Prusa-Firmware-Buddy_cs.po
@@ -355,8 +355,8 @@ msgid "Inserting"
 msgstr "Zavádění"
 
 #: src/gui/screen_menu_lan_settings.cpp:292
-msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
-msgstr "Nesprávné IP adresy nebo parametry, nebo soubor \"lan_settings.ini\" není v kořenovém adresáři USB disku."
+msgid "IP addresses or parameters are not valid or the file \"prusa_printer_settings.ini\" is not in the root directory of the USB drive."
+msgstr "Nesprávné IP adresy nebo parametry, nebo soubor \"prusa_printer_settings.ini\" není v kořenovém adresáři USB disku."
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Is color correct?"
@@ -924,8 +924,8 @@ msgid "The selftest failed to finish. Double-check the printer's wiring and axes
 msgstr "Selftest selhal. Zkontrolujte zapojení el. částí i všechny osy. Pak Selftest spusťte znovu."
 
 #: src/gui/screen_menu_lan_settings.cpp:283
-msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
-msgstr "Nastavení úspěšně uloženo do souboru \"lan_settings.ini\""
+msgid "The settings have been saved successfully in the \"prusa_printer_settings.ini\" file."
+msgstr "Nastavení úspěšně uloženo do souboru \"prusa_printer_settings.ini\""
 
 #: src/gui/wizard/screen_wizard.cpp:170
 msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
@@ -936,8 +936,8 @@ msgid "The XYZ calibration failed to finish. Double-check the printer's wiring a
 msgstr "Selhala kalibrace os XYZ. Zkontrolujte zapojení el. součástí i jednotlivé osy, pak restartuje kalibraci XYZ."
 
 #: src/gui/screen_menu_lan_settings.cpp:286
-msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
-msgstr "Při ukládání souboru \"lan_settings.ini\" došlo k chybě."
+msgid "There was an error saving the settings in the \"prusa_printer_settings.ini\" file."
+msgstr "Při ukládání souboru \"prusa_printer_settings.ini\" došlo k chybě."
 
 #. r=1, c=19
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:54

--- a/src/lang/po/de/Prusa-Firmware-Buddy_de.po
+++ b/src/lang/po/de/Prusa-Firmware-Buddy_de.po
@@ -355,8 +355,8 @@ msgid "Inserting"
 msgstr "Einführen"
 
 #: src/gui/screen_menu_lan_settings.cpp:292
-msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
-msgstr "IP-Adressen oder Parameter sind nicht gültig oder die Datei \"lan_settings.ini\" befindet sich nicht im Stammverzeichnis des USB-Laufwerks."
+msgid "IP addresses or parameters are not valid or the file \"prusa_printer_settings.ini\" is not in the root directory of the USB drive."
+msgstr "IP-Adressen oder Parameter sind nicht gültig oder die Datei \"prusa_printer_settings.ini\" befindet sich nicht im Stammverzeichnis des USB-Laufwerks."
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Is color correct?"
@@ -924,8 +924,8 @@ msgid "The selftest failed to finish. Double-check the printer's wiring and axes
 msgstr "Der Selbsttest wurde nicht beendet. Überprüfen Sie die Verkabelung und die Achsen des Druckers. Starten Sie dann den Selbsttest erneut."
 
 #: src/gui/screen_menu_lan_settings.cpp:283
-msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
-msgstr "Die Einstellungen wurden erfolgreich in der Datei \"lan_settings.ini\" gespeichert."
+msgid "The settings have been saved successfully in the \"prusa_printer_settings.ini\" file."
+msgstr "Die Einstellungen wurden erfolgreich in der Datei \"prusa_printer_settings.ini\" gespeichert."
 
 #: src/gui/wizard/screen_wizard.cpp:170
 msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
@@ -936,8 +936,8 @@ msgid "The XYZ calibration failed to finish. Double-check the printer's wiring a
 msgstr "Die XYZ-Kalibrierung konnte nicht abgeschlossen werden. Bitte Verkabelung und Achsen des Druckers überprüfen und starten Sie dann die XYZ-Kalibrierung erneut."
 
 #: src/gui/screen_menu_lan_settings.cpp:286
-msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
-msgstr "Es gab einen Fehler beim Speichern der Einstellungen in der Datei \"lan_settings.ini\"."
+msgid "There was an error saving the settings in the \"prusa_printer_settings.ini\" file."
+msgstr "Es gab einen Fehler beim Speichern der Einstellungen in der Datei \"prusa_printer_settings.ini\"."
 
 #. r=1, c=19
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:54

--- a/src/lang/po/en/Prusa-Firmware-Buddy_en.po
+++ b/src/lang/po/en/Prusa-Firmware-Buddy_en.po
@@ -355,8 +355,8 @@ msgid "Inserting"
 msgstr "Inserting"
 
 #: src/gui/screen_menu_lan_settings.cpp:292
-msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
-msgstr "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
+msgid "IP addresses or parameters are not valid or the file \"prusa_printer_settings.ini\" is not in the root directory of the USB drive."
+msgstr "IP addresses or parameters are not valid or the file \"prusa_printer_settings.ini\" is not in the root directory of the USB drive."
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Is color correct?"
@@ -924,8 +924,8 @@ msgid "The selftest failed to finish. Double-check the printer's wiring and axes
 msgstr "The selftest failed to finish. Double-check the printer's wiring and axes. Then restart the Selftest."
 
 #: src/gui/screen_menu_lan_settings.cpp:283
-msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
-msgstr "The settings have been saved successfully in the \"lan_settings.ini\" file."
+msgid "The settings have been saved successfully in the \"prusa_printer_settings.ini\" file."
+msgstr "The settings have been saved successfully in the \"prusa_printer_settings.ini\" file."
 
 #: src/gui/wizard/screen_wizard.cpp:170
 msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
@@ -936,8 +936,8 @@ msgid "The XYZ calibration failed to finish. Double-check the printer's wiring a
 msgstr "The XYZ calibration failed to finish. Double-check the printer's wiring and axes, then restart the XYZ calibration."
 
 #: src/gui/screen_menu_lan_settings.cpp:286
-msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
-msgstr "There was an error saving the settings in the \"lan_settings.ini\" file."
+msgid "There was an error saving the settings in the \"prusa_printer_settings.ini\" file."
+msgstr "There was an error saving the settings in the \"prusa_printer_settings.ini\" file."
 
 #. r=1, c=19
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:54

--- a/src/lang/po/es/Prusa-Firmware-Buddy_es.po
+++ b/src/lang/po/es/Prusa-Firmware-Buddy_es.po
@@ -355,8 +355,8 @@ msgid "Inserting"
 msgstr "Cargando"
 
 #: src/gui/screen_menu_lan_settings.cpp:292
-msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
-msgstr "Las direcciones IP o los parámetros no son válidos o el archivo \"lan_settings.ini\" no está en el directorio raíz de la unidad USB."
+msgid "IP addresses or parameters are not valid or the file \"prusa_printer_settings.ini\" is not in the root directory of the USB drive."
+msgstr "Las direcciones IP o los parámetros no son válidos o el archivo \"prusa_printer_settings.ini\" no está en el directorio raíz de la unidad USB."
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Is color correct?"
@@ -924,8 +924,8 @@ msgid "The selftest failed to finish. Double-check the printer's wiring and axes
 msgstr "El selftest falló al terminar. Verifica dos veces el cableado de la impresora y los ejes. Luego reinicie el Selftest."
 
 #: src/gui/screen_menu_lan_settings.cpp:283
-msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
-msgstr "La configuración se ha guardado correctamente en el archivo \"lan_settings.ini\"."
+msgid "The settings have been saved successfully in the \"prusa_printer_settings.ini\" file."
+msgstr "La configuración se ha guardado correctamente en el archivo \"prusa_printer_settings.ini\"."
 
 #: src/gui/wizard/screen_wizard.cpp:170
 msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
@@ -936,8 +936,8 @@ msgid "The XYZ calibration failed to finish. Double-check the printer's wiring a
 msgstr "La calibración XYZ no pudo finalizar. Vuelva a verificar el cableado y los ejes de la impresora, luego reinicia la calibración XYZ."
 
 #: src/gui/screen_menu_lan_settings.cpp:286
-msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
-msgstr "Se produjo un error al guardar la configuración en el archivo \"lan_settings.ini\"."
+msgid "There was an error saving the settings in the \"prusa_printer_settings.ini\" file."
+msgstr "Se produjo un error al guardar la configuración en el archivo \"prusa_printer_settings.ini\"."
 
 #. r=1, c=19
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:54

--- a/src/lang/po/fr/Prusa-Firmware-Buddy_fr.po
+++ b/src/lang/po/fr/Prusa-Firmware-Buddy_fr.po
@@ -355,8 +355,8 @@ msgid "Inserting"
 msgstr "Insertion"
 
 #: src/gui/screen_menu_lan_settings.cpp:292
-msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
-msgstr "Les adresses IP ou les paramètres ne sont pas valides ou alors le fichier \"lan_settings.ini\" ne se trouve pas dans le répertoire racine de la clé USB."
+msgid "IP addresses or parameters are not valid or the file \"prusa_printer_settings.ini\" is not in the root directory of the USB drive."
+msgstr "Les adresses IP ou les paramètres ne sont pas valides ou alors le fichier \"prusa_printer_settings.ini\" ne se trouve pas dans le répertoire racine de la clé USB."
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Is color correct?"
@@ -924,8 +924,8 @@ msgid "The selftest failed to finish. Double-check the printer's wiring and axes
 msgstr "Le selftest pas pu aboutir. Vérifiez bien le câblage et les axes de l'imprimante. Puis relancez le selftest."
 
 #: src/gui/screen_menu_lan_settings.cpp:283
-msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
-msgstr "Les réglages ont été sauvegardés avec succès dans le fichier \"lan_settings.ini\"."
+msgid "The settings have been saved successfully in the \"prusa_printer_settings.ini\" file."
+msgstr "Les réglages ont été sauvegardés avec succès dans le fichier \"prusa_printer_settings.ini\"."
 
 #: src/gui/wizard/screen_wizard.cpp:170
 msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
@@ -936,8 +936,8 @@ msgid "The XYZ calibration failed to finish. Double-check the printer's wiring a
 msgstr "La calibration XYZ n'a pas pu aboutir. Vérifiez bien le câblage et les axes de l'imprimante, puis relancez la calibration XYZ."
 
 #: src/gui/screen_menu_lan_settings.cpp:286
-msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
-msgstr "Une erreur s'est produite au moment de sauvegarder les réglages dans le fichier \"lan_settings.ini\"."
+msgid "There was an error saving the settings in the \"prusa_printer_settings.ini\" file."
+msgstr "Une erreur s'est produite au moment de sauvegarder les réglages dans le fichier \"prusa_printer_settings.ini\"."
 
 #. r=1, c=19
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:54

--- a/src/lang/po/it/Prusa-Firmware-Buddy_it.po
+++ b/src/lang/po/it/Prusa-Firmware-Buddy_it.po
@@ -355,8 +355,8 @@ msgid "Inserting"
 msgstr "Inserimento"
 
 #: src/gui/screen_menu_lan_settings.cpp:292
-msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
-msgstr "Indirizzi IP o parametri non validi o il file \"lan_settings.ini\" non presente nella directory principale del drive USB."
+msgid "IP addresses or parameters are not valid or the file \"prusa_printer_settings.ini\" is not in the root directory of the USB drive."
+msgstr "Indirizzi IP o parametri non validi o il file \"prusa_printer_settings.ini\" non presente nella directory principale del drive USB."
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Is color correct?"
@@ -924,8 +924,8 @@ msgid "The selftest failed to finish. Double-check the printer's wiring and axes
 msgstr "Autotest non completato. Ricontrolla gli assi e il cablaggio della stampante. Poi riavvia l'Autotest."
 
 #: src/gui/screen_menu_lan_settings.cpp:283
-msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
-msgstr "Impostazioni salvate correttamente nel file \"lan_settings.ini\"."
+msgid "The settings have been saved successfully in the \"prusa_printer_settings.ini\" file."
+msgstr "Impostazioni salvate correttamente nel file \"prusa_printer_settings.ini\"."
 
 #: src/gui/wizard/screen_wizard.cpp:170
 msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
@@ -936,8 +936,8 @@ msgid "The XYZ calibration failed to finish. Double-check the printer's wiring a
 msgstr "Calibrazione XYZ non riuscita. Ricontrolla il cablaggio e gli assi, quindi ripeti la calibrazione XYZ."
 
 #: src/gui/screen_menu_lan_settings.cpp:286
-msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
-msgstr "Errore nel salvataggio delle impostazioni nel file \"lan_settings.ini\"."
+msgid "There was an error saving the settings in the \"prusa_printer_settings.ini\" file."
+msgstr "Errore nel salvataggio delle impostazioni nel file \"prusa_printer_settings.ini\"."
 
 #. r=1, c=19
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:54

--- a/src/lang/po/pl/Prusa-Firmware-Buddy_pl.po
+++ b/src/lang/po/pl/Prusa-Firmware-Buddy_pl.po
@@ -355,8 +355,8 @@ msgid "Inserting"
 msgstr "Wsuwanie"
 
 #: src/gui/screen_menu_lan_settings.cpp:292
-msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
-msgstr "Adresy IP lub parametry są nieprawidłowe, albo plik \"lan_settings.ini\" nie znajduje się w katalogu głównym pamięci USB."
+msgid "IP addresses or parameters are not valid or the file \"prusa_printer_settings.ini\" is not in the root directory of the USB drive."
+msgstr "Adresy IP lub parametry są nieprawidłowe, albo plik \"prusa_printer_settings.ini\" nie znajduje się w katalogu głównym pamięci USB."
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Is color correct?"
@@ -924,8 +924,8 @@ msgid "The selftest failed to finish. Double-check the printer's wiring and axes
 msgstr "Selftest zakończony niepowodzeniem. Sprawdź okablowanie drukarki oraz osie, następnie zrestartuj Selftest."
 
 #: src/gui/screen_menu_lan_settings.cpp:283
-msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
-msgstr "Ustawienia zostały pomyślnie zapisane w pliku \"lan_settings.ini\"."
+msgid "The settings have been saved successfully in the \"prusa_printer_settings.ini\" file."
+msgstr "Ustawienia zostały pomyślnie zapisane w pliku \"prusa_printer_settings.ini\"."
 
 #: src/gui/wizard/screen_wizard.cpp:170
 msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
@@ -936,8 +936,8 @@ msgid "The XYZ calibration failed to finish. Double-check the printer's wiring a
 msgstr "Kalibracja XYZ zakończona niepowodzeniem. Sprawdź okablowanie oraz osie drukarki, następnie uruchom kalibrację ponownie."
 
 #: src/gui/screen_menu_lan_settings.cpp:286
-msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
-msgstr "Wystąpił błąd podczas zapisywania ustawień w pliku \"lan_settings.ini\"."
+msgid "There was an error saving the settings in the \"prusa_printer_settings.ini\" file."
+msgstr "Wystąpił błąd podczas zapisywania ustawień w pliku \"prusa_printer_settings.ini\"."
 
 #. r=1, c=19
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:54

--- a/tests/unit/common/str_utils_test.cpp
+++ b/tests/unit/common/str_utils_test.cpp
@@ -380,9 +380,9 @@ TEST_CASE("multi-line", "[text_wrap]") {
             std::make_tuple<std::string, size_t, std::string>(
                 "In the next step, use the knob to adjust the nozzle height. Check the pictures in the handbook for reference.", 7, "In the next step,\nuse the knob to\nadjust the nozzle\nheight. Check the\npictures in the\nhandbook for\nreference."),
             std::make_tuple<std::string, size_t, std::string>(
-                "IP addresses are not valid or the file \\lan_settings.ini\\ is not in the root directory of the USB drive.", 6, "IP addresses are not\nvalid or the file\n\\lan_settings.ini\\\nis not in the root\ndirectory of the USB\ndrive."),
+                "IP addresses are not valid or the file \\prusa_printer_settings.ini\\ is not in the root directory of the USB drive.", 6, "IP addresses are not\nvalid or the file\n\\prusa_printer_settings.ini\\\nis not in the root\ndirectory of the USB\ndrive."),
             std::make_tuple<std::string, size_t, std::string>(
-                "IP addresses or parameters are not valid or the file \\lan_settings.ini\\ is not in the root directory of the USB drive.", 7, "IP addresses or\nparameters are not\nvalid or the file\n\\lan_settings.ini\\\nis not in the root\ndirectory of the USB\ndrive."),
+                "IP addresses or parameters are not valid or the file \\prusa_printer_settings.ini\\ is not in the root directory of the USB drive.", 7, "IP addresses or\nparameters are not\nvalid or the file\n\\prusa_printer_settings.ini\\\nis not in the root\ndirectory of the USB\ndrive."),
             std::make_tuple<std::string, size_t, std::string>(
                 "Is filament in extruder gear?", 2, "Is filament in\nextruder gear?"),
             std::make_tuple<std::string, size_t, std::string>(
@@ -430,13 +430,13 @@ TEST_CASE("multi-line", "[text_wrap]") {
             std::make_tuple<std::string, size_t, std::string>(
                 "The selftest failed to finish. Double-check the printer's wiring and axes. Then restart the Selftest.", 6, "The selftest failed\nto finish.\nDouble-check the\nprinter's wiring and\naxes. Then restart\nthe Selftest."),
             std::make_tuple<std::string, size_t, std::string>(
-                "The settings have been saved successfully in the \\lan_settings.ini\\ file.", 5, "The settings have\nbeen saved\nsuccessfully in the\n\\lan_settings.ini\\\nfile."),
+                "The settings have been saved successfully in the \\prusa_printer_settings.ini\\ file.", 5, "The settings have\nbeen saved\nsuccessfully in the\n\\prusa_printer_settings.ini\\\nfile."),
             std::make_tuple<std::string, size_t, std::string>(
                 "The status bar is at the bottom of the screen. It contains information about: - Nozzle temp. - Heatbed temp. - Printing speed - Z-axis height - Selected filament", 9, "The status bar is at\nthe bottom of the\nscreen. It contains\ninformation about: -\nNozzle temp. -\nHeatbed temp. -\nPrinting speed -\nZ-axis height -\nSelected filament"),
             std::make_tuple<std::string, size_t, std::string>(
                 "The XYZ calibration failed to finish. Double-check the printer's wiring and axes, then restart the XYZ calibration.", 6, "The XYZ calibration\nfailed to finish.\nDouble-check the\nprinter's wiring and\naxes, then restart\nthe XYZ calibration."),
             std::make_tuple<std::string, size_t, std::string>(
-                "There was an error saving the settings in the \\lan_settings.ini\\ file.", 5, "There was an error\nsaving the settings\nin the\n\\lan_settings.ini\\\nfile."),
+                "There was an error saving the settings in the \\prusa_printer_settings.ini\\ file.", 5, "There was an error\nsaving the settings\nin the\n\\prusa_printer_settings.ini\\\nfile."),
             std::make_tuple<std::string, size_t, std::string>(
                 "This operation can't be undone, current configuration will be lost! Are you really sure to reset printer to factory defaults?", 7, "This operation can't\nbe undone, current\nconfiguration will\nbe lost! Are you\nreally sure to reset\nprinter to factory\ndefaults?"),
             std::make_tuple<std::string, size_t, std::string>(


### PR DESCRIPTION
Major changes
1. ini file read and parsed from file (before the whole file was copied to a char array and parsed)
2. There is a limit on the line length (now set to 200 chars) and data after this limit on any line is ignored
3. Added new EEPROM read and write functions for manipulating with string entries
4. The original inhi library was modified (some static functions made public)