### PR TITLE
UI: Change blinking blue to azure when cooling

### DIFF
--- a/src/gui/footer/footer_items_heaters.hpp
+++ b/src/gui/footer/footer_items_heaters.hpp
@@ -57,7 +57,7 @@ public:
 protected:
     static constexpr int heating_difference = 2;
 
-    static constexpr std::array<color_t, size_t(HeatState::_last) + 1> colors = { { COLOR_WHITE, COLOR_ORANGE, COLOR_BLUE, COLOR_GREEN } };
+    static constexpr std::array<color_t, size_t(HeatState::_last) + 1> colors = { { COLOR_WHITE, COLOR_ORANGE, COLOR_AZURE, COLOR_GREEN } };
     static HeatState getState(int current, int target, int display, int cold, int preheat); //need signed values for comparations
     static string_view_utf8 static_makeViewIntoBuff(int value, std::array<char, 10> &buff);
 

--- a/src/guiapi/include/guitypes.h
+++ b/src/guiapi/include/guitypes.h
@@ -15,6 +15,7 @@ static const color_t COLOR_RED = 0x000000ffL;
 static const color_t COLOR_RED_ALERT = 0x002646e7L;
 static const color_t COLOR_LIME = 0x0000ff00L;
 static const color_t COLOR_BLUE = 0x00ff0000L;
+static const color_t COLOR_AZURE = 0x00ff9d12L;
 static const color_t COLOR_YELLOW = 0x0000ffffL;
 static const color_t COLOR_CYAN = 0x00ffff00L;
 static const color_t COLOR_MAGENTA = 0x00ff00ffL;


### PR DESCRIPTION
Blue on black is ugly and unreadable. Switch it to a brighter shade of azure:

![2021-09-12T125559](https://user-images.githubusercontent.com/1017726/132984912-3f2df425-8926-4e68-911e-6fb813738515.png)
