### PR TITLE
Tweak printing time and remaining time strings

### DIFF
--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -146,7 +146,7 @@ screen_printing_data_t::screen_printing_data_t()
     w_etime_label.font = resource_font(IDR_FNT_SMALL);
     w_etime_label.SetAlignment(Align_t::RightBottom());
     w_etime_label.SetPadding({ 0, 2, 0, 2 });
-    w_etime_label.SetText(_("Remaining Time"));
+    w_etime_label.SetText(_("Remaining"));
 
     w_etime_value.font = resource_font(IDR_FNT_SMALL);
     w_etime_value.SetAlignment(Align_t::RightBottom());
@@ -157,7 +157,7 @@ screen_printing_data_t::screen_printing_data_t()
     w_time_label.font = resource_font(IDR_FNT_SMALL);
     w_time_label.SetAlignment(Align_t::RightBottom());
     w_time_label.SetPadding({ 0, 2, 0, 2 });
-    w_time_label.SetText(_("Printing time"));
+    w_time_label.SetText(_("Elapsed"));
 
     w_time_value.font = resource_font(IDR_FNT_SMALL);
     w_time_value.SetAlignment(Align_t::RightBottom());
@@ -245,7 +245,7 @@ void screen_printing_data_t::change_etime() {
         update_end_timestamp(sec, marlin_vars()->print_speed);
     } else {
         // store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
-        w_etime_label.SetText(label_etime = _("Remaining Time"));
+        w_etime_label.SetText(label_etime = _("Remaining"));
         update_remaining_time(marlin_vars()->time_to_end, marlin_vars()->print_speed);
     }
     last_time_to_end = marlin_vars()->time_to_end;
@@ -362,7 +362,7 @@ void screen_printing_data_t::update_print_duration(time_t rawtime) {
 
 void screen_printing_data_t::screen_printing_reprint() {
     print_begin(marlin_vars()->media_SFN_path);
-    w_etime_label.SetText(_("Remaining Time"));
+    w_etime_label.SetText(_("Remaining"));
     btn_stop.txt.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)printing_labels[static_cast<size_t>(item_id_t::stop)]));
     btn_stop.ico.SetIdRes(printing_icons[static_cast<size_t>(item_id_t::stop)]);
 

--- a/src/gui/screen_printing.hpp
+++ b/src/gui/screen_printing.hpp
@@ -56,7 +56,7 @@ class screen_printing_data_t : public AddSuperWindow<ScreenPrintingModel> {
 
     std::array<char, MAX_TIMEDUR_STR_SIZE> text_time_dur;
     std::array<char, MAX_END_TIMESTAMP_SIZE> text_etime;
-    //std::array<char, 15> label_etime;  // "Remaining Time" or "Print will end" // nope, if you have only 2 static const strings, you can swap pointers
+    //std::array<char, 15> label_etime;  // "Remaining" or "Print will end" // nope, if you have only 2 static const strings, you can swap pointers
     string_view_utf8 label_etime;      // not sure if we really must keep this in memory
     std::array<char, 5> text_filament; // 999m\0 | 1.2m\0
     uint32_t message_timer;

--- a/src/lang/po/Prusa-Firmware-Buddy.pot
+++ b/src/lang/po/Prusa-Firmware-Buddy.pot
@@ -793,7 +793,7 @@ msgid "Print will end"
 msgstr ""
 
 #: src/gui/screen_printing.cpp:160
-msgid "Printing time"
+msgid "Elapsed"
 msgstr ""
 
 #: src/gui/screen_menu_filament.cpp:86
@@ -837,7 +837,7 @@ msgstr ""
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #: src/gui/screen_printing.cpp:149 src/gui/screen_printing.cpp:248
 #: src/gui/screen_printing.cpp:365
-msgid "Remaining Time"
+msgid "Remaining"
 msgstr ""
 
 #: src/gui/screen_menu_steel_sheets.cpp:59

--- a/src/lang/po/cs/Prusa-Firmware-Buddy_cs.po
+++ b/src/lang/po/cs/Prusa-Firmware-Buddy_cs.po
@@ -675,7 +675,7 @@ msgid "PRINTING"
 msgstr "TISK"
 
 #: src/gui/screen_printing.cpp:158
-msgid "Printing time"
+msgid "Elapsed"
 msgstr "Čas tisku"
 
 #: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
@@ -715,7 +715,7 @@ msgstr "OPAK. NAHŘÁTÍ"
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
 #: src/gui/screen_printing.cpp:355
-msgid "Remaining Time"
+msgid "Remaining"
 msgstr "Zbývající čas"
 
 #: src/gui/screen_sheet_rename.cpp:22

--- a/src/lang/po/de/Prusa-Firmware-Buddy_de.po
+++ b/src/lang/po/de/Prusa-Firmware-Buddy_de.po
@@ -675,7 +675,7 @@ msgid "PRINTING"
 msgstr "DRUCKEN"
 
 #: src/gui/screen_printing.cpp:158
-msgid "Printing time"
+msgid "Elapsed"
 msgstr "Druckzeit"
 
 #: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
@@ -715,7 +715,7 @@ msgstr "erneut Heizen"
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
 #: src/gui/screen_printing.cpp:355
-msgid "Remaining Time"
+msgid "Remaining"
 msgstr "Restzeit"
 
 #: src/gui/screen_sheet_rename.cpp:22

--- a/src/lang/po/en/Prusa-Firmware-Buddy_en.po
+++ b/src/lang/po/en/Prusa-Firmware-Buddy_en.po
@@ -675,8 +675,8 @@ msgid "PRINTING"
 msgstr "PRINTING"
 
 #: src/gui/screen_printing.cpp:158
-msgid "Printing time"
-msgstr "Printing time"
+msgid "Elapsed"
+msgstr "Elapsed"
 
 #: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
 msgid "PURGE FILAMENT"
@@ -715,8 +715,8 @@ msgstr "REHEAT"
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
 #: src/gui/screen_printing.cpp:355
-msgid "Remaining Time"
-msgstr "Remaining Time"
+msgid "Remaining"
+msgstr "Remaining"
 
 #: src/gui/screen_sheet_rename.cpp:22
 msgid "RENAME"

--- a/src/lang/po/es/Prusa-Firmware-Buddy_es.po
+++ b/src/lang/po/es/Prusa-Firmware-Buddy_es.po
@@ -675,7 +675,7 @@ msgid "PRINTING"
 msgstr "IMPRIMIENDO"
 
 #: src/gui/screen_printing.cpp:158
-msgid "Printing time"
+msgid "Elapsed"
 msgstr "Tiempo de impresión"
 
 #: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
@@ -715,7 +715,7 @@ msgstr "RECALENTAR"
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
 #: src/gui/screen_printing.cpp:355
-msgid "Remaining Time"
+msgid "Remaining"
 msgstr "Tiempo Restante"
 
 #: src/gui/screen_sheet_rename.cpp:22

--- a/src/lang/po/fr/Prusa-Firmware-Buddy_fr.po
+++ b/src/lang/po/fr/Prusa-Firmware-Buddy_fr.po
@@ -675,7 +675,7 @@ msgid "PRINTING"
 msgstr "IMPRESSION"
 
 #: src/gui/screen_printing.cpp:158
-msgid "Printing time"
+msgid "Elapsed"
 msgstr "Temps d'impression"
 
 #: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
@@ -715,7 +715,7 @@ msgstr "RE-CHAUFFER"
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
 #: src/gui/screen_printing.cpp:355
-msgid "Remaining Time"
+msgid "Remaining"
 msgstr "Temps restant"
 
 #: src/gui/screen_sheet_rename.cpp:22

--- a/src/lang/po/it/Prusa-Firmware-Buddy_it.po
+++ b/src/lang/po/it/Prusa-Firmware-Buddy_it.po
@@ -675,7 +675,7 @@ msgid "PRINTING"
 msgstr "STAMPA"
 
 #: src/gui/screen_printing.cpp:158
-msgid "Printing time"
+msgid "Elapsed"
 msgstr "Tempo di stampa"
 
 #: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
@@ -715,7 +715,7 @@ msgstr "RISCALDA"
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
 #: src/gui/screen_printing.cpp:355
-msgid "Remaining Time"
+msgid "Remaining"
 msgstr "Tempo Rimanente"
 
 #: src/gui/screen_sheet_rename.cpp:22

--- a/src/lang/po/pl/Prusa-Firmware-Buddy_pl.po
+++ b/src/lang/po/pl/Prusa-Firmware-Buddy_pl.po
@@ -675,7 +675,7 @@ msgid "PRINTING"
 msgstr "DRUKOWANIE"
 
 #: src/gui/screen_printing.cpp:158
-msgid "Printing time"
+msgid "Elapsed"
 msgstr "Czas druku"
 
 #: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
@@ -715,7 +715,7 @@ msgstr "PONOWNE NAGRZEWANIE"
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
 #: src/gui/screen_printing.cpp:355
-msgid "Remaining Time"
+msgid "Remaining"
 msgstr "Pozostały czas"
 
 #: src/gui/screen_sheet_rename.cpp:22


### PR DESCRIPTION
Hello,
I want to tweak the **Printing time** and **Remaining Time** strings.
I think that **Elapsed** and **Remaining** are shorter and more accurate.
It also fixes the title case typo.
What do you think?
Do you want to update other translation files?

![](https://www.fabbaloo.com/wp-content/uploads/2020/07/prusa-mini-panel-printing-1.jpeg)