### PR TITLE
Fix menu item naming

### DIFF
--- a/src/guiapi/include/MItem_menus.hpp
+++ b/src/guiapi/include/MItem_menus.hpp
@@ -126,7 +126,7 @@ protected:
 };
 
 class MI_LAN_SETTINGS : public WI_LABEL_t {
-    static constexpr const char *const label = N_("Lan Settings");
+    static constexpr const char *const label = N_("Network Settings");
 
 public:
     MI_LAN_SETTINGS();


### PR DESCRIPTION
To use such a setting screen on only for LAN but also for WIFI the more relevant name will be "Network Settings"

BFW-1977