### PR TITLE
GUI: Fix filenames with diacritic not showing

### DIFF
--- a/include/ffconf.h
+++ b/include/ffconf.h
@@ -117,7 +117,7 @@
 / Locale and Namespace Configurations
 /-----------------------------------------------------------------------------*/
 
-#define _CODE_PAGE 850
+#define _CODE_PAGE 852
 /* This option specifies the OEM code page to be used on the target system.
 /  Incorrect setting of the code page can cause a file open failure.
 /

--- a/src/gui/lazyfilelist.h
+++ b/src/gui/lazyfilelist.h
@@ -314,12 +314,15 @@ private:
             static const char gcode[] = ".gcode";
             static const char gc[] = ".gc";
             static const char g[] = ".g";
+            static const char gco[] = ".gco";
 
             if (!strcasecmp(fname + len - sizeof(gcode) + 1, gcode))
                 return true;
             if (!strcasecmp(fname + len - sizeof(gc) + 1, gc))
                 return true;
             if (!strcasecmp(fname + len - sizeof(g) + 1, g))
+                return true;
+            if (!strcasecmp(fname + len - sizeof(gco) + 1, gco))
                 return true;
             return false;
         }


### PR DESCRIPTION
- added filter for shortened names by fatFS when character outside
current code page is present
- switched fatFS code page to 852, fatFS can load czech filenames, but
in code page 852 encoding and it is not compatible with utf8 encoding,
thus the name on screen is shown with * or ? intead of the characte