### PR TITLE
LwESP basic UDP

### DIFF
--- a/lib/ESP/prusa/include/sockets/lwesp_sockets.h
+++ b/lib/ESP/prusa/include/sockets/lwesp_sockets.h
@@ -693,4 +693,22 @@ int lwesp_inet_pton(int af, const char *src, void *dst);
 
 #endif /* LWIP_SOCKET */
 
+static inline esp_ip_t esp_ip_from_in_addr(const in_addr_t addr) {
+  esp_ip_t espip;
+  espip.ip[0] = addr & 0xff;
+  espip.ip[1] = addr >> 8 & 0xff;
+  espip.ip[2] = addr >> 16 & 0xff;
+  espip.ip[3] = addr >> 24 & 0xff;
+  return espip;
+}
+
+static inline esp_ip_t esp_ip_from_ip_addr(const ip_addr_t addr) {
+  // TODO: This is not correct, what about ipv6 addrs
+  return esp_ip_from_in_addr(addr.addr);
+}
+
+static inline in_addr_t addr_from_esp_ip(const esp_ip_t espip) {
+  return *((in_addr_t*)espip.ip);
+}
+
 #endif /* LWESP_HDR_SOCKETS_H */

--- a/lib/ESP/prusa/src/sockets/lwesp_netbuf.c
+++ b/lib/ESP/prusa/src/sockets/lwesp_netbuf.c
@@ -50,6 +50,7 @@
 
 #include "sockets/lwesp_netbuf.h"
 #include "lwip/memp.h"
+#include "esp/esp_private.h"
 
 #include <string.h>
 
@@ -67,6 +68,7 @@ lwesp_netbuf *lwesp_netbuf_new(void)
   struct lwesp_netbuf *buf;
 
   buf = (struct lwesp_netbuf *)memp_malloc(MEMP_NETBUF);
+
   if (buf != NULL) {
     memset(buf, 0, sizeof(struct lwesp_netbuf));
   }
@@ -153,7 +155,7 @@ lwesp_netbuf_free(struct lwesp_netbuf *buf)
  * @return ERR_OK if data is referenced
  *         ERR_MEM if data couldn't be referenced due to lack of memory
  */
-/*err_t
+err_t
 lwesp_netbuf_ref(struct lwesp_netbuf *buf, const void *dataptr, u16_t size)
 {
   LWIP_ERROR("netbuf_ref: invalid buf", (buf != NULL), return ERR_ARG;);
@@ -162,24 +164,21 @@ lwesp_netbuf_ref(struct lwesp_netbuf *buf, const void *dataptr, u16_t size)
   }
 
 //   buf->p = lwesp_pbuf_alloc(PBUF_TRANSPORT, 0, PBUF_REF);
-//   TODO: THis is not a direct equivalent
-  buf->p = lwesp_pbuf_new(0);
+//   TODO: This is not a direct equivalent
+  buf->p = esp_pbuf_new(0);
 
   if (buf->p == NULL) {
     buf->ptr = NULL;
     return ERR_MEM;
   }
-  ((struct pbuf_rom *)buf->p)->payload = dataptr;
+  // TODO: is this ok ?
+  buf->p->payload = ((void*)dataptr);
   
-  // TODO: is this ok
-  //   buf->p->len = buf->p->tot_len = size;
-  lwesp_pbuf_set_length(buf->p, size);
-  // lwesp does not support setting total length?
-  
+  buf->p->len = buf->p->tot_len = size;
   
   buf->ptr = buf->p;
   return ERR_OK;
-}*/
+}
 
 /**
  * @ingroup netbuf

--- a/lib/ESP/prusa/src/sockets/lwesp_sockets.c
+++ b/lib/ESP/prusa/src/sockets/lwesp_sockets.c
@@ -269,6 +269,17 @@ static int get_netconn_socket(esp_netconn_t *conn) {
 	return -1;
 }
 
+/* NOT USED YET
+static esp_netconn_t* get_socket_netconn(int socket) {
+	for(uint i = 0; i < NETCONN_SOCKET_MAPPING_MAX; i++) {
+		if(netconn_socket_mapping[i].socket == socket) {
+			return netconn_socket_mapping[i].conn;
+		}
+	}
+	return NULL;
+}
+*/
+
 static void set_netconn_socket_mapping(esp_netconn_t *conn, int socket) {
 	for(uint i = 0; i < NETCONN_SOCKET_MAPPING_MAX; i++) {
 		if(netconn_socket_mapping[i].conn == NULL) {
@@ -1236,9 +1247,11 @@ lwip_recvfrom_udp_raw(struct lwesp_sock *sock, int flags, struct msghdr *msg, u1
     /* No data was left from the previous operation, so we try to get
         some from the network. */
     
-    // TODO: Implement this
+    // TODO: Apiflags ignored, not supported by lwesp
     LWIP_UNUSED_ARG(apiflags);
     //err = esp_netconn_recv_udp_raw_netbuf_flags(sock->conn, &buf, apiflags);
+    buf = lwesp_netbuf_new();
+    err = esp_netconn_receive(sock->conn, &buf->p);
     
     
     LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_recvfrom_udp_raw[UDP/RAW]: netconn_recv err=%d, netbuf=%p\n",
@@ -1340,7 +1353,7 @@ lwesp_recvfrom(int s, void *mem, size_t len, int flags,
     return -1;
   }
 #if LWIP_TCP
-  if (NETCONNTYPE_GROUP(netconn_type(sock->conn)) == ESP_CONN_TYPE_TCP) {
+  if (netconn_type(sock->conn) == ESP_NETCONN_TYPE_TCP) {
     ret = lwip_recv_tcp(sock, mem, len, flags);
     lwip_recv_tcp_from(sock, from, fromlen, "lwip_recvfrom", s, ret);
     done_socket(sock);
@@ -1406,7 +1419,7 @@ lwesp_readv(int s, const struct iovec *iov, int iovcnt)
 ssize_t
 lwesp_recv(int s, void *mem, size_t len, int flags)
 {
-  return lwip_recvfrom(s, mem, len, flags, NULL, NULL);
+  return lwesp_recvfrom(s, mem, len, flags, NULL, NULL);
 }
 
 ssize_t
@@ -1545,9 +1558,9 @@ lwesp_send(int s, const void *data, size_t size, int flags)
   // err = esp_netconn_write_partly(sock->conn, data, size, write_flags, &written);
   err = esp_netconn_write(sock->conn, data, size);
   written = size;
-   // TODO: write_flags ignored as lwesp does not suport it
-   // TODO: written not supported by lwesp, fake to size
-   LWIP_UNUSED_ARG(write_flags);
+  // TODO: write_flags ignored as lwesp does not suport it
+  // TODO: written not supported by lwesp, fake to size
+  LWIP_UNUSED_ARG(write_flags);
 
   LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_send(%d) err=%d written=%"SZT_F"\n", s, err, written));
   sock_set_errno(sock, err_to_errno(err));
@@ -1742,17 +1755,17 @@ lwesp_sendto(int s, const void *data, size_t size, int flags,
   err_t err;
   u16_t short_size;
   u16_t remote_port;
-  struct netbuf buf;
+  struct lwesp_netbuf buf;
 
   sock = get_socket(s);
   if (!sock) {
     return -1;
   }
 
-  if (NETCONNTYPE_GROUP(netconn_type(sock->conn)) == ESP_CONN_TYPE_TCP) {
+  if (netconn_type(sock->conn) == ESP_NETCONN_TYPE_TCP) {
 #if LWIP_TCP
     done_socket(sock);
-    return lwip_send(s, data, size, flags);
+    return lwesp_send(s, data, size, flags);
 #else /* LWIP_TCP */
     LWIP_UNUSED_ARG(flags);
     sock_set_errno(sock, err_to_errno(ERR_ARG));
@@ -1785,7 +1798,7 @@ lwesp_sendto(int s, const void *data, size_t size, int flags,
     remote_port = 0;
     ip_addr_set_any(NETCONNTYPE_ISIPV6(netconn_type(sock->conn)), &buf.addr);
   }
-  netbuf_fromport(&buf) = remote_port;
+  lwesp_netbuf_fromport(&buf) = remote_port;
 
 
   LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_sendto(%d, data=%p, short_size=%"U16_F", flags=0x%x to=",
@@ -1811,7 +1824,7 @@ lwesp_sendto(int s, const void *data, size_t size, int flags,
     err = ERR_OK;
   }
 #else /* LWIP_NETIF_TX_SINGLE_PBUF */
-  err = netbuf_ref(&buf, data, short_size);
+  err = lwesp_netbuf_ref(&buf, data, short_size);
 #endif /* LWIP_NETIF_TX_SINGLE_PBUF */
   if (err == ERR_OK) {
 #if LWIP_IPV4 && LWIP_IPV6
@@ -1824,13 +1837,16 @@ lwesp_sendto(int s, const void *data, size_t size, int flags,
 
     /* send the data */
 
-//     err = esp_netconn_send(sock->conn, &buf);
-// TODO: Needs to implement sending netbuf data
-
+    // TODO: Needs to implement sending netbuf data, is this ok?
+    const void *dtw;
+    u16_t btw;
+    lwesp_netbuf_data(&buf, &dtw, &btw);
+    const esp_ip_t espip = esp_ip_from_ip_addr(buf.addr);
+    err = esp_netconn_sendto(sock->conn, &espip, buf.port, dtw, btw);
   }
 
   /* deallocated the buffer */
-  netbuf_free(&buf);
+  lwesp_netbuf_free(&buf);
 
   sock_set_errno(sock, err_to_errno(err));
   done_socket(sock);
@@ -1864,7 +1880,7 @@ lwesp_socket(int domain, int type, int protocol)
 //                                        ((protocol == IPPROTO_UDPLITE) ? NETCONN_UDPLITE : NETCONN_UDP)),
 //                                        DEFAULT_SOCKET_EVENTCB);
 //       TODO: Not available in lwesp, needs to be reimplemented
-      return -1;
+      conn = esp_netconn_new(ESP_NETCONN_TYPE_UDP);
 
       LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_socket(%s, SOCK_DGRAM, %d) = ",
                                   domain == PF_INET ? "PF_INET" : "UNKNOWN", protocol));
@@ -2908,7 +2924,7 @@ lwip_getaddrname(int s, struct sockaddr *name, socklen_t *namelen, u8_t local)
   } else {
     esp_conn_get_remote_ip(sock->conn->conn, &espip);
     // TODO: macro for proper IP composition?
-    naddr.addr = espip.ip[0] | espip.ip[1] << 8 | espip.ip[2] << 16 | espip.ip[3] << 24;
+    naddr.addr = addr_from_esp_ip(espip);
   }
   
   

--- a/tests/integration/network/sockets.c
+++ b/tests/integration/network/sockets.c
@@ -1,0 +1,432 @@
+/*
+ * Functions for testing sockets
+ *
+ * These are not used anywhere, but still usable for manual testing of networking.
+ */
+
+#include "lwip/sockets.h"
+#include "esp/esp.h"
+#include "sockets/lwesp_sockets.h"
+#include "dbg.h"
+
+void socket_listen_test_lwip() {
+    _dbg("LWIP TCP HELLO SERVER TEST\n");
+    int listenfd = lwip_socket(AF_INET, SOCK_STREAM, 0);
+    if (listenfd == -1) {
+        _dbg("FAILED TO CREATE LISTENING SOCKET\n");
+        return;
+    }
+    _dbg("SOCKET CREATED\n");
+
+    struct sockaddr_in servaddr, clientaddr;
+    bzero(&servaddr, sizeof(servaddr));
+    servaddr.sin_family = AF_INET;
+    servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+    servaddr.sin_port = htons(5000);
+
+    if ((lwip_bind(listenfd, (const struct sockaddr *)&servaddr, sizeof(servaddr))) != 0) {
+        _dbg("BIND FAILED\n");
+        return;
+    }
+
+    _dbg("SOCKET BOUND\n");
+
+    if ((lwip_listen(listenfd, 5)) != 0) {
+        printf("LISTEN FAILED\n");
+        return;
+    }
+
+    _dbg("SOCKET LISTENING\n");
+
+    socklen_t len = sizeof(clientaddr);
+
+    int connectionfd = lwip_accept(listenfd, (struct sockaddr *)&clientaddr, &len);
+    if (connectionfd < 0) {
+        printf("ACCEPT FAILED\n");
+        return;
+    }
+
+    _dbg("CONNECTION ACCEPTED\n");
+
+    const char buff[] = "Hello\n";
+    lwip_write(connectionfd, buff, sizeof(buff));
+
+    lwip_close(connectionfd);
+
+    // After chatting close the socket
+    lwip_close(listenfd);
+
+    _dbg("CONNECTION CLOSED\n");
+}
+
+void socket_connect_test_lwesp() {
+    _dbg("LWESP TCP HELLO CLIENT TEST\n");
+
+    int clientfd = lwesp_socket(AF_INET, SOCK_STREAM, 0);
+    if (clientfd == -1) {
+        _dbg("FAILED TO CREATE CLIENT SOCKET\n");
+        return;
+    }
+    _dbg("SOCKET CREATED\n");
+
+    struct sockaddr_in serveraddr;
+    bzero(&serveraddr, sizeof(serveraddr));
+    serveraddr.sin_family = AF_INET;
+    serveraddr.sin_addr.s_addr = inet_addr("10.42.0.1");
+    serveraddr.sin_port = htons(5000);
+
+    if (lwesp_connect(clientfd, (const struct sockaddr *)&serveraddr, sizeof(serveraddr)) != espOK) {
+        _dbg("FAILED TO CONNECT TO SERVER");
+        return;
+    }
+    _dbg("SOCKET CONNECTED");
+
+    char buff[20];
+
+    int msgLen = sprintf(buff, "Hello, fd:%d\n", clientfd);
+    ssize_t writen = lwesp_write(clientfd, buff, msgLen);
+    if (writen != msgLen) {
+        _dbg("FAILED TO WRITE: %d bytes", msgLen);
+        return;
+    }
+
+    _dbg("READING 20 bytes FROM SOCKET");
+    size_t read = lwesp_read(clientfd, buff, sizeof(buff));
+    if (read != sizeof(buff)) {
+        _dbg("FAILED TO READ");
+        return;
+    }
+    _dbg("Read: %s", buff);
+
+    if (lwesp_close(clientfd) != espOK) {
+        _dbg("FAILED TO CLOSE");
+        return;
+    }
+
+    _dbg("SOCKET CLOSED");
+}
+
+void socket_listen_test_lwesp() {
+    _dbg("LWESP TCP HELLO SERVER TEST\n");
+    int listenfd = lwesp_socket(AF_INET, SOCK_STREAM, 0);
+    if (listenfd == -1) {
+        _dbg("FAILED TO CREATE LISTENING SOCKET\n");
+        return;
+    }
+    _dbg("SOCKET CREATED\n");
+
+    struct sockaddr_in servaddr, clientaddr;
+    bzero(&servaddr, sizeof(servaddr));
+    servaddr.sin_family = AF_INET;
+    servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+    servaddr.sin_port = htons(5000);
+
+    if ((lwesp_bind(listenfd, (const struct sockaddr *)&servaddr, sizeof(servaddr))) != 0) {
+        _dbg("BIND FAILED\n");
+        return;
+    }
+
+    _dbg("SOCKET BOUND\n");
+
+    if ((lwesp_listen(listenfd, 5)) != 0) {
+        _dbg("LISTEN FAILED\n");
+        return;
+    }
+
+    _dbg("SOCKET LISTENING\n");
+
+    for (;;) {
+        socklen_t len = sizeof(clientaddr);
+        int connectionfd = lwesp_accept(listenfd, (struct sockaddr *)&clientaddr, &len);
+        if (connectionfd < 0) {
+            _dbg("ACCEPT FAILED\n");
+            return;
+        }
+
+        _dbg("CONNECTION ACCEPTED\n");
+
+        char buff[20];
+
+        lwesp_read(connectionfd, buff, sizeof(buff));
+        _dbg("Read: %s", buff);
+
+        int msgLen = sprintf(buff, "Hello, fd:%d\n", connectionfd);
+        lwesp_write(connectionfd, buff, msgLen);
+
+        lwesp_close(connectionfd);
+    }
+
+    // After chatting close the socket
+    lwesp_close(listenfd);
+
+    _dbg("CONNECTION CLOSED\n");
+}
+
+void netconn_listen_test() {
+    uint32_t res;
+    esp_netconn_p server, client;
+    esp_pbuf_p p;
+
+    /* Create netconn for server */
+    server = esp_netconn_new(ESP_NETCONN_TYPE_TCP);
+    if (server == NULL) {
+        _dbg("Cannot create server netconn!\r\n");
+    }
+
+    /* Bind it to port 5000 */
+    res = esp_netconn_bind(server, 5000);
+    if (res != 0) {
+        _dbg("Cannot bind server\r\n");
+        goto out;
+    }
+
+    /* Start listening for incoming connections with maximal 1 client */
+    res = esp_netconn_listen_with_max_conn(server, 1);
+    if (res != 0) {
+        _dbg("Cannot listen server\r\n");
+        goto out;
+    }
+
+    /* Unlimited loop */
+    while (1) {
+        /* Accept new client */
+        res = esp_netconn_accept(server, &client);
+        if (res != espOK) {
+            break;
+        }
+        _dbg("New client accepted!\r\n");
+        while (1) {
+            /* Receive data */
+            res = esp_netconn_receive(client, &p);
+            if (res == espOK) {
+                _dbg("Data received!\r\n");
+                esp_pbuf_free(p);
+            } else {
+                _dbg("Netconn receive returned: %d\r\n", (int)res);
+                if (res == espCLOSED) {
+                    _dbg("Connection closed by client\r\n");
+                    break;
+                }
+            }
+
+            static const char request_header[] = "@@@SERVER RESPONSE DATA###";
+            res = esp_netconn_write(client, request_header, sizeof(request_header) - 1); /* Send data to client */
+            if (res == espOK) {
+                res = esp_netconn_flush(client); /* Flush data to output */
+            }
+        }
+        /* Delete client */
+        if (client != NULL) {
+            esp_netconn_delete(client);
+            client = NULL;
+        }
+    }
+    /* Delete client */
+    if (client != NULL) {
+        esp_netconn_delete(client);
+        client = NULL;
+    }
+
+out:
+    printf("Terminating netconn thread!\r\n");
+    if (server != NULL) {
+        esp_netconn_delete(server);
+    }
+    esp_sys_thread_terminate(NULL);
+}
+
+#define NETCONN_HOST "10.42.0.1"
+#define NETCONN_PORT 5000
+
+static const char
+    request_header[]
+    = ""
+      "GET / HTTP/1.1\r\n"
+      "Host: " NETCONN_HOST "\r\n"
+      "Connection: close\r\n"
+      "\r\n";
+
+void netconn_client_test() {
+    espr_t res;
+    esp_pbuf_p pbuf;
+    esp_netconn_p client;
+
+    _dbg("Netconn client test");
+
+    /*
+     * First create a new instance of netconn
+     * connection and initialize system message boxes
+     * to accept received packet buffers
+     */
+    client = esp_netconn_new(ESP_NETCONN_TYPE_TCP);
+    if (client != NULL) {
+        /*
+         * Connect to external server as client
+         * with custom NETCONN_CONN_HOST and CONN_PORT values
+         *
+         * Function will block thread until we are successfully connected (or not) to server
+         */
+        res = esp_netconn_connect(client, NETCONN_HOST, NETCONN_PORT);
+        if (res == espOK) { /* Are we successfully connected? */
+            _dbg("Connected to " NETCONN_HOST "\r\n");
+            res = esp_netconn_write(client, request_header, sizeof(request_header) - 1); /* Send data to server */
+            if (res == espOK) {
+                res = esp_netconn_flush(client); /* Flush data to output */
+            }
+            if (res == espOK) { /* Were data sent? */
+                _dbg("Data were successfully sent to server\r\n");
+
+                /*
+                 * Since we sent HTTP request,
+                 * we are expecting some data from server
+                 * or at least forced connection close from remote side
+                 */
+                do {
+                    /*
+                     * Receive single packet of data
+                     *
+                     * Function will block thread until new packet
+                     * is ready to be read from remote side
+                     *
+                     * After function returns, don't forgot the check value.
+                     * Returned status will give you info in case connection
+                     * was closed too early from remote side
+                     */
+                    res = esp_netconn_receive(client, &pbuf);
+                    if (res == espCLOSED) { /* Was the connection closed? This can be checked by return status of receive function */
+                        _dbg("Connection closed by remote side...\r\n");
+                        break;
+                    } else if (res == espTIMEOUT) {
+                        _dbg("Netconn timeout while receiving data. You may try multiple readings before deciding to close manually\r\n");
+                    }
+
+                    if (res == espOK && pbuf != NULL) { /* Make sure we have valid packet buffer */
+                        /*
+                         * At this point read and manipulate
+                         * with received buffer and check if you expect more data
+                         *
+                         * After you are done using it, it is important
+                         * you free the memory otherwise memory leaks will appear
+                         */
+                        _dbg("Received new data packet of %d bytes\r\n", (int)esp_pbuf_length(pbuf, 1));
+                        esp_pbuf_free(pbuf); /* Free the memory after usage */
+                        pbuf = NULL;
+                    }
+                } while (1);
+            } else {
+                _dbg("Error writing data to remote host!\r\n");
+            }
+
+            /*
+             * Check if connection was closed by remote server
+             * and in case it wasn't, close it manually
+             */
+            if (res != espCLOSED) {
+                esp_netconn_close(client);
+            }
+        } else {
+            _dbg("Cannot connect to remote host %s:%d!, res: %d\r\n", NETCONN_HOST, NETCONN_PORT, res);
+        }
+        esp_netconn_delete(client); /* Delete netconn structure */
+    }
+
+    esp_sys_thread_terminate(NULL); /* Terminate current thread */
+}
+
+void socket_udp_client_test_lwesp() {
+    _dbg("LWESP UDP HELLO TEST\n");
+    int sockfd = lwesp_socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd == -1) {
+        _dbg("FAILED TO CREATE SOCKET\n");
+        return;
+    }
+    _dbg("SOCKET CREATED\n");
+
+    struct sockaddr_in servaddr;
+    bzero(&servaddr, sizeof(servaddr));
+    servaddr.sin_family = AF_INET;
+    servaddr.sin_addr.s_addr = inet_addr("10.42.0.1");
+    servaddr.sin_port = htons(5000);
+
+    int conres = lwesp_connect(sockfd, (const struct sockaddr *)&servaddr, sizeof(servaddr));
+    if (conres != 0) {
+        _dbg("CONNECT RETURNED: %d\n", conres);
+    }
+
+    for (;;) {
+        static const size_t BUF_SIZE = 20;
+        char buff[20] = "Hello world 1234567\n";
+
+        int send = lwesp_sendto(sockfd, buff, BUF_SIZE, 0, (const struct sockaddr *)&servaddr, sizeof(servaddr));
+        if (send < 0) {
+            _dbg("SENDTO FAILED: %d\n", send);
+        }
+
+        _dbg("RECIEVE");
+        struct sockaddr fromaddr;
+        socklen_t fromlen;
+        int recvd = lwesp_recvfrom(sockfd, buff, BUF_SIZE, 0, &fromaddr, &fromlen);
+        if (recvd < 0) {
+            _dbg("RECV FAILED: %d", recvd);
+        } else {
+            buff[recvd] = 0;
+            _dbg("RECEIVED: %d bytes", recvd);
+            _dbg("RECEIVED: %s", buff);
+        }
+    }
+
+    lwesp_close(sockfd);
+
+    _dbg("CONNECTION CLOSED\n");
+}
+
+void socket_udp_server_test_lwesp() {
+    _dbg("LWESP UDP SERVER TEST\n");
+    int sockfd = lwesp_socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd == -1) {
+        _dbg("FAILED TO CREATE SOCKET\n");
+        return;
+    }
+    _dbg("SOCKET CREATED\n");
+
+    struct sockaddr_in servaddr, otheraddr;
+    bzero(&servaddr, sizeof(servaddr));
+    servaddr.sin_family = AF_INET;
+    servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+    servaddr.sin_port = htons(5000);
+
+    bzero(&otheraddr, sizeof(otheraddr));
+
+    if ((lwesp_bind(sockfd, (const struct sockaddr *)&servaddr, sizeof(servaddr))) != 0) {
+        _dbg("BIND FAILED\n");
+        return;
+    }
+
+    _dbg("SOCKET BOUND\n");
+
+    for (;;) {
+        static const size_t BUF_SIZE = 20;
+        char buff[20];
+
+        socklen_t len = 0;
+        //int recvd = lwesp_recvfrom(sockfd, buff, BUF_SIZE, 0, (struct sockaddr *)&otheraddr, &len);
+        int recvd = lwesp_recv(sockfd, buff, BUF_SIZE, 0);
+        if (recvd < 0) {
+            _dbg("RECVFROM FAILED\n");
+        }
+
+        _dbg("Received: %d bytes", recvd);
+        _dbg("Received client addr len: %d bytes", len);
+        _dbg("Received: %s", buff);
+
+        int send = lwesp_sendto(sockfd, buff, recvd, 0, (const struct sockaddr *)&otheraddr, sizeof(otheraddr));
+        if (send < 0) {
+            _dbg("SENDTO FAILED: %d\n", send);
+        }
+    }
+
+    // After chatting close the socket
+    lwesp_close(sockfd);
+
+    _dbg("CONNECTION CLOSED\n");
+}

--- a/tests/integration/network/sockets.h
+++ b/tests/integration/network/sockets.h
@@ -1,0 +1,15 @@
+/*
+ * Functions for testing sockets
+ *
+ * These are not used anywhere, but still usable for manual testing of networking.
+ */
+
+#include "sockets/lwesp_sockets.h"
+
+void socket_listen_test_lwip();
+void socket_connect_test_lwesp();
+void socket_listen_test_lwesp();
+void netconn_listen_test();
+void netconn_client_test();
+void socket_udp_client_test_lwesp();
+void socket_udp_server_test_lwesp();


### PR DESCRIPTION
Basic support for UDP sockets over LwESP
    
This is limited to "client" connections. Bind does not work. Also the client is supposed to call connect even when it is not necessary for UDP. Otherwise the received packets are dropped by ESP. This seems to be a limitation of used AT ESP firmware.

Part of BFW-1874