### PR TITLE
Fix write error during the flash process

### DIFF
--- a/include/esp/lwesp_ll_buddy.h
+++ b/include/esp/lwesp_ll_buddy.h
@@ -37,6 +37,16 @@ extern void esp_set_operating_mode(uint32_t);
 /// @return Return UART an operating mode
 extern uint32_t esp_get_operating_mode(void);
 
+////////////////////////////////////////////////////////////////////////////
+/// @brief Reconfigure UART baudrate
+/// @param[in] baudrate Desired baudrate
+/// @return ESP error code
+extern espr_t esp_reconfigure_uart(const uint32_t baudrate);
+
+////////////////////////////////////////////////////////////////////////////
+/// @brief Hard reset ESP device using a reset pin
+extern void esp_hard_reset_device();
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/include/esp/lwesp_ll_buddy.h
+++ b/include/esp/lwesp_ll_buddy.h
@@ -47,6 +47,14 @@ extern espr_t esp_reconfigure_uart(const uint32_t baudrate);
 /// @brief Hard reset ESP device using a reset pin
 extern void esp_hard_reset_device();
 
+// UART buffer stuff
+#define RX_BUFFER_LEN 0x1000
+#if !defined(ESP_MEM_SIZE)
+    #define ESP_MEM_SIZE 0x1000
+#endif /* !defined(ESP_MEM_SIZE) */
+
+extern uint8_t dma_buffer_rx[RX_BUFFER_LEN];
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/lib/ESP/prusa/src/esp.c
+++ b/lib/ESP/prusa/src/esp.c
@@ -1,5 +1,6 @@
 #include "esp.h"
 #include "esp/esp_includes.h"
+
 #include "dbg.h"
 
 #define MAX_TIMEOUT_ATTEMPTS (2UL)

--- a/lib/ESP/prusa/src/system/lwesp_ll_buddy.c
+++ b/lib/ESP/prusa/src/system/lwesp_ll_buddy.c
@@ -28,23 +28,12 @@ static osThreadId UartBufferThread_id;
 osMessageQDef(uartBufferMbox, 16, NULL);
 static osMessageQId uartBufferMbox_id;
 
-//UART buffer stuffs
-#define RX_BUFFER_LEN 0x1000
-#if !defined(ESP_MEM_SIZE)
-    #define ESP_MEM_SIZE 0x1000
-#endif /* !defined(ESP_MEM_SIZE) */
-
 static uint32_t esp_working_mode;
 static uint32_t initialized;
 
 uint8_t dma_buffer_rx[RX_BUFFER_LEN];
 
 void esp_set_operating_mode(uint32_t mode) {
-    if (mode == ESP_RUNNING_MODE) {
-        __HAL_UART_ENABLE_IT(&huart6, UART_IT_IDLE);
-    } else if (mode == ESP_FLASHING_MODE) {
-        __HAL_UART_DISABLE_IT(&huart6, UART_IT_IDLE);
-    }
     esp_working_mode = mode;
 }
 

--- a/lib/WUI/netdev.c
+++ b/lib/WUI/netdev.c
@@ -12,6 +12,8 @@
 #include "dbg.h"
 #include "wui_api.h"
 #include "alsockets.h"
+#include "lwesp_ll_buddy.h"
+
 
 typedef struct {
     const char *ssid;
@@ -134,6 +136,7 @@ uint32_t netdev_init() {
     active_netdev_id = variant_get_ui8(eeprom_get_var(EEVAR_ACTIVE_NETDEV));
 
     tcpip_init(tcpip_init_done_callback, NULL);
+    esp_hard_reset_device();
     esp_init(esp_callback_func, 0);
     alsockets_funcs(netdev_get_sockets(active_netdev_id));
     return 0;

--- a/lib/WUI/netdev.c
+++ b/lib/WUI/netdev.c
@@ -14,7 +14,6 @@
 #include "alsockets.h"
 #include "lwesp_ll_buddy.h"
 
-
 typedef struct {
     const char *ssid;
     const char *pass;

--- a/src/gui/screen_menu_esp_update.cpp
+++ b/src/gui/screen_menu_esp_update.cpp
@@ -119,6 +119,7 @@ ScreenMenuESPUpdate::ScreenMenuESPUpdate()
     CaptureNormalWindow(menu);        // set capture to list
     help.SetText(_("- ESP not connected"));
     esp_set_operating_mode(ESP_FLASHING_MODE);
+    esp_reconfigure_uart(115200);
     loader_port_stm32_init(&loader_config);
 }
 


### PR DESCRIPTION
Solves ESP flashing instability. Bootloader flashing kept skipped, this one can be fixed by patching the flash params in bootloader binary.

BFW-2052