### PR TITLE
Fix watchdog reset while printing from Octoprint

### DIFF
--- a/lib/Marlin/Marlin/src/Marlin.cpp
+++ b/lib/Marlin/Marlin/src/Marlin.cpp
@@ -710,7 +710,9 @@ void idle(
  */
 void kill(PGM_P const lcd_error/*=nullptr*/, PGM_P const lcd_component/*=nullptr*/, const bool steppers_off/*=false*/) {
   thermalManager.disable_all_heaters();
-
+  
+    //while connected to octoprint, this line kills whole firmware
+    //TODO: fix with new logging framework from Alan
 //   SERIAL_ERROR_MSG(MSG_ERR_KILLED);
 
   #if HAS_DISPLAY

--- a/lib/Marlin/Marlin/src/Marlin.cpp
+++ b/lib/Marlin/Marlin/src/Marlin.cpp
@@ -711,7 +711,7 @@ void idle(
 void kill(PGM_P const lcd_error/*=nullptr*/, PGM_P const lcd_component/*=nullptr*/, const bool steppers_off/*=false*/) {
   thermalManager.disable_all_heaters();
 
-  SERIAL_ERROR_MSG(MSG_ERR_KILLED);
+//   SERIAL_ERROR_MSG(MSG_ERR_KILLED);
 
   #if HAS_DISPLAY
     ui.kill_screen(lcd_error ?: GET_TEXT(MSG_KILLED), lcd_component);


### PR DESCRIPTION
problem with serial error message from Marlin kill comand, will be fixed with new logging
framework from Alan

BFW-1158
