### PR TITLE
ALTCP ESP

### DIFF
--- a/lib/ESP/CMakeLists.txt
+++ b/lib/ESP/CMakeLists.txt
@@ -39,7 +39,7 @@ target_sources(
             prusa/src/system/lwesp_sys_buddy.c
             prusa/src/system/lwesp_ll_buddy.c
             prusa/src/esp.c
-            # prusa/src/system/esp_tcp.c
+            prusa/src/system/esp_tcp.c
             prusa/snippets/client.c
             lwesp/src/api/esp_netconn.c
             prusa/src/sockets/lwesp_sockets.c

--- a/lib/ESP/lwesp/src/esp/esp_conn.c
+++ b/lib/ESP/lwesp/src/esp/esp_conn.c
@@ -152,7 +152,7 @@ conn_get_val_id(esp_conn_p conn) {
  * \param[in]       blocking: Status whether command should be blocking or not
  * \return          \ref espOK on success, member of \ref espr_t enumeration otherwise
  */
-static espr_t
+espr_t
 conn_send(esp_conn_p conn, const esp_ip_t* const ip, esp_port_t port, const void* data,
             size_t btw, size_t* const bw, uint8_t fau, const uint32_t blocking) {
     ESP_MSG_VAR_DEFINE(msg);

--- a/lib/ESP/prusa/include/esp_tcp.h
+++ b/lib/ESP/prusa/include/esp_tcp.h
@@ -44,6 +44,9 @@
 #define ESP_HDR_ALTCP_TCP_H
 
 #include "esp/esp_config.h"
+#include "sockets/lwesp_sockets_priv.h"
+
+#define EPCB_POOL_SIZE 10
 
 #if ESP_ALTCP /* don't build if not configured for use in lwipopts.h */
 
@@ -59,6 +62,15 @@ struct altcp_pcb *altcp_esp_new_ip_type(u8_t ip_type);
     #define altcp_esp_new_ip6() altcp_esp_new_ip_type(IPADDR_TYPE_V6)
 
 struct altcp_pcb *altcp_esp_alloc(void *arg, u8_t ip_type);
+
+typedef struct {
+    struct esp_conn *econn;   // ESP conn connection
+    struct altcp_pcb *alconn; // Application layer TCP connection
+    esp_port_t listen_port;
+    uint16_t conn_timeout;
+    size_t rcv_packets;            // Received packets
+    char host[IP4ADDR_STRLEN_MAX]; // Connect host
+} esp_pcb;
 
     #ifdef __cplusplus
 }

--- a/lib/ESP/prusa/include/sockets/lwesp_sockets_priv.h
+++ b/lib/ESP/prusa/include/sockets/lwesp_sockets_priv.h
@@ -47,6 +47,9 @@
 #include "lwip/sockets.h"
 #include "lwip/sys.h"
 
+#include "esp/esp.h"
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/ESP/prusa/src/system/esp_tcp.c
+++ b/lib/ESP/prusa/src/system/esp_tcp.c
@@ -38,10 +38,13 @@
  * This file is part of the ESPIP TCP/IP stack.
  *
  * Author: Marek Mosna <marek.mosna@prusa3d.cz>
+ * Author: Vladimir Matena <vladimir.matena@prusa3d.cz>
  *
  */
 
 #include "esp/esp_config.h"
+
+#include "dbg.h"
 
 #if ESP_ALTCP /* don't build if not configured for use in espopts.h */
 
@@ -49,140 +52,356 @@
     #include <string.h>
     #include "lwip/altcp.h"
     #include "lwip/priv/altcp_priv.h"
-    #include "esp/esp_netconn.h"
+
+    #include "sockets/lwesp_sockets_priv.h"
 
     #include "lwip/tcp.h"
-// #include "lwip/mem.h"
-//#include "lwip/altcp_tcp.h"
+
+    #include "esp_tcp.h"
 
 /* Variable prototype, the actual declaration is at the end of this file
    since it contains pointers to static functions declared here */
 extern const struct altcp_functions altcp_esp_functions;
 
-static void altcp_esp_setup(struct altcp_pcb *conn, esp_netconn_p tpcb);
+static void altcp_esp_setup(struct altcp_pcb *conn, esp_pcb *epcb);
+
+static err_t espr_t2err_t(const espr_t err) {
+    switch (err) {
+    case espOK:
+        return ERR_OK;    /*!< Function succeeded */
+    case espOKIGNOREMORE: /*!< Function succedded, should continue as espOK but ignore sending more data. This result is possible on connection data receive callback */
+        _dbg("espOKIGNOREMORE - pretending all ok");
+        return ERR_OK;
+    case espERR:
+        _dbg("Generic ESP err");
+        return ERR_IF;
+    case espERRCONNTIMEOUT: /*!< Timeout received when connection to access point */
+        _dbg("espERRCONNTIMEOUT");
+        return ERR_IF;
+    case espERRPASS: /*!< Invalid password for access point */
+        _dbg("espERRPASS");
+        return ERR_IF;
+    case espERRNOAP: /*!< No access point found with specific SSID and MAC address */
+        _dbg("espERRNOAP");
+        return ERR_IF;
+    case espERRCONNFAIL: /*!< Connection failed to access point */
+        _dbg("espERRCONNFAIL");
+        return ERR_IF;
+    case espERRWIFINOTCONNECTED: /*!< Wifi not connected to access point */
+        _dbg("espERRWIFINOTCONNECTED");
+        return ERR_IF;
+    case espERRNODEVICE: /*!< Device is not present */
+        _dbg("espERRNODEVICE");
+        return ERR_IF;
+    case espCONT:
+        _dbg("espCONT"); /*!< There is still some command to be processed in current command */
+        return ERR_IF;
+    case espPARERR:
+        return ERR_VAL;    /*!< Wrong parameters on function call */
+    case espERRNOFREECONN: /*!< There is no free connection available to start */
+    case espERRMEM:
+        return ERR_MEM; /*!< Memory error occurred */
+    case espTIMEOUT:
+        return ERR_TIMEOUT; /*!< Timeout occurred on command */
+    case espCLOSED:
+        return ERR_CLSD; /*!< Connection just closed */
+    case espINPROG:
+        return ERR_INPROGRESS; /*!< Operation is in progress */
+    case espERRNOIP:
+        return ERR_ISCONN; /*!< Station does not have IP address */
+    case espERRBLOCKING:
+        return ERR_WOULDBLOCK;
+    default:
+        _dbg("Unknown ESP err");
+        return -1;
+    }
+}
+
+static void ALTCP_TCP_ASSERT_CONN_PCB(struct altcp_pcb *conn, esp_pcb *epcb) {
+    if (!conn) {
+        _dbg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! !conn");
+    }
+
+    if (!epcb) {
+        _dbg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! !epcb");
+    }
+
+    if (conn->state != epcb) {
+        _dbg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! conn->state: %x != epcb: %x", conn->state, epcb);
+    }
+
+    if (epcb->alconn != conn) {
+        _dbg("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! epcb->alconn: %x != conn: %x", epcb->alconn, conn);
+    }
+}
 
 /* callback functions for TCP */
 static err_t
-altcp_esp_accept(void *arg, esp_netconn_p new_tpcb, err_t err) {
+altcp_esp_accept(void *arg, esp_pcb *new_epcb, err_t err) {
+    _dbg("altcp_esp_accept");
     struct altcp_pcb *listen_conn = (struct altcp_pcb *)arg;
-    if (listen_conn && listen_conn->accept) {
-        /* create a new altcp_conn to pass to the next 'accept' callback */
-        struct altcp_pcb *new_conn = altcp_alloc();
-        if (new_conn == NULL) {
-            return ERR_MEM;
-        }
-        altcp_esp_setup(new_conn, new_tpcb);
-        return listen_conn->accept(listen_conn->arg, new_conn, err);
+    if (!listen_conn || !listen_conn->accept) {
+        _dbg("!!! listen connection not set properly !!!");
+        return ERR_ARG;
     }
-    return ERR_ARG;
+
+    /* create a new altcp_conn to pass to the next 'accept' callback */
+    struct altcp_pcb *new_conn = altcp_alloc();
+    if (new_conn == NULL) {
+        _dbg("No mem to alloc altcp !!!");
+        return ERR_MEM;
+    }
+    altcp_esp_setup(new_conn, new_epcb);
+    return listen_conn->accept(listen_conn->arg, new_conn, err);
 }
 
 static err_t
-altcp_esp_connected(void *arg, struct tcp_pcb *tpcb, err_t err) {
+altcp_esp_connected(void *arg, esp_pcb *epcb, err_t err) {
+    _dbg("altcp_esp_connected");
+    struct altcp_pcb *conn = (struct altcp_pcb *)arg;
+    if (epcb->alconn && epcb->alconn->connected) {
+        epcb->alconn->connected(conn->arg, conn, 0);
+    }
     return ERR_OK;
 }
 
 static err_t
-altcp_esp_recv(void *arg, struct altcp_pcb *tpcb, struct pbuf *p, err_t err) {
-    // esp_netconn_p conn = (esp_netconn_p)arg;
-    // if (conn) {
-    //   esp_netconn_receive(conn, )
-    // }
-    // if (p != NULL) {
-    //   /* prevent memory leaks */
-    //   pbuf_free(p);
-    // }
+altcp_esp_recv(void *arg, esp_pcb *epcb, struct pbuf *p, err_t err) {
+    _dbg("altcp_esp_recv");
+    struct altcp_pcb *conn = (struct altcp_pcb *)arg;
+
+    if (conn) {
+        ALTCP_TCP_ASSERT_CONN_PCB(conn, epcb);
+        if (conn->recv) {
+            return conn->recv(conn->arg, conn, p, err);
+        }
+    }
+    if (p != NULL) {
+        // prevent memory leaks
+        pbuf_free(p);
+    }
     return ERR_OK;
 }
 
 static err_t
-altcp_esp_sent(void *arg, struct altcp_pcb *tpcb, u16_t len) {
-    // struct altcp_pcb *conn = (struct altcp_pcb *)arg;
-    // if (conn) {
-    //   ALTCP_TCP_ASSERT_CONN_PCB(conn, tpcb);
-    //   if (conn->sent) {
-    //     return conn->sent(conn->arg, conn, len);
-    //   }
-    // }
+altcp_esp_sent(void *arg, esp_pcb *epcb, u16_t len) {
+    _dbg("altcp_esp_sent");
+    struct altcp_pcb *conn = (struct altcp_pcb *)arg;
+    if (conn) {
+        ALTCP_TCP_ASSERT_CONN_PCB(conn, epcb);
+        if (conn->sent) {
+            return conn->sent(conn->arg, conn, len);
+        }
+    }
     return ERR_OK;
 }
 
 static err_t
-altcp_esp_poll(void *arg, struct altcp_pcb *tpcb) {
-    // struct altcp_pcb *conn = (struct altcp_pcb *)arg;
-    // if (conn) {
-    //   ALTCP_TCP_ASSERT_CONN_PCB(conn, tpcb);
-    //   if (conn->poll) {
-    //     return conn->poll(conn->arg, conn);
-    //   }
-    // }
+altcp_esp_poll(void *arg, esp_pcb *epcb) {
+    _dbg("altcp_esp_poll");
+    _dbg("arg: %x, esp_pcb: %x", arg, epcb);
+    struct altcp_pcb *conn = (struct altcp_pcb *)arg;
+    if (conn) {
+        ALTCP_TCP_ASSERT_CONN_PCB(conn, epcb);
+        if (conn->poll) {
+
+            _dbg("CALLING POL FUNC %x, arg: %x", conn->poll, conn->arg);
+            err_t ret = conn->poll(conn->arg, conn);
+            _dbg("POLL FUNC RETURNED");
+            return ret;
+        }
+    }
     return ERR_OK;
 }
 
 static void
 altcp_esp_err(void *arg, err_t err) {
-    // struct altcp_pcb *conn = (struct altcp_pcb *)arg;
-    // if (conn) {
-    //   conn->state = NULL; /* already freed */
-    //   if (conn->err) {
-    //     conn->err(conn->arg, err);
-    //   }
-    //   altcp_free(conn);
-    // }
+    _dbg("altcp_esp_err");
+    struct altcp_pcb *conn = (struct altcp_pcb *)arg;
+    if (conn) {
+        conn->state = NULL; /* already freed */
+        if (conn->err) {
+            conn->err(conn->arg, err);
+        }
+        altcp_free(conn);
+    }
 }
 
 /* setup functions */
 
 static void
-altcp_esp_remove_callbacks(struct altcp_pcb *pcb) {
-    LWIP_ASSERT_CORE_LOCKED();
-    if (pcb != NULL) {
-        pcb->recv = NULL;
-        pcb->sent = NULL;
-        pcb->err = NULL;
-        pcb->poll = NULL;
-    }
-    // tcp_arg(tpcb, NULL);
-    // tcp_recv(tpcb, NULL);
-    // tcp_sent(tpcb, NULL);
-    // tcp_err(tpcb, NULL);
-    // tcp_poll(tpcb, NULL, tpcb->pollinterval);
-}
-
-static void
-altcp_esp_setup_callbacks(struct altcp_pcb *pcb, esp_netconn_p tpcb) {
-    LWIP_ASSERT_CORE_LOCKED();
-    if (pcb != NULL) {
-        pcb->recv = altcp_esp_recv;
-        pcb->sent = altcp_esp_sent;
-        pcb->err = altcp_esp_err;
-    }
-
-    // tcp_arg(tpcb, conn);
-    /* tcp_poll is set when interval is set by application */
-    /* listen is set totally different :-) */
-}
-
-static void
-altcp_esp_setup(struct altcp_pcb *conn, esp_netconn_p tpcb) {
-    altcp_esp_setup_callbacks(conn, tpcb);
-    conn->state = tpcb;
+altcp_esp_setup(struct altcp_pcb *conn, esp_pcb *epcb) {
+    _dbg("altcp_esp_setup");
+    conn->state = epcb;
     conn->fns = &altcp_esp_functions;
+    epcb->alconn = conn;
+    _dbg("Setup epcb: %x, alcon: %x", epcb, epcb->alconn);
+}
+
+LWIP_MEMPOOL_DECLARE(EPCB_POOL, EPCB_POOL_SIZE, sizeof(esp_pcb), "ESP PCB pool");
+
+static int memp_initialized = 0;
+
+static esp_pcb *esp_new_ip_type(u8_t ip_type) {
+    if (!memp_initialized) {
+        memp_initialized = 1;
+        LWIP_MEMPOOL_INIT(EPCB_POOL);
+    }
+
+    esp_pcb *pcb = (esp_pcb *)LWIP_MEMPOOL_ALLOC(EPCB_POOL);
+    memset(pcb, 0, sizeof(esp_pcb));
+    return pcb;
+}
+
+static void esp_ip_free(esp_pcb *epcb) {
+    LWIP_MEMPOOL_FREE(EPCB_POOL, epcb);
+}
+
+static esp_pcb *listen_api;
+
+static espr_t altcp_esp_evt(esp_evt_t *evt) {
+    esp_conn_p conn;
+    esp_pcb *epcb = NULL;
+    uint8_t close = 0;
+
+    conn = esp_conn_get_from_evt(evt);
+    _dbg("Event from conn %d", esp_conn_getnum(conn));
+    switch (esp_evt_get_type(evt)) {
+    case ESP_EVT_CONN_ACTIVE: {
+        _dbg("ESP_EVT_CONN_ACTIVE");
+        if (esp_conn_is_client(conn)) {
+            _dbg("ESP_EVT_CONN_ACTIVE - CLIENT");
+            epcb = esp_conn_get_arg(conn);
+            if (epcb != NULL) {
+                epcb->econn = conn;
+                altcp_esp_connected(epcb->alconn, epcb, 0);
+            } else {
+                _dbg("ACTIVE CLIENT WITHOUT EPCB POINTER !!!!");
+                close = 1;
+            }
+        } else if (esp_conn_is_server(conn) && listen_api != NULL) {
+            _dbg("ESP_EVT_CONN_ACTIVE - SERVER");
+            epcb = esp_new_ip_type(0);
+            ESP_DEBUGW(ESP_DBG_TYPE_TRACE | ESP_DBG_LVL_WARNING,
+                nc == NULL, "[ESPTCP] Cannot create new structure for incoming server connection!\r\n");
+
+            if (epcb != NULL) {
+                epcb->econn = conn;
+                esp_conn_set_arg(conn, epcb);
+                altcp_esp_accept(listen_api->alconn, epcb, 0);
+            } else {
+                _dbg("esp_pcb not created");
+                close = 1;
+            }
+        } else {
+            _dbg("ESP_EVT_CONN_ACTIVE - OTHER");
+            ESP_DEBUGW(ESP_DBG_TYPE_TRACE | ESP_DBG_LVL_WARNING, listen_api == NULL,
+                "[ESPTCP] Closing connection as there is no listening API in ESP PCB!\r\n");
+            close = 1; /* Close the connection at this point */
+        }
+
+        /* Decide if some events want to close the connection */
+        if (close) {
+            if (epcb != NULL) {
+                _dbg("Closing conn %d", esp_conn_getnum(conn));
+                esp_conn_set_arg(conn, NULL); /* Reset argument */
+                esp_ip_free(epcb);
+            }
+            esp_conn_close(conn, 0); /* Close the connection */
+            close = 0;
+        }
+        break;
+    }
+
+    /*
+         * We have a new data received which
+         * should have esp pcb structure as argument
+         */
+    case ESP_EVT_CONN_RECV: {
+        _dbg("ESP_EVT_CONN_RECV");
+        esp_pbuf_p pbuf;
+
+        epcb = esp_conn_get_arg(conn);          /* Get API from connection */
+        pbuf = esp_evt_conn_recv_get_buff(evt); /* Get received buff */
+
+        esp_conn_recved(conn, pbuf); /* Notify stack about received data */
+        epcb->rcv_packets++;         /* Increase number of received packets */
+
+        esp_pbuf_ref(pbuf); /* Increase reference counter */
+        if (!epcb) {
+            esp_pbuf_free(pbuf);
+        }
+
+        // Copy pbuf data pbuf to pbuf
+        struct pbuf *lwip_pbuf = pbuf_alloc(PBUF_TRANSPORT, esp_pbuf_length(pbuf, 0), PBUF_RAM);
+        esp_pbuf_copy(pbuf, lwip_pbuf->payload, esp_pbuf_length(pbuf, 0), 0);
+        esp_pbuf_free(pbuf);
+
+        struct altcp_pcb *pcb = epcb->alconn;
+        altcp_esp_recv(pcb, epcb, lwip_pbuf, 0);
+
+        ESP_DEBUGF(ESP_DBG_TYPE_TRACE,
+            "[ESPTCP] Written %d bytes to receive mbox\r\n",
+            (int)esp_pbuf_length(pbuf, 0));
+        break;
+    }
+
+    /* Connection was just closed */
+    case ESP_EVT_CONN_CLOSED: {
+        _dbg("ESP_EVT_CONN_CLOSED");
+        epcb = esp_conn_get_arg(conn); /* Get API from connection */
+
+        if (epcb) {
+            _dbg("Connection closed and epcb not NULL -> free, err");
+            struct altcp_pcb *pcb = epcb->alconn;
+            esp_conn_set_arg(conn, NULL);
+            esp_ip_free(epcb);
+            altcp_esp_err(pcb, ERR_CLSD);
+        }
+
+        break;
+    }
+    case ESP_EVT_CONN_SEND:
+        _dbg("ESP_EVT_CONN_SEND");
+        epcb = esp_conn_get_arg(conn);
+        if (epcb) {
+            struct altcp_pcb *pcb = epcb->alconn;
+            const size_t sent = esp_evt_conn_send_get_length(evt);
+            altcp_esp_sent(pcb, epcb, sent);
+        }
+
+        break;
+
+    case ESP_EVT_CONN_POLL:
+        _dbg("ESP_EVT_CONN_POLL");
+        epcb = esp_conn_get_arg(conn);
+        if (epcb == NULL) {
+            _dbg("epcb is NULL !!!");
+            break;
+        }
+        altcp_esp_poll(epcb->alconn, epcb);
+        break;
+    default:
+        _dbg("Unknown event type: %d", esp_evt_get_type(evt));
+        return espERR;
+    }
+    return espOK;
 }
 
 struct altcp_pcb *
 altcp_esp_new_ip_type(u8_t ip_type) {
+    _dbg("altcp_esp_new_ip_type");
     /* Allocate the tcp pcb first to invoke the priority handling code
      if we're out of pcbs */
-    esp_netconn_p tpcb = esp_netconn_new(ip_type);
-    if (tpcb != NULL) {
+    esp_pcb *epcb = esp_new_ip_type(ip_type);
+    if (epcb != NULL) {
         struct altcp_pcb *ret = altcp_alloc();
         if (ret != NULL) {
-            altcp_esp_setup(ret, tpcb);
+            altcp_esp_setup(ret, epcb);
             return ret;
         } else {
             /* altcp_pcb allocation failed -> free the tcp_pcb too */
-            esp_netconn_delete(tpcb);
+            esp_ip_free(epcb);
         }
     }
     return NULL;
@@ -194,269 +413,187 @@ altcp_esp_new_ip_type(u8_t ip_type) {
 */
 struct altcp_pcb *
 altcp_esp_alloc(void *arg, u8_t ip_type) {
+    _dbg("altcp_esp_alloc");
     LWIP_UNUSED_ARG(arg);
     return altcp_esp_new_ip_type(ip_type);
 }
 
 struct altcp_pcb *
 altcp_esp_wrap(struct tcp_pcb *tpcb) {
-    // if (tpcb != NULL) {
-    //   struct altcp_pcb *ret = altcp_alloc();
-    //   if (ret != NULL) {
-    //     altcp_esp_setup(ret, tpcb);
-    //     return ret;
-    //   }
-    // }
+    _dbg("altcp_esp_wrap - NOT IMPLEMENTED");
     return NULL;
 }
 
 /* "virtual" functions calling into tcp */
 static void
 altcp_esp_set_poll(struct altcp_pcb *conn, u8_t interval) {
-    // if (conn != NULL) {
-    //   struct tcp_pcb *pcb = (struct tcp_pcb *)conn->state;
-    //   ALTCP_TCP_ASSERT_CONN(conn);
-    //   tcp_poll(pcb, altcp_esp_poll, interval);
-    // }
+    _dbg("altcp_esp_set_poll - NOT IMPLEMENTED");
 }
 
 static void
 altcp_esp_recved(struct altcp_pcb *conn, u16_t len) {
-    // if (conn != NULL) {
-    //   struct tcp_pcb *pcb = (struct tcp_pcb *)conn->state;
-    //   ALTCP_TCP_ASSERT_CONN(conn);
-    //   tcp_recved(pcb, len);
-    // }
+    _dbg("altcp_esp_recved - NOT IMPLEMENTED");
 }
 
 static err_t
 altcp_esp_bind(struct altcp_pcb *conn, const ip_addr_t *ipaddr, u16_t port) {
-    // struct tcp_pcb *pcb;
-    // if (conn == NULL) {
-    return ERR_VAL;
-    // }
-    // ALTCP_TCP_ASSERT_CONN(conn);
-    // pcb = (struct tcp_pcb *)conn->state;
-    // return tcp_bind(pcb, ipaddr, port);
+    _dbg("altcp_esp_bind");
+    if (conn == NULL) {
+        return ERR_VAL;
+    }
+    esp_pcb *epcb = (esp_pcb *)conn->state;
+    // ESP does not support listening on IP
+    epcb->listen_port = port;
+    return ERR_OK;
 }
 
 static err_t
 altcp_esp_connect(struct altcp_pcb *conn, const ip_addr_t *ipaddr, u16_t port, altcp_connected_fn connected) {
-    // struct tcp_pcb *pcb;
-    // if (conn == NULL) {
-    return ERR_VAL;
-    // }
-    // ALTCP_TCP_ASSERT_CONN(conn);
-    // conn->connected = connected;
-    // pcb = (struct tcp_pcb *)conn->state;
-    // return tcp_connect(pcb, ipaddr, port, altcp_esp_connected);
+    _dbg("altcp_esp_connect"); // TODO: Not properly tested
+    if (conn == NULL) {
+        return ERR_VAL;
+    }
+
+    esp_pcb *epcb = (esp_pcb *)conn->state;
+    memcpy(epcb->host, ip4addr_ntoa(ipaddr), IP4ADDR_STRLEN_MAX);
+    const espr_t ret = esp_conn_start(&epcb->econn, ESP_CONN_TYPE_TCP, epcb->host, port, NULL, altcp_esp_evt, 0);
+    epcb->alconn->connected = connected;
+    return espr_t2err_t(ret);
 }
 
 static struct altcp_pcb *
 altcp_esp_listen(struct altcp_pcb *conn, u8_t backlog, err_t *err) {
-    esp_netconn_p pcb;
-    esp_netconn_p lpcb;
+    _dbg("altcp_esp_listen");
     if (conn == NULL) {
         return NULL;
     }
 
-    pcb = (esp_netconn_p)conn->state;
-    lpcb = esp_netconn_listen(pcb);
-    if (lpcb != NULL) {
-        conn->state = lpcb;
-        esp_netconn_accept()
-            tcp_accept(lpcb, altcp_esp_accept);
-        return conn;
+    esp_pcb *epcb = (esp_pcb *)conn->state;
+
+    // Enable server on port and set default altcp callback
+    if (esp_set_server(1, epcb->listen_port, ESP_U16(ESP_MIN(backlog, ESP_CFG_MAX_CONNS)), epcb->conn_timeout, altcp_esp_evt, NULL, NULL, 1) != espOK) {
+        _dbg("Failed to set connection to server mode");
     }
-    return NULL;
+    listen_api = epcb;
+    return conn;
 }
 
 static void
 altcp_esp_abort(struct altcp_pcb *conn) {
-    // if (conn != NULL) {
-    //   struct tcp_pcb *pcb = (struct tcp_pcb *)conn->state;
-    //   ALTCP_TCP_ASSERT_CONN(conn);
-    //   if (pcb) {
-    //     tcp_abort(pcb);
-    //   }
-    // }
+    _dbg("altcp_esp_abort - NOT IMPLEMENTED");
 }
 
 static err_t
 altcp_esp_close(struct altcp_pcb *conn) {
-    // struct tcp_pcb *pcb;
-    // if (conn == NULL) {
-    //   return ERR_VAL;
-    // }
-    // ALTCP_TCP_ASSERT_CONN(conn);
-    // pcb = (struct tcp_pcb *)conn->state;
-    // if (pcb) {
-    //   err_t err;
-    //   tcp_poll_fn oldpoll = pcb->poll;
-    //   altcp_esp_remove_callbacks(pcb);
-    //   err = tcp_close(pcb);
-    //   if (err != ERR_OK) {
-    //     /* not closed, set up all callbacks again */
-    //     altcp_esp_setup_callbacks(conn, pcb);
-    //     /* poll callback is not included in the above */
-    //     tcp_poll(pcb, oldpoll, pcb->pollinterval);
-    //     return err;
-    //   }
-    //   conn->state = NULL; /* unsafe to reference pcb after tcp_close(). */
-    // }
-    // altcp_free(conn);
+    _dbg("altcp_esp_close");
+
+    if (conn == NULL) {
+        return ERR_VAL;
+    }
+
+    esp_pcb *epcb = (esp_pcb *)conn->state;
+    if (epcb) {
+        _dbg("CLosing connections: %d", esp_conn_getnum(epcb->econn));
+        espr_t err = esp_conn_close(epcb->econn, 0);
+
+        if (err != espOK) {
+            return espr_t2err_t(err);
+        }
+    }
+
     return ERR_OK;
 }
 
 static err_t
 altcp_esp_shutdown(struct altcp_pcb *conn, int shut_rx, int shut_tx) {
-    // struct tcp_pcb *pcb;
-    // if (conn == NULL) {
+    _dbg("altcp_esp_shutdown - NOT IMPLEMENTED");
     return ERR_VAL;
-    // }
-    // ALTCP_TCP_ASSERT_CONN(conn);
-    // pcb = (struct tcp_pcb *)conn->state;
-    // return tcp_shutdown(pcb, shut_rx, shut_tx);
 }
 
 static err_t
 altcp_esp_write(struct altcp_pcb *conn, const void *dataptr, u16_t len, u8_t apiflags) {
-    // struct tcp_pcb *pcb;
-    // if (conn == NULL) {
-    return ERR_VAL;
-    // }
-    // ALTCP_TCP_ASSERT_CONN(conn);
-    // pcb = (struct tcp_pcb *)conn->state;
-    // return tcp_write(pcb, dataptr, len, apiflags);
+    _dbg("altcp_esp_write");
+    if (conn == NULL) {
+        return ERR_VAL;
+    }
+    esp_pcb *epcb = conn->state;
+    if (epcb == NULL) {
+        return ERR_VAL;
+    }
+    size_t written = 0;
+    espr_t err = esp_conn_send(epcb->econn, dataptr, len, &written, 0); // TODO: Flags ignored, we could only set blocking
+    _dbg("esp writen: %d commited, err: %d", len, err);
+    return espr_t2err_t(err);
 }
 
 static err_t
 altcp_esp_output(struct altcp_pcb *conn) {
-    // struct tcp_pcb *pcb;
-    // if (conn == NULL) {
+    _dbg("altcp_esp_output - NOT IMPLEMENTED");
     return ERR_VAL;
-    // }
-    // ALTCP_TCP_ASSERT_CONN(conn);
-    // pcb = (struct tcp_pcb *)conn->state;
-    // return tcp_output(pcb);
 }
 
 static u16_t
 altcp_esp_mss(struct altcp_pcb *conn) {
-    // struct tcp_pcb *pcb;
-    // if (conn == NULL) {
-    return 0;
-    // }
-    // ALTCP_TCP_ASSERT_CONN(conn);
-    // pcb = (struct tcp_pcb *)conn->state;
-    // return tcp_mss(pcb);
+    return 536; // Minimal required MSS, TODO: Implement properly
 }
 
 static u16_t
 altcp_esp_sndbuf(struct altcp_pcb *conn) {
-    // struct tcp_pcb *pcb;
-    // if (conn == NULL) {
-    return 0;
-    // }
-    // ALTCP_TCP_ASSERT_CONN(conn);
-    // pcb = (struct tcp_pcb *)conn->state;
-    // return tcp_sndbuf(pcb);
+    return 536 / 2; // TODO: Some reasoneable size. Reading from ESP would be better
 }
 
 static u16_t
 altcp_esp_sndqueuelen(struct altcp_pcb *conn) {
-    // struct tcp_pcb *pcb;
-    // if (conn == NULL) {
-    return 0;
-    // }
-    // ALTCP_TCP_ASSERT_CONN(conn);
-    // pcb = (struct tcp_pcb *)conn->state;
-    // return tcp_sndqueuelen(pcb);
+    _dbg("altcp_esp_sndqueuelen");
+    return 0; // TODO: Implement properly
 }
 
 static void
 altcp_esp_nagle_disable(struct altcp_pcb *conn) {
-    // if (conn && conn->state) {
-    //   struct tcp_pcb *pcb = (struct tcp_pcb *)conn->state;
-    //   ALTCP_TCP_ASSERT_CONN(conn);
-    //   tcp_nagle_disable(pcb);
-    // }
+    _dbg("altcp_esp_nagle_disable - NOT IMPLEMENTED");
 }
 
 static void
 altcp_esp_nagle_enable(struct altcp_pcb *conn) {
-    // if (conn && conn->state) {
-    //   struct tcp_pcb *pcb = (struct tcp_pcb *)conn->state;
-    //   ALTCP_TCP_ASSERT_CONN(conn);
-    //   tcp_nagle_enable(pcb);
-    // }
+    _dbg("altcp_esp_nagle_ensable - NOT IMPLEMENTED");
 }
 
 static int
 altcp_esp_nagle_disabled(struct altcp_pcb *conn) {
-    // if (conn && conn->state) {
-    //   struct tcp_pcb *pcb = (struct tcp_pcb *)conn->state;
-    //   ALTCP_TCP_ASSERT_CONN(conn);
-    //   return tcp_nagle_disabled(pcb);
-    // }
+    _dbg("altcp_esp_nagle_disabled - NOT IMPLEMENTED");
     return 0;
 }
 
 static void
 altcp_esp_setprio(struct altcp_pcb *conn, u8_t prio) {
-    // if (conn != NULL) {
-    //   struct tcp_pcb *pcb = (struct tcp_pcb *)conn->state;
-    //   ALTCP_TCP_ASSERT_CONN(conn);
-    //   tcp_setprio(pcb, prio);
-    // }
+    _dbg("altcp_esp_setprio - NOT IMPLEMENTED");
 }
 
 static void
 altcp_esp_dealloc(struct altcp_pcb *conn) {
-    // ESP_UNUSED_ARG(conn);
-    // ALTCP_TCP_ASSERT_CONN(conn);
-    /* no private state to clean up */
+    _dbg("altcp_esp_dealloc");
+    esp_pcb *epcb = conn->state;
+    if (epcb) {
+        esp_ip_free(epcb);
+        conn->state = NULL;
+    }
 }
 
 static err_t
 altcp_esp_get_tcp_addrinfo(struct altcp_pcb *conn, int local, ip_addr_t *addr, u16_t *port) {
-    // if (conn) {
-    //   struct tcp_pcb *pcb = (struct tcp_pcb *)conn->state;
-    //   ALTCP_TCP_ASSERT_CONN(conn);
-    //   return tcp_tcp_get_tcp_addrinfo(pcb, local, addr, port);
-    // }
+    _dbg("altcp_esp_get_tcp_addrinfo - NOT IMPLEMENTED");
     return ERR_VAL;
 }
 
 static ip_addr_t *
 altcp_esp_get_ip(struct altcp_pcb *conn, int local) {
-    // if (conn) {
-    //   struct tcp_pcb *pcb = (struct tcp_pcb *)conn->state;
-    //   ALTCP_TCP_ASSERT_CONN(conn);
-    //   if (pcb) {
-    //     if (local) {
-    //       return &pcb->local_ip;
-    //     } else {
-    //       return &pcb->remote_ip;
-    //     }
-    //   }
-    // }
+    _dbg("altcp_esp_get_ip - NOT IMPLEMENTED");
     return NULL;
 }
 
 static u16_t
 altcp_esp_get_port(struct altcp_pcb *conn, int local) {
-    // if (conn) {
-    //   struct tcp_pcb *pcb = (struct tcp_pcb *)conn->state;
-    //   ALTCP_TCP_ASSERT_CONN(conn);
-    //   if (pcb) {
-    //     if (local) {
-    //       return pcb->local_port;
-    //     } else {
-    //       return pcb->remote_port;
-    //     }
-    //   }
-    // }
+    _dbg("altcp_esp_get_port - NOT IMPLEMENTED");
     return 0;
 }
 

--- a/lib/ESP/prusa/src/system/lwesp_ll_buddy.c
+++ b/lib/ESP/prusa/src/system/lwesp_ll_buddy.c
@@ -28,9 +28,9 @@ osMessageQDef(uartBufferMbox, 16, NULL);
 static osMessageQId uartBufferMbox_id;
 
 //UART buffer stuffs
-#define RX_BUFFER_LEN 0x500
+#define RX_BUFFER_LEN 0x1000
 #if !defined(ESP_MEM_SIZE)
-    #define ESP_MEM_SIZE 0x500
+    #define ESP_MEM_SIZE 0x1000
 #endif /* !defined(ESP_MEM_SIZE) */
 
 static uint32_t esp_working_mode;

--- a/lib/WUI/lwipopts.h
+++ b/lib/WUI/lwipopts.h
@@ -142,15 +142,16 @@ extern "C" {
     #define CHECKSUM_CHECK_ICMP6 0
     /*-----------------------------------------------------------------------------*/
     /* USER CODE BEGIN 1 */
-    #define HTTPD_USE_CUSTOM_FSDATA    1 // uses the web resources from fsdata_custom.c (buddy web pages)
-    #define LWIP_NETIF_API             1 // enable LWIP_NETIF_API==1: Support netif api (in netifapi.c)
-    #define LWIP_NETIF_LINK_CALLBACK   1 // Support a callback function from an interface whenever the link changes (i.e., link down)
-    #define LWIP_NETIF_STATUS_CALLBACK 1 // Support a callback function whenever an interface changes its up/down status (i.e., due to DHCP IP acquisition)
-    #define LWIP_HTTPD_DYNAMIC_HEADERS 1
-    #define LWIP_NETIF_HOSTNAME        1
-    #define LWIP_HTTPD_SUPPORT_POST    1
-    #define LWIP_COMPAT_SOCKETS        2
-    #define LWIP_ALTCP                 1
+    #define HTTPD_USE_CUSTOM_FSDATA      1 // uses the web resources from fsdata_custom.c (buddy web pages)
+    #define LWIP_NETIF_API               1 // enable LWIP_NETIF_API==1: Support netif api (in netifapi.c)
+    #define LWIP_NETIF_LINK_CALLBACK     1 // Support a callback function from an interface whenever the link changes (i.e., link down)
+    #define LWIP_NETIF_STATUS_CALLBACK   1 // Support a callback function whenever an interface changes its up/down status (i.e., due to DHCP IP acquisition)
+    #define LWIP_HTTPD_DYNAMIC_HEADERS   1
+    #define LWIP_NETIF_HOSTNAME          1
+    #define LWIP_HTTPD_SUPPORT_POST      1
+    #define LWIP_COMPAT_SOCKETS          2
+    #define LWIP_ALTCP                   1
+    #define LWIP_HTTPD_DYNAMIC_FILE_READ 1
 
     #ifdef WUI_HOST_NAME
         #define HTTPD_SERVER_AGENT WUI_HOST_NAME

--- a/lib/WUI/wui.c
+++ b/lib/WUI/wui.c
@@ -19,8 +19,6 @@
 #include "lwip/altcp_tcp.h"
 #include "esp_tcp.h"
 #include "esp.h"
-#include "esp/apps/esp_http_server.h"
-#include "esp/apps/esp_http_server_fs.h"
 #include "netifapi.h"
 #include "dns.h"
 #include "httpd.h"
@@ -180,6 +178,17 @@ void StartWebServerTask(void const *argument) {
     // TcpIp related initalizations
     tcpip_init(tcpip_init_done_callback, &wui_eth_config);
 
+    // LwESP stuffs
+    /*
+    // TODO: Handle enable disable of ESP
+    _dbg("LwESP initialized with result = %ld", esp_initialize());
+    ap_entry_t ap = { "esptest", "lwesp8266" };
+    if (!esp_connect_to_AP(&ap)) {
+        _dbg("LwESP connect to AP %s!", ap.ssid);
+        httpd_init();
+    }
+    */
+
     for (;;) {
         osEvent evt = osMessageGet(networkMbox_id, 500);
         if (evt.status == osEventMessage) {
@@ -252,6 +261,5 @@ struct altcp_pcb *prusa_alloc(void *arg, uint8_t ip_type) {
     if (get_eth_status() == ETH_NETIF_UP)
         return altcp_tcp_new_ip_type(ip_type);
     else
-        return NULL;
-    // return altcp_esp_new_ip_type(ip_type);
+        return altcp_esp_new_ip_type(ip_type);
 }

--- a/lib/WUI/wui_REST_api.c
+++ b/lib/WUI/wui_REST_api.c
@@ -121,8 +121,8 @@ void get_printer(char *data, const uint32_t buf_len) {
         "}"
         "}",
         filament_material,
-        (int)wui_vars_copy.temp_nozzle, (int)((wui_vars_copy.temp_nozzle - (int)wui_vars_copy.temp_nozzle) * 10),
-        (int)wui_vars_copy.temp_bed, (int)((wui_vars_copy.temp_bed - (int)wui_vars_copy.temp_bed) * 10),
+        (int)wui_vars_copy.temp_nozzle, (int)((abs(wui_vars_copy.temp_nozzle - (int)wui_vars_copy.temp_nozzle)) * 10),
+        (int)wui_vars_copy.temp_bed, (int)((abs(wui_vars_copy.temp_bed - (int)wui_vars_copy.temp_bed)) * 10),
         operational, paused, printing, cancelling, pausing, sd_ready,
         error, ready, closed_on_error, busy);
 }


### PR DESCRIPTION
LwIP ALTCP using LwESP
    
Implement ALTCP using LwESP conn layer. This is minimal implementation enabling LwIP HTTPD. Many features are missing, some places are suboptimal, some features are even not supported by LwESP/ESP. Especially, these might need further attention:
- Receive needs to be decoupled from write (i.e using mboxes)
- MSS, send buff, send queue length are constants. Should be computed or read from ESP.
- TCP connect is not tested (as it is not used by HTTPD)
- ESP UART connection is configured to 115200 Baud, can be 2M.

Necessary fixes included:
- Fix REST API negative float format
- Increase UART6 RX buffer size 0x500 -> 0x1000
- Enable lwip HTTPD dynamic file read