### PR TITLE
Prepare translations for FW 4.3.3

### DIFF
--- a/src/gui/screen_menu_experimental_settings_debug.cpp
+++ b/src/gui/screen_menu_experimental_settings_debug.cpp
@@ -25,8 +25,8 @@ using Screen = ScreenMenu<EHeader::Off, EFooter::On, HelpLines_None, MI_SAVE_AND
     MI_CURRENT_X, MI_CURRENT_Y, MI_CURRENT_Z, MI_CURRENT_E, MI_RESET_CURRENTS>;
 
 class ScreenMenuExperimentalSettings : public Screen {
-    static constexpr const char *const save_and_reboot = N_("Do you want to save changes and reboot the printer?");
-    constexpr static const char *label = N_("Experimental Settings");
+    static constexpr const char *const save_and_reboot = "Do you want to save changes and reboot the printer?";
+    constexpr static const char *label = "Experimental Settings";
     struct values_t {
         values_t(ScreenMenuExperimentalSettings &parent)
             : z_len(parent.Item<MI_Z_AXIS_LEN>().GetVal())

--- a/src/gui/screen_menu_experimental_settings_mini.cpp
+++ b/src/gui/screen_menu_experimental_settings_mini.cpp
@@ -21,8 +21,8 @@
 using Screen = ScreenMenu<EHeader::Off, EFooter::On, HelpLines_None, MI_SAVE_AND_RETURN,
     MI_Z_AXIS_LEN, MI_RESET_Z_AXIS_LEN, MI_STEPS_PER_UNIT_E, MI_RESET_STEPS_PER_UNIT, MI_DIRECTION_E, MI_RESET_DIRECTION>;
 class ScreenMenuExperimentalSettings : public Screen {
-    static constexpr const char *const save_and_reboot = N_("Do you want to save changes and reboot the printer?");
-    constexpr static const char *label = N_("Experimental Settings");
+    static constexpr const char *const save_and_reboot = "Do you want to save changes and reboot the printer?";
+    constexpr static const char *label = "Experimental Settings";
     struct values_t {
         values_t(ScreenMenuExperimentalSettings &parent)
             : z_len(parent.Item<MI_Z_AXIS_LEN>().GetVal())

--- a/src/gui/screen_menu_odometer.cpp
+++ b/src/gui/screen_menu_odometer.cpp
@@ -12,12 +12,12 @@
 using MenuContainer = WinMenuContainer<MI_RETURN>;
 
 class ScreenMenuOdometer : public AddSuperWindow<screen_t> {
-    static constexpr const char *label = N_("ODOMETER");
-    static const constexpr char *x_text = N_("X axis");
-    static const constexpr char *y_text = N_("Y axis");
-    static const constexpr char *z_text = N_("Z axis");
+    static constexpr const char *label = N_("STATISTICS");
+    static const constexpr char *x_text = N_("X-axis");
+    static const constexpr char *y_text = N_("Y-axis");
+    static const constexpr char *z_text = N_("Z-axis");
     static const constexpr char *e_text = N_("Filament");
-    static const constexpr char *t_text = N_("Print time");
+    static const constexpr char *t_text = N_("Print Time");
     static const constexpr char *val_format = "%0.1f m"; // do not translate
     static const constexpr char *time_format = "%u s";   // do not translate
 

--- a/src/guiapi/include/MItem_experimental_tools.hpp
+++ b/src/guiapi/include/MItem_experimental_tools.hpp
@@ -18,7 +18,7 @@ enum class ClickCommand : intptr_t { Return,
     Reset_currents };
 
 class MI_Z_AXIS_LEN : public WiSpinInt {
-    constexpr static const char *const label = N_("Z axis length");
+    constexpr static const char *const label = "Z-axis length";
 
 public:
     MI_Z_AXIS_LEN();
@@ -26,7 +26,7 @@ public:
 };
 
 class MI_RESET_Z_AXIS_LEN : public WI_LABEL_t {
-    static constexpr const char *const label = N_("Default Z length");
+    static constexpr const char *const label = "Default Z-length";
 
 public:
     MI_RESET_Z_AXIS_LEN();
@@ -36,7 +36,7 @@ protected:
 };
 
 class MI_STEPS_PER_UNIT_X : public WiSpinInt {
-    constexpr static const char *const label = N_("X axis steps per unit");
+    constexpr static const char *const label = "X-axis steps per unit";
 
 public:
     MI_STEPS_PER_UNIT_X();
@@ -44,7 +44,7 @@ public:
 };
 
 class MI_STEPS_PER_UNIT_Y : public WiSpinInt {
-    constexpr static const char *const label = N_("Y axis steps per unit");
+    constexpr static const char *const label = "Y-axis steps per unit";
 
 public:
     MI_STEPS_PER_UNIT_Y();
@@ -52,7 +52,7 @@ public:
 };
 
 class MI_STEPS_PER_UNIT_Z : public WiSpinInt {
-    constexpr static const char *const label = N_("Z axis steps per unit");
+    constexpr static const char *const label = "Z-axis steps per unit";
 
 public:
     MI_STEPS_PER_UNIT_Z();
@@ -60,7 +60,7 @@ public:
 };
 
 class MI_STEPS_PER_UNIT_E : public WiSpinInt {
-    constexpr static const char *const label = N_("Extruder steps per unit");
+    constexpr static const char *const label = "Extruder steps per unit";
 
 public:
     MI_STEPS_PER_UNIT_E();
@@ -68,7 +68,7 @@ public:
 };
 
 class MI_RESET_STEPS_PER_UNIT : public WI_LABEL_t {
-    static constexpr const char *const label = N_("Default steps per unit");
+    static constexpr const char *const label = "Default steps per unit";
 
 public:
     MI_RESET_STEPS_PER_UNIT();
@@ -78,15 +78,15 @@ protected:
 };
 
 class WiSwitchDirection : public WI_SWITCH_t<2> {
-    constexpr static const char *const str_prusa = N_("Prusa");
-    constexpr static const char *const str_wrong = N_("Wrong");
+    constexpr static const char *const str_prusa = "Prusa";
+    constexpr static const char *const str_wrong = "Wrong";
 
 public:
     WiSwitchDirection(bool current_direction_negative, string_view_utf8 label_view);
 };
 
 class MI_DIRECTION_X : public WiSwitchDirection {
-    constexpr static const char *const label = N_("X axis direction");
+    constexpr static const char *const label = "X-axis direction";
 
 public:
     MI_DIRECTION_X();
@@ -94,7 +94,7 @@ public:
 };
 
 class MI_DIRECTION_Y : public WiSwitchDirection {
-    constexpr static const char *const label = N_("Y axis direction");
+    constexpr static const char *const label = "Y-axis direction";
 
 public:
     MI_DIRECTION_Y();
@@ -102,7 +102,7 @@ public:
 };
 
 class MI_DIRECTION_Z : public WiSwitchDirection {
-    constexpr static const char *const label = N_("Z axis direction");
+    constexpr static const char *const label = "Z-axis direction";
 
 public:
     MI_DIRECTION_Z();
@@ -110,7 +110,7 @@ public:
 };
 
 class MI_DIRECTION_E : public WiSwitchDirection {
-    constexpr static const char *const label = N_("Extruder direction");
+    constexpr static const char *const label = "Extruder direction";
 
 public:
     MI_DIRECTION_E();
@@ -118,7 +118,7 @@ public:
 };
 
 class MI_RESET_DIRECTION : public WI_LABEL_t {
-    static constexpr const char *const label = N_("Default directions");
+    static constexpr const char *const label = "Default directions";
 
 public:
     MI_RESET_DIRECTION();
@@ -128,7 +128,7 @@ protected:
 };
 
 class MI_MICROSTEPS_X : public WiSpinExp {
-    constexpr static const char *const label = N_("X axis microsteps");
+    constexpr static const char *const label = "X-axis microsteps";
 
 public:
     MI_MICROSTEPS_X();
@@ -136,7 +136,7 @@ public:
 };
 
 class MI_MICROSTEPS_Y : public WiSpinExp {
-    constexpr static const char *const label = N_("Y axis microsteps");
+    constexpr static const char *const label = "Y-axis microsteps";
 
 public:
     MI_MICROSTEPS_Y();
@@ -144,7 +144,7 @@ public:
 };
 
 class MI_MICROSTEPS_Z : public WiSpinExp {
-    constexpr static const char *const label = N_("Z axis microsteps");
+    constexpr static const char *const label = "Z-axis microsteps";
 
 public:
     MI_MICROSTEPS_Z();
@@ -152,7 +152,7 @@ public:
 };
 
 class MI_MICROSTEPS_E : public WiSpinExp {
-    constexpr static const char *const label = N_("Extruder microsteps");
+    constexpr static const char *const label = "Extruder microsteps";
 
 public:
     MI_MICROSTEPS_E();
@@ -160,7 +160,7 @@ public:
 };
 
 class MI_RESET_MICROSTEPS : public WI_LABEL_t {
-    static constexpr const char *const label = N_("Reset microsteps");
+    static constexpr const char *const label = "Reset microsteps";
 
 public:
     MI_RESET_MICROSTEPS();
@@ -170,7 +170,7 @@ protected:
 };
 
 class MI_CURRENT_X : public WiSpinInt {
-    constexpr static const char *const label = N_("X current");
+    constexpr static const char *const label = "X current";
 
 public:
     MI_CURRENT_X();
@@ -178,7 +178,7 @@ public:
 };
 
 class MI_CURRENT_Y : public WiSpinInt {
-    constexpr static const char *const label = N_("Y current");
+    constexpr static const char *const label = "Y current";
 
 public:
     MI_CURRENT_Y();
@@ -186,7 +186,7 @@ public:
 };
 
 class MI_CURRENT_Z : public WiSpinInt {
-    constexpr static const char *const label = N_("Z current");
+    constexpr static const char *const label = "Z current";
 
 public:
     MI_CURRENT_Z();
@@ -194,7 +194,7 @@ public:
 };
 
 class MI_CURRENT_E : public WiSpinInt {
-    constexpr static const char *const label = N_("Extruder current");
+    constexpr static const char *const label = "Extruder current";
 
 public:
     MI_CURRENT_E();
@@ -202,7 +202,7 @@ public:
 };
 
 class MI_RESET_CURRENTS : public WI_LABEL_t {
-    static constexpr const char *const label = N_("Reset currents");
+    static constexpr const char *const label = "Reset currents";
 
 public:
     MI_RESET_CURRENTS();
@@ -212,7 +212,7 @@ protected:
 };
 
 class MI_SAVE_AND_RETURN : public WI_LABEL_t {
-    static constexpr const char *const label = N_("Save and return");
+    static constexpr const char *const label = "Save and return";
 
 public:
     MI_SAVE_AND_RETURN();

--- a/src/guiapi/include/MItem_menus.hpp
+++ b/src/guiapi/include/MItem_menus.hpp
@@ -26,7 +26,7 @@ protected:
 };
 
 class MI_ODOMETER : public WI_LABEL_t {
-    static constexpr const char *const label = N_("Odometer");
+    static constexpr const char *const label = N_("Statistics");
 
 public:
     MI_ODOMETER();
@@ -56,7 +56,7 @@ protected:
 };
 
 class MI_STATISTIC_disabled : public WI_LABEL_t {
-    static constexpr const char *const label = N_("Statistic");
+    static constexpr const char *const label = "Statistic";
 
 public:
     MI_STATISTIC_disabled();
@@ -207,7 +207,7 @@ public:
 };
 
 class MI_EXPERIMENTAL_SETTINGS : public WI_LABEL_t {
-    static constexpr const char *const label = N_("Experimental Settings");
+    static constexpr const char *const label = "Experimental Settings";
 
 public:
     MI_EXPERIMENTAL_SETTINGS();

--- a/src/guiapi/include/MItem_menus.hpp
+++ b/src/guiapi/include/MItem_menus.hpp
@@ -55,16 +55,6 @@ protected:
     virtual void click(IWindowMenu &window_menu) override;
 };
 
-class MI_STATISTIC_disabled : public WI_LABEL_t {
-    static constexpr const char *const label = "Statistic";
-
-public:
-    MI_STATISTIC_disabled();
-
-protected:
-    virtual void click(IWindowMenu &window_menu) override {}
-};
-
 class MI_FAIL_STAT_disabled : public WI_LABEL_t {
     static constexpr const char *const label = N_("Fail Stats");
 

--- a/src/guiapi/src/MItem_menus.cpp
+++ b/src/guiapi/src/MItem_menus.cpp
@@ -57,12 +57,6 @@ void MI_SYS_INFO::click(IWindowMenu & /*window_menu*/) {
 }
 
 /*****************************************************************************/
-//MI_STATISTIC_disabled
-MI_STATISTIC_disabled::MI_STATISTIC_disabled()
-    : WI_LABEL_t(_(label), 0, is_enabled_t::no, is_hidden_t::no) {
-}
-
-/*****************************************************************************/
 //MI_FAIL_STAT_disabled
 MI_FAIL_STAT_disabled::MI_FAIL_STAT_disabled()
     : WI_LABEL_t(_(label), 0, is_enabled_t::no, is_hidden_t::no) {

--- a/src/lang/po/Prusa-Firmware-Buddy.pot
+++ b/src/lang/po/Prusa-Firmware-Buddy.pot
@@ -1,14 +1,14 @@
 # Prusa-Firmware-Buddy
-# Copyright (C) 2020 Prusa Research
+# Copyright (C) 2021 Prusa Research
 # This file is distributed under the same license as the Prusa-Firmware-Buddy package.
-# Prusa Research <info@prusa3d.com>, 2020
+# Prusa Research <info@prusa3d.com>, 2021
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Prusa-Firmware-Buddy 4.1\n"
 "Report-Msgid-Bugs-To: info@prusa3d.com\n"
-"POT-Creation-Date: 2020-12-18 18:54+0100\n"
+"POT-Creation-Date: 2021-09-17 10:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,7 +40,7 @@ msgid "ABORT"
 msgstr ""
 
 #. / title text
-#: src/gui/dialogs/liveadjust_z.cpp:205
+#: src/gui/dialogs/liveadjust_z.cpp:207
 msgid "Adjust the nozzle height above the heatbed by turning the knob"
 msgstr ""
 
@@ -52,7 +52,7 @@ msgstr ""
 msgid "Always"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:103
+#: src/gui/screen_printing.cpp:104
 msgid "Are you sure to stop this printing?"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:205
+#: src/gui/screen_printing.cpp:207
 msgid "Bed leveling failed. Try again?"
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 msgid "CANCEL"
 msgstr ""
 
-#: src/gui/dialogs/DialogFactory.cpp:12 src/gui/screen_menu_filament.cpp:90
+#: src/gui/dialogs/DialogFactory.cpp:20 src/gui/screen_menu_filament.cpp:90
 msgid "CHANGE FILAMENT"
 msgstr ""
 
@@ -148,7 +148,7 @@ msgstr ""
 msgid "Checking axes"
 msgstr ""
 
-#: src/gui/wizard/firstlay.cpp:168
+#: src/gui/wizard/firstlay.cpp:169
 msgid "Clean steel sheet."
 msgstr ""
 
@@ -156,11 +156,11 @@ msgstr ""
 msgid "Congratulations! XYZ calibration is ok. XY axes are perpendicular."
 msgstr ""
 
-#: src/common/filament.cpp:13 src/gui/screen_menu_temperature.cpp:12
+#: src/common/filament.cpp:25 src/gui/screen_menu_temperature.cpp:12
 msgid "Cooldown"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:169
+#: src/guiapi/include/MItem_menus.hpp:179
 msgid "Current Profile"
 msgstr ""
 
@@ -169,7 +169,7 @@ msgstr ""
 msgid "DISABLE SENSOR"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:192
+#: src/guiapi/include/MItem_menus.hpp:202
 msgid "Device hash in QR"
 msgstr ""
 
@@ -177,17 +177,17 @@ msgstr ""
 msgid "Disable Steppers"
 msgstr ""
 
-#: src/gui/screen_printing_serial.hpp:10
+#: src/gui/screen_printing_serial.hpp:11
 msgid "Disconnect"
 msgstr ""
 
-#: src/gui/wizard/firstlay.cpp:160
+#: src/gui/wizard/firstlay.cpp:161
 msgid ""
 "Do you want to repeat the last step and readjust the distance between the "
 "nozzle and heatbed?"
 msgstr ""
 
-#. c=20 r=6
+#. c=21 r=9
 #: src/gui/wizard/firstlay.cpp:112
 #, c-format
 msgid ""
@@ -233,7 +233,7 @@ msgstr ""
 msgid "FW UPDATE"
 msgstr ""
 
-#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:119
+#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:129
 msgid "FW Update"
 msgstr ""
 
@@ -245,7 +245,7 @@ msgstr ""
 msgid "Factory defaults loaded. The system will now restart."
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:59
+#: src/guiapi/include/MItem_menus.hpp:69
 msgid "Fail Stats"
 msgstr ""
 
@@ -262,11 +262,12 @@ msgstr ""
 msgid "Fan1 RPM"
 msgstr ""
 
-#: src/gui/screen_home.cpp:35 src/guiapi/include/MItem_menus.hpp:29
+#: src/gui/screen_menu_odometer.cpp:19 src/gui/screen_home.cpp:35
+#: src/guiapi/include/MItem_menus.hpp:39
 msgid "Filament"
 msgstr ""
 
-#: src/gui/screen_menu_settings.cpp:25 src/guiapi/include/MItem_tools.hpp:384
+#: src/gui/screen_menu_settings.cpp:27 src/guiapi/include/MItem_tools.hpp:384
 msgid "Filament Sensor"
 msgstr ""
 
@@ -307,15 +308,15 @@ msgstr ""
 msgid "Fri"
 msgstr ""
 
-#: src/gui/screen_home.cpp:68
+#: src/gui/screen_home.cpp:70
 msgid "HOME"
 msgstr ""
 
-#: src/gui/dialogs/DialogFactory.cpp:40
+#: src/gui/dialogs/DialogFactory.cpp:48
 msgid "HOME TO MAX"
 msgstr ""
 
-#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:159
+#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:169
 msgid "HW Setup"
 msgstr ""
 
@@ -336,11 +337,11 @@ msgstr ""
 msgid "Heating disabled due to 30 minutes of inactivity."
 msgstr ""
 
-#: src/gui/screen_printing.cpp:43
+#: src/gui/screen_printing.cpp:44
 msgid "Heating..."
 msgstr ""
 
-#: src/gui/guimain.cpp:223
+#: src/gui/guimain.cpp:228
 msgid ""
 "Hi, this is your\n"
 "Original Prusa MINI."
@@ -348,7 +349,7 @@ msgstr ""
 
 #. special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
 #. and will get a nice house-like icon
-#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:45
+#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:46
 msgid "Home"
 msgstr ""
 
@@ -423,15 +424,15 @@ msgstr ""
 msgid "LOAD"
 msgstr ""
 
-#: src/gui/dialogs/DialogFactory.cpp:13 src/gui/screen_menu_filament.cpp:52
+#: src/gui/dialogs/DialogFactory.cpp:21 src/gui/screen_menu_filament.cpp:52
 msgid "LOAD FILAMENT"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:129
+#: src/guiapi/include/MItem_menus.hpp:139
 msgid "Lan Settings"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:149
+#: src/guiapi/include/MItem_menus.hpp:159
 msgid "Language"
 msgstr ""
 
@@ -511,7 +512,7 @@ msgstr ""
 msgid "Mesh Bed Leveling"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:139
+#: src/guiapi/include/MItem_menus.hpp:149
 msgid "Messages"
 msgstr ""
 
@@ -520,7 +521,7 @@ msgstr ""
 msgid "Mon"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:89
+#: src/guiapi/include/MItem_menus.hpp:99
 msgid "Move Axis"
 msgstr ""
 
@@ -558,7 +559,7 @@ msgstr ""
 msgid "No USB"
 msgstr ""
 
-#: src/gui/screen_menu_settings.cpp:42
+#: src/gui/screen_menu_settings.cpp:44
 msgid ""
 "No filament sensor detected. Verify that the sensor is connected and try "
 "again."
@@ -611,7 +612,7 @@ msgid ""
 "turning the knob until the filament sticks to the print sheet."
 msgstr ""
 
-#: src/gui/screen_menu_preheat.cpp:25 src/gui/screen_menu_preheat.cpp:47
+#: src/gui/screen_menu_preheat.cpp:26 src/gui/screen_menu_preheat.cpp:49
 msgid "PREHEAT"
 msgstr ""
 
@@ -630,11 +631,11 @@ msgstr ""
 msgid "PREHEAT for UNLOAD"
 msgstr ""
 
-#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:360
+#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:369
 msgid "PRINTING"
 msgstr ""
 
-#: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
+#: src/gui/dialogs/DialogFactory.cpp:23 src/gui/screen_menu_filament.cpp:110
 msgid "PURGE FILAMENT"
 msgstr ""
 
@@ -647,11 +648,11 @@ msgstr ""
 msgid "Parking"
 msgstr ""
 
-#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:38
+#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:39
 msgid "Pause"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:39
+#: src/gui/screen_printing.cpp:40
 msgid "Pausing..."
 msgstr ""
 
@@ -669,7 +670,7 @@ msgstr ""
 msgid "Please insert a USB drive and try again."
 msgstr ""
 
-#: src/gui/guimain.cpp:224
+#: src/gui/guimain.cpp:229
 msgid ""
 "Please insert the USB\n"
 "drive that came with\n"
@@ -726,7 +727,7 @@ msgstr ""
 msgid "Print Fan"
 msgstr ""
 
-#: src/gui/screen_print_preview.cpp:127
+#: src/gui/screen_menu_odometer.cpp:20 src/gui/screen_print_preview.cpp:127
 msgid "Print Time"
 msgstr ""
 
@@ -738,11 +739,11 @@ msgstr ""
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #. theoretically it can be removed completely in case the string is constant for the whole run of the screen
-#: src/gui/screen_printing.cpp:222
+#: src/gui/screen_printing.cpp:243
 msgid "Print will end"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:158
+#: src/gui/screen_printing.cpp:159
 msgid "Printing time"
 msgstr ""
 
@@ -767,7 +768,7 @@ msgstr ""
 msgid "RENAME"
 msgstr ""
 
-#: src/common/MindaRedscreen.cpp:175 src/gui/guimain.cpp:225
+#: src/common/MindaRedscreen.cpp:175 src/gui/guimain.cpp:230
 msgid "RESET PRINTER"
 msgstr ""
 
@@ -780,13 +781,13 @@ msgstr ""
 msgid "Ramming"
 msgstr ""
 
-#: src/gui/screen_printing_serial.cpp:45
+#: src/gui/screen_printing_serial.cpp:46
 msgid "Really Disconnect?"
 msgstr ""
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
-#: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
-#: src/gui/screen_printing.cpp:355
+#: src/gui/screen_printing.cpp:148 src/gui/screen_printing.cpp:247
+#: src/gui/screen_printing.cpp:364
 msgid "Remaining Time"
 msgstr ""
 
@@ -794,7 +795,7 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:44
+#: src/gui/screen_printing.cpp:45
 msgid "Reprint"
 msgstr ""
 
@@ -802,11 +803,11 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:41
+#: src/gui/screen_printing.cpp:42
 msgid "Resume"
 msgstr ""
 
-#: src/gui/screen_printing.cpp:42
+#: src/gui/screen_printing.cpp:43
 msgid "Resuming..."
 msgstr ""
 
@@ -830,12 +831,17 @@ msgstr ""
 msgid "SENSOR INFO"
 msgstr ""
 
-#: src/gui/screen_printing_serial.hpp:13
+#. filament sensor will think printer is in printing state
+#: src/gui/screen_printing_serial.hpp:15
 msgid "SERIAL PRINTING"
 msgstr ""
 
-#: src/gui/screen_menu_settings.cpp:107
+#: src/gui/screen_menu_settings.cpp:109
 msgid "SETTINGS"
+msgstr ""
+
+#: src/gui/screen_menu_odometer.cpp:15
+msgid "STATISTICS"
 msgstr ""
 
 #. Retry
@@ -884,7 +890,7 @@ msgstr ""
 msgid "Sensor Info"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:99
+#: src/guiapi/include/MItem_menus.hpp:109
 msgid "Service"
 msgstr ""
 
@@ -928,15 +934,15 @@ msgstr ""
 msgid "Static IPv4 addresses were not set."
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:49
-msgid "Statistic"
+#: src/guiapi/include/MItem_menus.hpp:29
+msgid "Statistics"
 msgstr ""
 
 #: src/gui/screen_menu_steel_sheets.cpp:176 src/gui/screen_menu_hw_setup.cpp:16
 msgid "Steel Sheets"
 msgstr ""
 
-#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:40
+#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:41
 msgid "Stop"
 msgstr ""
 
@@ -945,11 +951,11 @@ msgstr ""
 msgid "Sun"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:69
+#: src/guiapi/include/MItem_menus.hpp:79
 msgid "Support"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:39
+#: src/guiapi/include/MItem_menus.hpp:49
 msgid "System Info"
 msgstr ""
 
@@ -967,11 +973,11 @@ msgstr ""
 msgid "TUNE"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:79
+#: src/guiapi/include/MItem_menus.hpp:89
 msgid "Temperature"
 msgstr ""
 
-#: src/guiapi/include/MItem_menus.hpp:109
+#: src/guiapi/include/MItem_menus.hpp:119
 msgid "Test"
 msgstr ""
 
@@ -994,7 +1000,7 @@ msgid ""
 msgstr ""
 
 #. save eeprom flag
-#: src/gui/wizard/firstlay.cpp:184
+#: src/gui/wizard/firstlay.cpp:185
 msgid ""
 "The first layer calibration failed to finish. Double-check the printer's "
 "wiring, nozzle and axes, then restart the calibration."
@@ -1069,7 +1075,7 @@ msgstr ""
 msgid "Tue"
 msgstr ""
 
-#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:37
+#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:38
 msgid "Tune"
 msgstr ""
 
@@ -1078,7 +1084,7 @@ msgstr ""
 msgid "UNLOAD"
 msgstr ""
 
-#: src/gui/dialogs/DialogFactory.cpp:14 src/gui/screen_menu_filament.cpp:72
+#: src/gui/dialogs/DialogFactory.cpp:22 src/gui/screen_menu_filament.cpp:72
 msgid "UNLOAD FILAMENT"
 msgstr ""
 
@@ -1148,6 +1154,7 @@ msgstr ""
 msgid "Wizard"
 msgstr ""
 
+#: src/gui/screen_menu_odometer.cpp:16
 #: src/gui/dialogs/DialogSelftestResult.cpp:43
 #: src/gui/dialogs/DialogSelftestAxis.cpp:19
 msgid "X-axis"
@@ -1157,6 +1164,7 @@ msgstr ""
 msgid "XYZ CALIBRATION"
 msgstr ""
 
+#: src/gui/screen_menu_odometer.cpp:17
 #: src/gui/dialogs/DialogSelftestResult.cpp:44
 #: src/gui/dialogs/DialogSelftestAxis.cpp:20
 msgid "Y-axis"
@@ -1171,6 +1179,7 @@ msgstr ""
 msgid "Z height:"
 msgstr ""
 
+#: src/gui/screen_menu_odometer.cpp:18
 #: src/gui/dialogs/DialogSelftestResult.cpp:45
 #: src/gui/dialogs/DialogSelftestAxis.cpp:21
 msgid "Z-axis"

--- a/src/lang/po/cs/Prusa-Firmware-Buddy_cs.po
+++ b/src/lang/po/cs/Prusa-Firmware-Buddy_cs.po
@@ -4,26 +4,40 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
+"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n%10 >= 2 && n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || n%10 == 1 || (n%10 >= 5 && n%10 <=9)) || (n%100 >= 12 && n%100 <= 14)) ? 2 : 3);\n"
+"X-Generator: Phrase (phrase.com)\n"
 
 #. c=20 r=4
-#: src/gui/screen_menu_version_info.cpp:82
+#: src/gui/version_info_ST7789V.cpp:102
 #, c-format
-msgid "\nBootloader Version\n%d.%d.%d\n\nBuddy Board\n%d.%d.%d\n%s"
-msgstr "\nVerze bootloaderu\n%d.%d.%d\n\nBuddy deska\n%d.%d.%d\n%s"
+msgid ""
+"\n"
+"Bootloader Version\n"
+"%d.%d.%d\n"
+"\n"
+"Buddy Board\n"
+"%d.%d.%d\n"
+"%s"
+msgstr ""
+"\n"
+"Verze bootloaderu\n"
+"%d.%d.%d\n"
+"\n"
+"Buddy deska\n"
+"%d.%d.%d\n"
+"%s"
 
 #: src/guiapi/src/MItem_tools.cpp:200
 msgid "A crash dump report (file dump.bin) has been saved to the USB drive."
 msgstr "Výpis chyb (soubor dump.bin) byl zapsán na USB disk."
 
 #. _none
-#: src/gui/dialogs/dialog_response.cpp:11
+#: src/common/client_response_texts.cpp:11
 msgid "ABORT"
 msgstr "ZRUŠIT"
 
 #. / title text
-#: src/gui/dialogs/liveadjust_z.cpp:205
+#: src/gui/dialogs/liveadjust_z.cpp:207
 msgid "Adjust the nozzle height above the heatbed by turning the knob"
 msgstr "K doladění výšky trysky nad podložkou otáčejte ovládacím tlačítkem."
 
@@ -35,7 +49,7 @@ msgstr "Testy úspěšně dokončeny!"
 msgid "Always"
 msgstr "Vždy"
 
-#: src/gui/screen_printing.cpp:103
+#: src/gui/screen_printing.cpp:104
 msgid "Are you sure to stop this printing?"
 msgstr "Chcete zrušit tisk?"
 
@@ -48,15 +62,17 @@ msgid "Auto Home"
 msgstr "Auto Home"
 
 #. Abort
-#: src/gui/dialogs/dialog_response.cpp:12
+#. ABS filament, do not translate
+#. ASA filament, do not translate
+#: src/common/client_response_texts.cpp:14
 msgid "BACK"
 msgstr "ZPĚT"
 
-#: src/gui/screen_print_preview.cpp:189
+#: src/gui/screen_print_preview.cpp:68
 msgid "Back"
 msgstr "Zpět"
 
-#: src/gui/screen_printing.cpp:205
+#: src/gui/screen_printing.cpp:208
 msgid "Bed leveling failed. Try again?"
 msgstr "Mesh Bed L. selhal. Opakovat?"
 
@@ -64,7 +80,7 @@ msgstr "Mesh Bed L. selhal. Opakovat?"
 msgid "Calibrating Z"
 msgstr "Kalibrace Z"
 
-#: src/gui/screen_home.cpp:36
+#: src/gui/screen_home.cpp:37
 msgid "Calibration"
 msgstr "Kalibrace"
 
@@ -81,48 +97,48 @@ msgid "Calibration XY"
 msgstr "Kalibrace XY"
 
 #. Back
-#: src/gui/screen_sheet_rename.cpp:18 src/gui/dialogs/dialog_response.cpp:13
+#: src/common/client_response_texts.cpp:15 src/gui/screen_sheet_rename.cpp:18
 msgid "CANCEL"
 msgstr "ZRUŠIT"
 
-#: src/gui/dialogs/DialogFactory.cpp:12 src/gui/screen_menu_filament.cpp:90
+#: src/gui/dialogs/DialogFactory.cpp:8 src/gui/screen_menu_filament.cpp:72
 msgid "CHANGE FILAMENT"
 msgstr "VYMĚNIT FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:89 src/guiapi/include/MItem_tools.hpp:279
+#: src/gui/screen_menu_filament.cpp:71 src/guiapi/include/MItem_tools.hpp:279
 msgid "Change Filament"
 msgstr "Vyměnit filament"
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:44
 msgid "Check the heatbed heater & thermistor wiring for possible damage."
-msgstr "Zkontrolujte, zda nejsou poškozeny kabely vyhřívané podložky a termistoru."
+msgstr "Zkontrolujte kabeláž vyhřívané podložky & termistoru z důvodu možného poškození."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:56
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:68
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:80
 msgid "Check the heatbed thermistor wiring for possible damage."
-msgstr "Zkontrolujte, zda není poškozen kabel termistoru vyhřívané podložky."
+msgstr "Zkontrolujte kabeláž termistoru vyhřívané podložky z důvodu možného poškození."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:50
 msgid "Check the print head heater & thermistor wiring for possible damage."
-msgstr "Zkontrolujte, zda nejsou poškozené kabely od topného bloku a termistoru tiskové hlavy."
+msgstr "Zkontrolujte kabeláž vyhřívacího tělesa tiskové hlavy & termistoru z důvodu možného poškození."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:62
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:74
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:86
 msgid "Check the print head thermistor wiring for possible damage."
-msgstr "Zkontrolujte, zda není poškozen kabel termistoru tiskové hlavy."
+msgstr "Zkontrolujte kabeláž termistoru tiskové hlavy z důvodu možného poškození. "
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:42
-#: src/gui/dialogs/DialogSelftestAxis.cpp:18
+#: src/gui/dialogs/DialogSelftestAxis.cpp:24
 msgid "Checking axes"
 msgstr "Kontrola os"
 
-#: src/gui/wizard/firstlay.cpp:168
+#: src/gui/wizard/firstlay.cpp:173
 msgid "Clean steel sheet."
 msgstr "Očistěte podložku."
 
@@ -130,12 +146,12 @@ msgstr "Očistěte podložku."
 msgid "Congratulations! XYZ calibration is ok. XY axes are perpendicular."
 msgstr "Gratulujeme! XYZ kalibrace v pořádku, všechny osy kolmé."
 
-#. Cancel
-#: src/gui/dialogs/dialog_response.cpp:14
+#. Change
+#: src/common/client_response_texts.cpp:17
 msgid "CONTINUE"
 msgstr "POKRAČOVAT"
 
-#: src/common/filament.cpp:13 src/gui/screen_menu_temperature.cpp:12
+#: src/gui/screen_menu_temperature.cpp:12
 msgid "Cooldown"
 msgstr "Zchladit"
 
@@ -143,16 +159,16 @@ msgstr "Zchladit"
 msgid "CPU load"
 msgstr "CPU vyt."
 
-#: src/guiapi/include/MItem_menus.hpp:169
+#: src/guiapi/include/MItem_menus.hpp:179
 msgid "Current Profile"
 msgstr "Zvolený profil"
 
-#: src/guiapi/include/MItem_menus.hpp:192
+#: src/guiapi/include/MItem_menus.hpp:202
 msgid "Device hash in QR"
 msgstr "Hash zařízení v QR"
 
-#. Continue
-#: src/gui/dialogs/dialog_response.cpp:15
+#. Cooldown
+#: src/common/client_response_texts.cpp:19
 msgid "DISABLE SENSOR"
 msgstr "VYPNOUT SENZOR"
 
@@ -160,25 +176,33 @@ msgstr "VYPNOUT SENZOR"
 msgid "Disable Steppers"
 msgstr "Vypnout motory"
 
-#: src/gui/screen_printing_serial.hpp:10
+#: src/gui/screen_printing_serial.hpp:11
 msgid "Disconnect"
 msgstr "Odpojit"
 
-#: src/gui/wizard/firstlay.cpp:160
+#: src/gui/wizard/firstlay.cpp:165
 msgid "Do you want to repeat the last step and readjust the distance between the nozzle and heatbed?"
 msgstr "Chcete zopakovat poslední krok a upravit nastavení vzdálenosti mezi tryskou a podložkou?"
 
-#. c=20 r=6
-#: src/gui/wizard/firstlay.cpp:112
+#. c=21 r=9
+#: src/gui/wizard/firstlay.cpp:116
 #, c-format
-msgid "Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)"
-msgstr "Chcete použít aktuální hodnotu?\nAktuální: %0.3f.\nVýchozí: %0.3f.\nZvolením NE vyberete výchozí hodnotu (doporučeno)"
+msgid ""
+"Do you want to use the current value?\n"
+"Current: %0.3f.\n"
+"Default: %0.3f.\n"
+"Click NO to use the default value (recommended)"
+msgstr ""
+"Chcete použít aktuální hodnotu?\n"
+"Aktuální: %0.3f.\n"
+"Výchozí: %03.f.\n"
+"Zvolením NE vyberete výchozí hodnotu (doporučeno)"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:27
+#: src/gui/dialogs/DialogLoadUnload.cpp:28
 msgid "Ejecting"
 msgstr "Vysouvání"
 
-#: src/guiapi/src/window_msgbox.cpp:150
+#: src/guiapi/src/window_msgbox.cpp:152
 msgid "Error"
 msgstr "Chyba"
 
@@ -202,11 +226,11 @@ msgstr "Nahrány výchozí hodnoty. Systém se restartuje."
 msgid "Factory Reset"
 msgstr "Tovární nastavení"
 
-#: src/guiapi/include/MItem_menus.hpp:59
+#: src/guiapi/include/MItem_menus.hpp:69
 msgid "Fail Stats"
 msgstr "Stat. chyb"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:17
+#: src/gui/dialogs/DialogSelftestFans.cpp:18
 #: src/gui/dialogs/DialogSelftestResult.cpp:39
 msgid "Fan Test"
 msgstr "Test ventilátorů"
@@ -219,19 +243,22 @@ msgstr "Vent0 RPM"
 msgid "Fan1 RPM"
 msgstr "Vent1 RPM"
 
-#: src/gui/screen_menu_filament.cpp:127
+#: src/gui/screen_menu_filament.cpp:101
 msgid "FILAMENT"
 msgstr "FILAMENT"
 
-#: src/gui/screen_home.cpp:35 src/guiapi/include/MItem_menus.hpp:29
+#. ItemBed
+#: src/gui/screen_menu_odometer.cpp:18
+#: src/gui/screen_menu_footer_settings.cpp:60 src/gui/screen_home.cpp:36
+#: src/guiapi/include/MItem_menus.hpp:39
 msgid "Filament"
 msgstr "Filament"
 
-#: src/gui/screen_menu_filament.cpp:53
+#: src/gui/screen_menu_filament.cpp:41
 msgid "Filament appears to be already loaded, are you sure you want to load it anyway?"
 msgstr "Zdá se, že filament je už zaveden. Chcete jej přesto zavést znovu?"
 
-#: src/gui/screen_print_preview.cpp:223
+#: src/gui/screen_print_preview.cpp:95
 msgid "Filament not detected. Load filament now? Select NO to cancel, or IGNORE to disable the filament sensor and continue."
 msgstr "Filament nebyl detekován. Zavést filament nyní? Vyberte NE pro zrušení tisku, nebo IGNOROVAT pro vypnutí senzoru a pokračování."
 
@@ -246,7 +273,7 @@ msgid "Finishing buffered gcodes."
 msgstr "Dokončování načtených Gcodů."
 
 #. r=1 c=20
-#: src/gui/screen_menu_version_info.cpp:60
+#: src/gui/version_info_ST7789V.cpp:80
 msgid "Firmware Version\n"
 msgstr "Verze firmwaru\n"
 
@@ -268,11 +295,11 @@ msgstr "Průtok"
 msgid "Fri"
 msgstr "Pá"
 
-#: src/gui/screen_menu_fw_update.cpp:70
+#: src/gui/screen_menu_fw_update.cpp:69
 msgid "FW UPDATE"
 msgstr "AKTUALIZACE FW"
 
-#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:119
+#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:129
 msgid "FW Update"
 msgstr "Aktualizace FW"
 
@@ -281,41 +308,45 @@ msgstr "Aktualizace FW"
 msgid "Heatbed"
 msgstr "Podložka"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:25
+#: src/gui/dialogs/DialogSelftestTemp.cpp:26
 msgid "Heatbed heater check"
 msgstr "Výhřev podložky"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:27
+#: src/gui/dialogs/DialogSelftestTemp.cpp:28
 msgid "Heater testing"
 msgstr "Testování výhřevu"
 
-#: src/gui/guimain.cpp:194
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:34
 msgid "Heating disabled due to 30 minutes of inactivity."
 msgstr "Vyhřívání vypnuto po 30 minutách neaktivity."
 
-#: src/gui/screen_printing.cpp:43
+#: src/gui/screen_printing.cpp:44
 msgid "Heating..."
 msgstr "Zahřívání..."
 
-#: src/gui/guimain.cpp:205
-msgid "Hi, this is your\nOriginal Prusa MINI."
-msgstr "Vítá vás\nOriginal Prusa MINI!"
+#: src/gui/guimain.cpp:228
+msgid ""
+"Hi, this is your\n"
+"Original Prusa MINI."
+msgstr ""
+"Ahoj, tohle je vaše \n"
+"Original Prusa MINI."
 
-#: src/gui/screen_home.cpp:68
+#: src/gui/screen_home.cpp:72
 msgid "HOME"
 msgstr "MENU"
 
 #. special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
 #. and will get a nice house-like icon
-#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:45
+#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:46
 msgid "Home"
 msgstr "Domů"
 
-#: src/gui/dialogs/DialogFactory.cpp:40
+#: src/gui/dialogs/DialogFactory.cpp:53
 msgid "HOME TO MAX"
 msgstr "HOME TO MAX"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:18
+#: src/gui/dialogs/DialogSelftestFans.cpp:19
 #: src/gui/dialogs/DialogSelftestResult.cpp:40
 msgid "Hotend Fan"
 msgstr "Vent. hotendu"
@@ -324,45 +355,48 @@ msgstr "Vent. hotendu"
 msgid "Hotend fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "Ventilátor hotendu se netočí. Zkontrolujte, zda není blokován. Pak zkontrolujte zapojení."
 
-#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:159
+#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:169
 msgid "HW Setup"
 msgstr "HW nastavení"
 
 #. Filament_removed
-#: src/gui/dialogs/dialog_response.cpp:16
+#. FLEX filament, do not translate
+#. HIPS filament, do not translate
+#: src/common/client_response_texts.cpp:22
 msgid "IGNORE"
 msgstr "IGNOROVAT"
 
 #. static const char en_text[] = N_("Observe the pattern and turn the knob to adjust the nozzle height in real time. Extruded plastic must stick to the print surface.");
-#: src/gui/wizard/firstlay.cpp:128
+#: src/gui/wizard/firstlay.cpp:132
 msgid "In the next step, use the knob to adjust the nozzle height. Check the pictures in the handbook for reference."
 msgstr "V dalším kroku použijte ovládací tlačítko a nastavte výšku trysky. V příručce naleznete detailní instrukce a ilustrace."
 
-#: src/gui/screen_menu_info.cpp:20
+#: src/gui/screen_menu_info.cpp:19
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:31
 msgid "INFO"
 msgstr "INFO"
 
-#: src/gui/screen_home.cpp:38
+#: src/gui/screen_home.cpp:39
 msgid "Info"
 msgstr "Info"
 
-#: src/guiapi/src/window_msgbox.cpp:172
+#: src/guiapi/src/window_msgbox.cpp:171
 msgid "Information"
 msgstr "Informace"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:25
+#: src/gui/dialogs/DialogLoadUnload.cpp:26
 msgid "Inserting"
 msgstr "Zavádění"
 
-#: src/gui/screen_menu_lan_settings.cpp:292
+#: src/gui/screen_menu_lan_settings.cpp:294
 msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
 msgstr "Nesprávné IP adresy nebo parametry, nebo soubor \"lan_settings.ini\" není v kořenovém adresáři USB disku."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:30
+#: src/gui/dialogs/DialogLoadUnload.cpp:31
 msgid "Is color correct?"
 msgstr "Je barva správná?"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:26
+#: src/gui/dialogs/DialogLoadUnload.cpp:27
 msgid "Is filament in extruder gear?"
 msgstr "Je filament v podávacím soukolí extruderu?"
 
@@ -370,15 +404,15 @@ msgstr "Je filament v podávacím soukolí extruderu?"
 msgid "Is steel sheet on heatbed?"
 msgstr "Je na podložce tiskový plát?"
 
-#: src/gui/screen_menu_lan_settings.cpp:221
+#: src/gui/screen_menu_lan_settings.cpp:217
 msgid "LAN SETTINGS"
 msgstr "NASTAVENÍ LAN"
 
-#: src/guiapi/include/MItem_menus.hpp:129
+#: src/guiapi/include/MItem_menus.hpp:139
 msgid "Lan Settings"
 msgstr "Nastavení LAN"
 
-#: src/guiapi/include/MItem_menus.hpp:149
+#: src/guiapi/include/MItem_menus.hpp:159
 msgid "Language"
 msgstr "Jazyk"
 
@@ -391,15 +425,15 @@ msgid "Live Adjust Z"
 msgstr "Doladit Z"
 
 #. Ignore
-#: src/gui/dialogs/dialog_response.cpp:17
+#: src/common/client_response_texts.cpp:23
 msgid "LOAD"
 msgstr "ZAVÉST"
 
-#: src/gui/dialogs/DialogFactory.cpp:13 src/gui/screen_menu_filament.cpp:52
+#: src/gui/dialogs/DialogFactory.cpp:9
 msgid "LOAD FILAMENT"
 msgstr "ZAVÉST FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:51
+#: src/gui/screen_menu_filament.cpp:40
 msgid "Load Filament"
 msgstr "Zavést filament"
 
@@ -407,11 +441,11 @@ msgstr "Zavést filament"
 msgid "Load Settings"
 msgstr "Nahrát nastavení"
 
-#: src/gui/screen_splash.cpp:43
+#: src/gui/screen_splash.cpp:38
 msgid "Loading ..."
 msgstr "Nahrává se..."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:28
+#: src/gui/dialogs/DialogLoadUnload.cpp:29
 msgid "Loading to nozzle"
 msgstr "Zavádění do trysky"
 
@@ -423,11 +457,11 @@ msgstr "Hlasitý"
 msgid "M.I.N.D.A."
 msgstr "M.I.N.D.A."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:24
+#: src/gui/dialogs/DialogLoadUnload.cpp:25
 msgid "Make sure the filament is inserted through the sensor."
 msgstr "Ujistěte se, že je filament vložen skrz fil. senzor."
 
-#: src/gui/screen_print_preview.cpp:128
+#: src/gui/gcode_description.cpp:37
 msgid "Material"
 msgstr "Materiál"
 
@@ -438,8 +472,14 @@ msgid "MAXTEMP ERROR"
 msgstr "CHYBA MAXTEMP"
 
 #: src/gui/wizard/xyzcalib.cpp:192
-msgid "Measuring reference\nheight of calib.\npoints"
-msgstr "Měření referenční\nvýšky kalibračních\nbodů"
+msgid ""
+"Measuring reference\n"
+"height of calib.\n"
+"points"
+msgstr ""
+"Měření referenční\n"
+"výšky kalibračních\n"
+"bodů"
 
 #: src/guiapi/include/MItem_tools.hpp:289
 msgid "Menu Timeout"
@@ -458,7 +498,7 @@ msgstr "MESH BED LEVELING"
 msgid "MESSAGES"
 msgstr "ZPRÁVY"
 
-#: src/guiapi/include/MItem_menus.hpp:139
+#: src/guiapi/include/MItem_menus.hpp:149
 msgid "Messages"
 msgstr "Zprávy"
 
@@ -473,7 +513,7 @@ msgstr "CHYBA MINTEMP"
 msgid "Mon"
 msgstr "Po"
 
-#: src/guiapi/include/MItem_menus.hpp:89
+#: src/guiapi/include/MItem_menus.hpp:99
 msgid "Move Axis"
 msgstr "Pohyb osy"
 
@@ -502,12 +542,12 @@ msgid "Name"
 msgstr "Název"
 
 #. Load
-#: src/gui/dialogs/dialog_response.cpp:18
+#: src/common/client_response_texts.cpp:24
 msgid "NEXT"
 msgstr "DALŠÍ"
 
 #. Next
-#: src/gui/dialogs/dialog_response.cpp:19
+#: src/common/client_response_texts.cpp:25
 msgid "NO"
 msgstr "NE"
 
@@ -515,14 +555,15 @@ msgstr "NE"
 msgid "No filament sensor detected. Verify that the sensor is connected and try again."
 msgstr "Senzor filamentu nenalezen. Ujistěte se, že je správně zapojen a opakujte akci."
 
-#: src/gui/screen_home.cpp:39
+#: src/gui/screen_home.cpp:40
 msgid "No USB"
 msgstr "Vložte USB"
 
-#: src/gui/wizard/firstlay.cpp:98
+#: src/gui/wizard/firstlay.cpp:102
 msgid "Now, let's calibrate the distance between the tip of the nozzle and the print sheet."
 msgstr "Nyní zkalibrujeme vzdálenost mezi tryskou a tiskovým plátem."
 
+#: src/gui/screen_menu_footer_settings.cpp:58
 #: src/gui/dialogs/DialogSelftestResult.cpp:47
 #: src/guiapi/include/MItem_print.hpp:8
 msgid "Nozzle"
@@ -532,17 +573,18 @@ msgstr "Tryska"
 msgid "Nozzle and Heatbed"
 msgstr "Tryska a podložka"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:24
+#: src/gui/dialogs/DialogSelftestTemp.cpp:25
 msgid "Nozzle heater check"
 msgstr "Výhřev trysky"
 
 #: src/gui/screen_menu_fw_update.cpp:28
 #: src/guiapi/include/WindowMenuItems.hpp:19
+#: src/guiapi/include/WindowMenuSpin.hpp:21
 msgid "Off"
 msgstr "Vyp."
 
 #. No
-#: src/gui/screen_sheet_rename.cpp:17 src/gui/dialogs/dialog_response.cpp:20
+#: src/common/client_response_texts.cpp:26 src/gui/screen_sheet_rename.cpp:17
 msgid "OK"
 msgstr "OK"
 
@@ -566,11 +608,11 @@ msgstr "Až začne MINI vytlačovat plast, nastav výšku trysky otáčením ovl
 msgid "Parking"
 msgstr "Parkování"
 
-#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:38
+#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:39
 msgid "Pause"
 msgstr "Pauza"
 
-#: src/gui/screen_printing.cpp:39
+#: src/gui/screen_printing.cpp:40
 msgid "Pausing..."
 msgstr "Pozastavení..."
 
@@ -582,15 +624,25 @@ msgstr "Pro kalibraci prvních 4 bodů vložte pod trysku list papíru. Pokud tr
 msgid "Please clean the nozzle for calibration. Click NEXT when done."
 msgstr "Nyní je nutné očistit trysku. Až bude hotovo, zvolte DALŠÍ."
 
-#: src/gui/screen_menu_lan_settings.cpp:280
+#: src/gui/screen_menu_lan_settings.cpp:282
 msgid "Please insert a USB drive and try again."
 msgstr "Vložte USB disk a opakujte akci."
 
-#: src/gui/guimain.cpp:206
-msgid "Please insert the USB\ndrive that came with\nyour MINI and reset\nthe printer to flash\nthe firmware"
-msgstr "Vložte USB disk\ndodávaný k tiskárně\na restartujte MINI.\nTím zahájíte proces\naktualizace FW."
+#: src/gui/guimain.cpp:229
+msgid ""
+"Please insert the USB\n"
+"drive that came with\n"
+"your MINI and reset\n"
+"the printer to flash\n"
+"the firmware"
+msgstr ""
+"Prosím vložte USB\n"
+"disk, který jste obdrželi \n"
+"s vaší MINI a resetujte \n"
+"tiskárnu pro flashování\n"
+"firmwaru"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:22
+#: src/gui/dialogs/DialogLoadUnload.cpp:23
 msgid "Please open idler and remove filament manually"
 msgstr "Otevřete idler a vyjměte filament ručně"
 
@@ -606,11 +658,11 @@ msgstr "Odstraňte tiskový plát z vyhřívané podložky."
 msgid "Please wait"
 msgstr "Vyčkejte"
 
-#: src/gui/screen_menu_preheat.cpp:25 src/gui/screen_menu_preheat.cpp:47
+#: src/gui/screen_menu_preheat.cpp:26 src/gui/screen_menu_preheat.cpp:49
 msgid "PREHEAT"
 msgstr "PŘEDEHŘEV"
 
-#: src/gui/screen_home.cpp:34
+#: src/gui/screen_home.cpp:35
 msgid "Preheat"
 msgstr "Předehřev"
 
@@ -618,19 +670,17 @@ msgstr "Předehřev"
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:42
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:48
 msgid "PREHEAT ERROR"
-msgstr "CHYBA PŘEDEHŘEVU"
+msgstr "PREHEAT ERROR (Chyba předehřevu)"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:34
+#: src/gui/dialogs/DialogFactory.cpp:12
 msgid "PREHEAT for LOAD"
 msgstr "PŘEDEHŘÁT pro ZAVEDENÍ"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:54
+#: src/gui/dialogs/DialogFactory.cpp:13
 msgid "PREHEAT for UNLOAD"
 msgstr "PŘEDEHŘÁT pro VYSUNUTÍ"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:26
+#: src/gui/dialogs/DialogSelftestTemp.cpp:27
 msgid "Preparing"
 msgstr "Příprava"
 
@@ -638,7 +688,7 @@ msgstr "Příprava"
 msgid "Preparing to ram"
 msgstr "Příprava na ramming"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:23
+#: src/gui/dialogs/DialogLoadUnload.cpp:24
 msgid "Press CONTINUE and push filament into the extruder."
 msgstr "Zvolte POKRAČOVAT a zasuňte filament do extruderu."
 
@@ -646,11 +696,11 @@ msgstr "Zvolte POKRAČOVAT a zasuňte filament do extruderu."
 msgid "Press NEXT to run the Selftest, which checks for potential issues related to the assembly."
 msgstr "Zvolte DALŠÍ pro spuštění Selftestu, který ověří, zda je tiskárna správně sestavena."
 
-#: src/gui/screen_print_preview.cpp:185 src/gui/screen_home.cpp:33
+#: src/gui/screen_print_preview.cpp:64 src/gui/screen_home.cpp:34
 msgid "Print"
 msgstr "Tisk"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:19
+#: src/gui/dialogs/DialogSelftestFans.cpp:20
 #: src/gui/dialogs/DialogSelftestResult.cpp:41
 #: src/guiapi/include/MItem_print.hpp:24
 msgid "Print Fan"
@@ -660,42 +710,46 @@ msgstr "Tisk. vent."
 msgid "Print fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "Tiskový ventilátor se netočí. Zkontrolujte, zda není blokován. Pak zkontrolujte zapojení."
 
-#: src/gui/screen_print_preview.cpp:127
+#: src/gui/gcode_description.cpp:36
 msgid "Print Time"
 msgstr "Doba tisku"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #. theoretically it can be removed completely in case the string is constant for the whole run of the screen
-#: src/gui/screen_printing.cpp:222
+#: src/gui/screen_printing.cpp:244
 msgid "Print will end"
 msgstr "Konec tisku:"
 
-#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:360
+#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:370
 msgid "PRINTING"
 msgstr "TISK"
 
-#: src/gui/screen_printing.cpp:158
+#: src/gui/screen_printing.cpp:160
 msgid "Printing time"
 msgstr "Čas tisku"
 
-#: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
+#: src/gui/dialogs/DialogFactory.cpp:11 src/gui/screen_menu_filament.cpp:87
 msgid "PURGE FILAMENT"
 msgstr "ČISTIT TRYSKU"
 
-#: src/gui/screen_menu_filament.cpp:109
+#: src/gui/screen_menu_filament.cpp:86
 msgid "Purge Filament"
 msgstr "Čistit trysku"
 
 #. Ok
-#: src/gui/dialogs/dialog_response.cpp:21
+#. PC filament, do not translate
+#. PETG filament, do not translate
+#. PLA filament, do not translate
+#. PP filament, do not translate
+#: src/common/client_response_texts.cpp:31
 msgid "PURGE MORE"
 msgstr "ČISTIT VÍCE"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:29
+#: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Purging"
 msgstr "Čištění"
 
-#: src/guiapi/src/window_msgbox.cpp:156
+#: src/guiapi/src/window_msgbox.cpp:157
 msgid "Question"
 msgstr "Otázka"
 
@@ -703,18 +757,18 @@ msgstr "Otázka"
 msgid "Ramming"
 msgstr "Ramming"
 
-#: src/gui/screen_printing_serial.cpp:45
+#: src/gui/screen_printing_serial.cpp:43
 msgid "Really Disconnect?"
 msgstr "Opravdu odpojit?"
 
 #. Purge_more
-#: src/gui/dialogs/dialog_response.cpp:22
+#: src/common/client_response_texts.cpp:32
 msgid "REHEAT"
 msgstr "OPAK. NAHŘÁTÍ"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
-#: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
-#: src/gui/screen_printing.cpp:355
+#: src/gui/screen_printing.cpp:149 src/gui/screen_printing.cpp:248
+#: src/gui/screen_printing.cpp:365
 msgid "Remaining Time"
 msgstr "Zbývající čas"
 
@@ -726,7 +780,7 @@ msgstr "PŘEJMENOVAT"
 msgid "Rename"
 msgstr "Přejmenovat"
 
-#: src/gui/screen_printing.cpp:44
+#: src/gui/screen_printing.cpp:45
 msgid "Reprint"
 msgstr "Tisk. znovu"
 
@@ -734,23 +788,24 @@ msgstr "Tisk. znovu"
 msgid "Reset"
 msgstr "Reset"
 
-#: src/common/MindaRedscreen.cpp:175 src/gui/guimain.cpp:207
+#: src/common/MindaRedscreen.cpp:175
 msgid "RESET PRINTER"
 msgstr "RESET ZAŘÍZENÍ"
 
-#: src/gui/screen_printing.cpp:41
+#: src/gui/screen_printing.cpp:42
 msgid "Resume"
 msgstr "Pokračovat"
 
-#: src/gui/screen_printing.cpp:42
+#: src/gui/screen_printing.cpp:43
 msgid "Resuming..."
 msgstr "Opětovné spuštění..."
 
 #. Reheat
-#: src/gui/dialogs/dialog_response.cpp:23
+#: src/common/client_response_texts.cpp:33
 msgid "RETRY"
 msgstr "ZNOVU"
 
+#: src/gui/dialogs/window_dlg_preheat.hpp:39
 #: src/guiapi/include/WindowMenuItems.hpp:54
 msgid "Return"
 msgstr "Zpět"
@@ -769,8 +824,12 @@ msgid "Save Settings"
 msgstr "Uložit nastavení"
 
 #: src/gui/wizard/xyzcalib.cpp:180
-msgid "Searching bed\ncalibration points"
-msgstr "Hledání kalibračních\nbodů na podložce"
+msgid ""
+"Searching bed\n"
+"calibration points"
+msgstr ""
+"Hledání kalibračních\n"
+"bodů na podložce"
 
 #: src/gui/screen_menu_steel_sheets.cpp:33
 msgid "Select"
@@ -778,9 +837,9 @@ msgstr "Vybrat"
 
 #: src/gui/wizard/firstlay.cpp:71
 msgid "Select Filament Type"
-msgstr "Zvolte typ filamentu"
+msgstr "Vyberte typ filamentu "
 
-#: src/gui/screen_filebrowser.cpp:42
+#: src/gui/screen_filebrowser.cpp:43
 msgid "SELECT FILE"
 msgstr "VÝBĚR SOUBORU"
 
@@ -788,7 +847,7 @@ msgstr "VÝBĚR SOUBORU"
 msgid "SELECT LANGUAGE"
 msgstr "VÝBĚR JAZYKA"
 
-#: src/gui/screen_menu_fw_update.cpp:74
+#: src/gui/screen_menu_fw_update.cpp:96
 msgid "Select when you want to automatically flash updated firmware from USB flash disk."
 msgstr "Zvolte, kdy má dojít k automatické aktualizaci nového firmwaru z USB disku."
 
@@ -808,23 +867,24 @@ msgstr "STAV SENZORU"
 msgid "Sensor Info"
 msgstr "Stav senzoru"
 
-#: src/gui/screen_printing_serial.hpp:13
+#. filament sensor will think printer is in printing state
+#: src/gui/screen_printing_serial.hpp:15
 msgid "SERIAL PRINTING"
 msgstr "TISK - SÉRIOVÝ PORT"
 
-#: src/guiapi/include/MItem_menus.hpp:99
+#: src/guiapi/include/MItem_menus.hpp:109
 msgid "Service"
 msgstr "Služba"
 
-#: src/gui/screen_home.cpp:37
+#: src/gui/screen_home.cpp:38
 msgid "Settings"
 msgstr "Nastavení"
 
-#: src/gui/screen_menu_settings.cpp:107
+#: src/gui/screen_menu_settings.cpp:108
 msgid "SETTINGS"
 msgstr "NASTAVENÍ"
 
-#: src/gui/screen_menu_lan_settings.cpp:289
+#: src/gui/screen_menu_lan_settings.cpp:291
 msgid "Settings successfully loaded"
 msgstr "Nastavení načteno"
 
@@ -852,28 +912,34 @@ msgstr "Zvuk"
 msgid "Sound Volume"
 msgstr "Hlasitost"
 
+#. ItemFilament
+#: src/gui/screen_menu_footer_settings.cpp:61
 #: src/guiapi/include/MItem_print.hpp:32
 msgid "Speed"
 msgstr "Rychlost"
 
-#: src/gui/screen_menu_lan_settings.cpp:277
+#: src/gui/screen_menu_lan_settings.cpp:279
 msgid "Static IPv4 addresses were not set."
 msgstr "Statické IPv4 adresy nenastaveny."
 
-#: src/guiapi/include/MItem_menus.hpp:49
-msgid "Statistic"
-msgstr "Statistika"
+#: src/gui/screen_menu_odometer.cpp:15
+msgid "STATISTICS"
+msgstr "STATISTIKY"
+
+#: src/guiapi/include/MItem_menus.hpp:29
+msgid "Statistics"
+msgstr "Statistiky"
 
 #: src/gui/screen_menu_steel_sheets.cpp:176 src/gui/screen_menu_hw_setup.cpp:16
 msgid "Steel Sheets"
 msgstr "Tiskové pláty"
 
 #. Retry
-#: src/gui/dialogs/dialog_response.cpp:24
+#: src/common/client_response_texts.cpp:34
 msgid "STOP"
 msgstr "STOP"
 
-#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:40
+#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:41
 msgid "Stop"
 msgstr "Stop"
 
@@ -882,11 +948,11 @@ msgstr "Stop"
 msgid "Sun"
 msgstr "Ne"
 
-#: src/guiapi/include/MItem_menus.hpp:69
+#: src/guiapi/include/MItem_menus.hpp:79
 msgid "Support"
 msgstr "Podpora"
 
-#: src/guiapi/include/MItem_menus.hpp:39
+#: src/guiapi/include/MItem_menus.hpp:49
 msgid "System Info"
 msgstr "Systém. info"
 
@@ -894,11 +960,11 @@ msgstr "Systém. info"
 msgid "TEMPERATURE"
 msgstr "TEPLOTA"
 
-#: src/guiapi/include/MItem_menus.hpp:79
+#: src/guiapi/include/MItem_menus.hpp:89
 msgid "Temperature"
 msgstr "Teplota"
 
-#: src/guiapi/include/MItem_menus.hpp:109
+#: src/guiapi/include/MItem_menus.hpp:119
 msgid "Test"
 msgstr "Test"
 
@@ -915,7 +981,7 @@ msgid "Test XYZ-Axis"
 msgstr "Test os XYZ"
 
 #. save eeprom flag
-#: src/gui/wizard/firstlay.cpp:184
+#: src/gui/wizard/firstlay.cpp:189
 msgid "The first layer calibration failed to finish. Double-check the printer's wiring, nozzle and axes, then restart the calibration."
 msgstr "Selhala kalibrace první vrstvy. Zkontrolujte zapojení el. částí tiskárny, trysku a jednotlivé osy, pak restartujte kalibraci."
 
@@ -923,19 +989,31 @@ msgstr "Selhala kalibrace první vrstvy. Zkontrolujte zapojení el. částí tis
 msgid "The selftest failed to finish. Double-check the printer's wiring and axes. Then restart the Selftest."
 msgstr "Selftest selhal. Zkontrolujte zapojení el. částí i všechny osy. Pak Selftest spusťte znovu."
 
-#: src/gui/screen_menu_lan_settings.cpp:283
+#: src/gui/screen_menu_lan_settings.cpp:285
 msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
 msgstr "Nastavení úspěšně uloženo do souboru \"lan_settings.ini\""
 
 #: src/gui/wizard/screen_wizard.cpp:170
-msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
-msgstr "Stavový řádek je ve spodní části LCD. Obsahuje informace o:\n- Teplotě trysky\n- Teplotě podložky\n- Rychlosti tisku\n- Výšce osy Z\n- Filamentu"
+msgid ""
+"The status bar is at the bottom of the screen. It contains information about:\n"
+"- Nozzle temp.\n"
+"- Heatbed temp.\n"
+"- Printing speed\n"
+"- Z-axis height\n"
+"- Selected filament"
+msgstr ""
+"Stavový řádek je ve spodní části LCD. Obsahuje informace o:\n"
+"- Teplotě trysky\n"
+"- Teplotě podložky\n"
+"- Rychlosti tisku\n"
+"- Výšce osy Z\n"
+"- Filamentu"
 
 #: src/gui/wizard/xyzcalib.cpp:298
 msgid "The XYZ calibration failed to finish. Double-check the printer's wiring and axes, then restart the XYZ calibration."
 msgstr "Selhala kalibrace os XYZ. Zkontrolujte zapojení el. součástí i jednotlivé osy, pak restartuje kalibraci XYZ."
 
-#: src/gui/screen_menu_lan_settings.cpp:286
+#: src/gui/screen_menu_lan_settings.cpp:288
 msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
 msgstr "Při ukládání souboru \"lan_settings.ini\" došlo k chybě."
 
@@ -943,9 +1021,9 @@ msgstr "Při ukládání souboru \"lan_settings.ini\" došlo k chybě."
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:54
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:60
 msgid "THERMAL RUNAWAY"
-msgstr "THERMAL RUNAWAY"
+msgstr "THERMAL RUNAWAY (Ztráta teploty)"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26
 msgid "This G-CODE was set up for another printer type."
 msgstr "Tento G-CODE je určen pro jiný typ tiskárny."
 
@@ -985,20 +1063,20 @@ msgstr "Út"
 msgid "TUNE"
 msgstr "LADIT"
 
-#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:37
+#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:38
 msgid "Tune"
 msgstr "Ladit"
 
 #. Stop
-#: src/gui/dialogs/dialog_response.cpp:25
+#: src/common/client_response_texts.cpp:35
 msgid "UNLOAD"
 msgstr "VYJM."
 
-#: src/gui/dialogs/DialogFactory.cpp:14 src/gui/screen_menu_filament.cpp:72
+#: src/gui/dialogs/DialogFactory.cpp:10 src/gui/screen_menu_filament.cpp:57
 msgid "UNLOAD FILAMENT"
 msgstr "VYJMOUT FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:71
+#: src/gui/screen_menu_filament.cpp:56
 msgid "Unload Filament"
 msgstr "Vyjmout filament"
 
@@ -1014,11 +1092,11 @@ msgstr "Odparkování"
 msgid "USB drive error, the print is now paused. Reconnect the drive."
 msgstr "Chyba USB úložiště. Tisk pozastaven. Disk vyjměte a znovu vložte."
 
-#: src/gui/screen_print_preview.cpp:129
+#: src/gui/gcode_description.cpp:38
 msgid "Used Filament"
 msgstr "Množství filamentu"
 
-#: src/gui/screen_menu_version_info.cpp:31
+#: src/gui/version_info_ST7789V.cpp:27
 msgid "VERSION INFO"
 msgstr "INFO O VERZI"
 
@@ -1034,7 +1112,7 @@ msgstr "Nastavování provozních teplot"
 msgid "Warning"
 msgstr "Varování"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26 src/gui/screen_print_preview.cpp:113
 msgid "WARNING:"
 msgstr "VAROVÁNÍ:"
 
@@ -1064,7 +1142,7 @@ msgid "WIZARD - OK"
 msgstr "PRŮVODCE - OK"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:43
-#: src/gui/dialogs/DialogSelftestAxis.cpp:19
+#: src/gui/dialogs/DialogSelftestAxis.cpp:25
 msgid "X-axis"
 msgstr "Osa X"
 
@@ -1073,12 +1151,12 @@ msgid "XYZ CALIBRATION"
 msgstr "KALIBRACE XYZ"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:44
-#: src/gui/dialogs/DialogSelftestAxis.cpp:20
+#: src/gui/dialogs/DialogSelftestAxis.cpp:26
 msgid "Y-axis"
 msgstr "Osa Y"
 
 #. Unload
-#: src/gui/dialogs/dialog_response.cpp:26
+#: src/common/client_response_texts.cpp:36
 msgid "YES"
 msgstr "ANO"
 
@@ -1087,6 +1165,6 @@ msgid "Z height:"
 msgstr "Výška Z:"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:45
-#: src/gui/dialogs/DialogSelftestAxis.cpp:21
+#: src/gui/dialogs/DialogSelftestAxis.cpp:27
 msgid "Z-axis"
 msgstr "Osa Z"

--- a/src/lang/po/de/Prusa-Firmware-Buddy_de.po
+++ b/src/lang/po/de/Prusa-Firmware-Buddy_de.po
@@ -5,27 +5,41 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
+"X-Generator: Phrase (phrase.com)\n"
 
 #. c=20 r=4
-#: src/gui/screen_menu_version_info.cpp:82
+#: src/gui/version_info_ST7789V.cpp:102
 #, c-format
-msgid "\nBootloader Version\n%d.%d.%d\n\nBuddy Board\n%d.%d.%d\n%s"
-msgstr "\nBootloader Version\n %d.%d.%d\n\nBuddy Board\n%d.%d.%d\n%s"
+msgid ""
+"\n"
+"Bootloader Version\n"
+"%d.%d.%d\n"
+"\n"
+"Buddy Board\n"
+"%d.%d.%d\n"
+"%s"
+msgstr ""
+"\n"
+"Bootloader Version\n"
+" %d.%d.%d\n"
+"\n"
+"Buddy Board\n"
+"%d.%d.%d\n"
+"%s"
 
 #: src/guiapi/src/MItem_tools.cpp:200
 msgid "A crash dump report (file dump.bin) has been saved to the USB drive."
 msgstr "Ein Crash-Dump-Bericht (Datei dump.bin) wurde auf dem USB-Laufwerk gespeichert."
 
 #. _none
-#: src/gui/dialogs/dialog_response.cpp:11
+#: src/common/client_response_texts.cpp:11
 msgid "ABORT"
 msgstr "Abbruch"
 
 #. / title text
-#: src/gui/dialogs/liveadjust_z.cpp:205
+#: src/gui/dialogs/liveadjust_z.cpp:207
 msgid "Adjust the nozzle height above the heatbed by turning the knob"
-msgstr "Stellen Sie die Düsenhöhe zum Heiz- bett durch drehen des Knopfes ein"
+msgstr "Stellen Sie die Düsenhöhe über dem Heizbett durch Drehen des Knopfes ein"
 
 #: src/gui/wizard/selftest.cpp:43
 msgid "All tests finished successfully!"
@@ -35,7 +49,7 @@ msgstr "Alle Tests erfolgreich abgeschlossen!"
 msgid "Always"
 msgstr "Immer"
 
-#: src/gui/screen_printing.cpp:103
+#: src/gui/screen_printing.cpp:104
 msgid "Are you sure to stop this printing?"
 msgstr "Druck wirklich beenden?"
 
@@ -48,15 +62,17 @@ msgid "Auto Home"
 msgstr "Auto Home"
 
 #. Abort
-#: src/gui/dialogs/dialog_response.cpp:12
+#. ABS filament, do not translate
+#. ASA filament, do not translate
+#: src/common/client_response_texts.cpp:14
 msgid "BACK"
 msgstr "zurück"
 
-#: src/gui/screen_print_preview.cpp:189
+#: src/gui/screen_print_preview.cpp:68
 msgid "Back"
 msgstr "zurück"
 
-#: src/gui/screen_printing.cpp:205
+#: src/gui/screen_printing.cpp:208
 msgid "Bed leveling failed. Try again?"
 msgstr "Bettnivellierung fehlgeschlagen. Nochmals versuchen?"
 
@@ -64,7 +80,7 @@ msgstr "Bettnivellierung fehlgeschlagen. Nochmals versuchen?"
 msgid "Calibrating Z"
 msgstr "Kalibriere Z"
 
-#: src/gui/screen_home.cpp:36
+#: src/gui/screen_home.cpp:37
 msgid "Calibration"
 msgstr "Kalibrieren"
 
@@ -74,55 +90,57 @@ msgstr "Kalibrieren"
 
 #: src/gui/wizard/screen_wizard.cpp:192
 msgid "Calibration successful! Happy printing!"
-msgstr "Kalibrierung erfolgreich!\nFrohes Drucken!"
+msgstr ""
+"Kalibrierung erfolgreich!\n"
+"Frohes Drucken!"
 
 #: src/gui/wizard/xyzcalib.cpp:230
 msgid "Calibration XY"
 msgstr "Kalibriere XY"
 
 #. Back
-#: src/gui/screen_sheet_rename.cpp:18 src/gui/dialogs/dialog_response.cpp:13
+#: src/common/client_response_texts.cpp:15 src/gui/screen_sheet_rename.cpp:18
 msgid "CANCEL"
 msgstr "Abbruch"
 
-#: src/gui/dialogs/DialogFactory.cpp:12 src/gui/screen_menu_filament.cpp:90
+#: src/gui/dialogs/DialogFactory.cpp:8 src/gui/screen_menu_filament.cpp:72
 msgid "CHANGE FILAMENT"
 msgstr "Filamentwechsel"
 
-#: src/gui/screen_menu_filament.cpp:89 src/guiapi/include/MItem_tools.hpp:279
+#: src/gui/screen_menu_filament.cpp:71 src/guiapi/include/MItem_tools.hpp:279
 msgid "Change Filament"
 msgstr "Filament wechseln"
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:44
 msgid "Check the heatbed heater & thermistor wiring for possible damage."
-msgstr "Die Verkabelung von Heizbettheizung und Thermistor auf mögliche Schäden prüfen."
+msgstr "Überprüfen Sie die Verdrahtung der Heizbettheizung und des Thermistors auf mögliche Schäden."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:56
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:68
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:80
 msgid "Check the heatbed thermistor wiring for possible damage."
-msgstr "Die Verkabelung des Heizbettthermistors auf mögliche Schäden prüfen."
+msgstr "Überprüfen Sie die Verdrahtung des Heizbett-Thermistors auf mögliche Schäden."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:50
 msgid "Check the print head heater & thermistor wiring for possible damage."
-msgstr "Die Verkabelung der Druckkopfheizung und des Thermistors auf mögliche Schäden prüfen."
+msgstr "Überprüfen Sie die Verkabelung der Druckkopfheizung und des Thermistors auf mögliche Schäden."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:62
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:74
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:86
 msgid "Check the print head thermistor wiring for possible damage."
-msgstr "Die Verkabelung des Druckkopf-Thermistor auf mögliche Schäden prüfen."
+msgstr "Überprüfen Sie die Verkabelung des Druckkopf-Thermistors auf mögliche Schäden."
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:42
-#: src/gui/dialogs/DialogSelftestAxis.cpp:18
+#: src/gui/dialogs/DialogSelftestAxis.cpp:24
 msgid "Checking axes"
 msgstr "Prüfe Achsen"
 
-#: src/gui/wizard/firstlay.cpp:168
+#: src/gui/wizard/firstlay.cpp:173
 msgid "Clean steel sheet."
 msgstr "Stahlblech reinigen."
 
@@ -130,12 +148,12 @@ msgstr "Stahlblech reinigen."
 msgid "Congratulations! XYZ calibration is ok. XY axes are perpendicular."
 msgstr "Glückwunsch! Die XYZ-Kalibrierung ist in Ordnung. XY-Achsen sind senkrecht."
 
-#. Cancel
-#: src/gui/dialogs/dialog_response.cpp:14
+#. Change
+#: src/common/client_response_texts.cpp:17
 msgid "CONTINUE"
 msgstr "weiter"
 
-#: src/common/filament.cpp:13 src/gui/screen_menu_temperature.cpp:12
+#: src/gui/screen_menu_temperature.cpp:12
 msgid "Cooldown"
 msgstr "Abkühlen"
 
@@ -143,16 +161,16 @@ msgstr "Abkühlen"
 msgid "CPU load"
 msgstr "CPU Auslastung"
 
-#: src/guiapi/include/MItem_menus.hpp:169
+#: src/guiapi/include/MItem_menus.hpp:179
 msgid "Current Profile"
 msgstr "Aktuelles Profil"
 
-#: src/guiapi/include/MItem_menus.hpp:192
+#: src/guiapi/include/MItem_menus.hpp:202
 msgid "Device hash in QR"
 msgstr "Gerätehash in QR"
 
-#. Continue
-#: src/gui/dialogs/dialog_response.cpp:15
+#. Cooldown
+#: src/common/client_response_texts.cpp:19
 msgid "DISABLE SENSOR"
 msgstr "Sensor aus"
 
@@ -160,25 +178,33 @@ msgstr "Sensor aus"
 msgid "Disable Steppers"
 msgstr "Motoren ausschalten"
 
-#: src/gui/screen_printing_serial.hpp:10
+#: src/gui/screen_printing_serial.hpp:11
 msgid "Disconnect"
 msgstr "Trennen"
 
-#: src/gui/wizard/firstlay.cpp:160
+#: src/gui/wizard/firstlay.cpp:165
 msgid "Do you want to repeat the last step and readjust the distance between the nozzle and heatbed?"
 msgstr "Möchten Sie den letzten Schritt wiederholen und den Abstand zwischen Düse und Heizbett neu einstellen?"
 
-#. c=20 r=6
-#: src/gui/wizard/firstlay.cpp:112
+#. c=21 r=9
+#: src/gui/wizard/firstlay.cpp:116
 #, c-format
-msgid "Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)"
-msgstr "Wollen Sie den aktuellen Wert verwenden?\nAktuell: %0.3f.\nStandard: %0.3f.\nKlicken Sie auf NEIN, um den Standardwert zu verwenden (empfohlen)"
+msgid ""
+"Do you want to use the current value?\n"
+"Current: %0.3f.\n"
+"Default: %0.3f.\n"
+"Click NO to use the default value (recommended)"
+msgstr ""
+"Wollen Sie den aktuellen Wert verwenden?\n"
+"Aktuell: %0.3f.\n"
+"Standard: %0.3f.\n"
+"Klicken Sie auf NEIN, um den Standardwert zu verwenden (empfohlen)"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:27
+#: src/gui/dialogs/DialogLoadUnload.cpp:28
 msgid "Ejecting"
 msgstr "Auswerfen"
 
-#: src/guiapi/src/window_msgbox.cpp:150
+#: src/guiapi/src/window_msgbox.cpp:152
 msgid "Error"
 msgstr "Fehler"
 
@@ -202,11 +228,11 @@ msgstr "Werkeinstellung geladen. Das System wird neu gestartet."
 msgid "Factory Reset"
 msgstr "Werkseinstellung"
 
-#: src/guiapi/include/MItem_menus.hpp:59
+#: src/guiapi/include/MItem_menus.hpp:69
 msgid "Fail Stats"
 msgstr "Fehlerstat."
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:17
+#: src/gui/dialogs/DialogSelftestFans.cpp:18
 #: src/gui/dialogs/DialogSelftestResult.cpp:39
 msgid "Fan Test"
 msgstr "Lüftertest"
@@ -219,19 +245,22 @@ msgstr "Fan0 UPM"
 msgid "Fan1 RPM"
 msgstr "Fan1 UPM"
 
-#: src/gui/screen_menu_filament.cpp:127
+#: src/gui/screen_menu_filament.cpp:101
 msgid "FILAMENT"
 msgstr "Filament"
 
-#: src/gui/screen_home.cpp:35 src/guiapi/include/MItem_menus.hpp:29
+#. ItemBed
+#: src/gui/screen_menu_odometer.cpp:18
+#: src/gui/screen_menu_footer_settings.cpp:60 src/gui/screen_home.cpp:36
+#: src/guiapi/include/MItem_menus.hpp:39
 msgid "Filament"
 msgstr "Filament"
 
-#: src/gui/screen_menu_filament.cpp:53
+#: src/gui/screen_menu_filament.cpp:41
 msgid "Filament appears to be already loaded, are you sure you want to load it anyway?"
 msgstr "Das Filament scheint bereits geladen zu sein, sind Sie sicher, dass Sie es trotzdem laden wollen?"
 
-#: src/gui/screen_print_preview.cpp:223
+#: src/gui/screen_print_preview.cpp:95
 msgid "Filament not detected. Load filament now? Select NO to cancel, or IGNORE to disable the filament sensor and continue."
 msgstr "Filament nicht erkannt. Filament jetzt laden? Wählen Sie NEIN, um abzubrechen, oder IGNORIEREN, um den Filament-Sensor zu deaktivieren und fortzufahren."
 
@@ -246,7 +275,7 @@ msgid "Finishing buffered gcodes."
 msgstr "Beende gepufferten gcode."
 
 #. r=1 c=20
-#: src/gui/screen_menu_version_info.cpp:60
+#: src/gui/version_info_ST7789V.cpp:80
 msgid "Firmware Version\n"
 msgstr "Firmware Version\n"
 
@@ -268,11 +297,11 @@ msgstr "Flussfaktor"
 msgid "Fri"
 msgstr "Fr."
 
-#: src/gui/screen_menu_fw_update.cpp:70
+#: src/gui/screen_menu_fw_update.cpp:69
 msgid "FW UPDATE"
 msgstr "FW UPDATE"
 
-#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:119
+#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:129
 msgid "FW Update"
 msgstr "FW Update"
 
@@ -281,41 +310,45 @@ msgstr "FW Update"
 msgid "Heatbed"
 msgstr "Heizbett"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:25
+#: src/gui/dialogs/DialogSelftestTemp.cpp:26
 msgid "Heatbed heater check"
 msgstr "Heizbettheizung prüfen"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:27
+#: src/gui/dialogs/DialogSelftestTemp.cpp:28
 msgid "Heater testing"
 msgstr "Heizungsprüfung"
 
-#: src/gui/guimain.cpp:194
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:34
 msgid "Heating disabled due to 30 minutes of inactivity."
 msgstr "Heizung wegen 30 Minuten Inaktivität deaktiviert."
 
-#: src/gui/screen_printing.cpp:43
+#: src/gui/screen_printing.cpp:44
 msgid "Heating..."
 msgstr "Aufheizen..."
 
-#: src/gui/guimain.cpp:205
-msgid "Hi, this is your\nOriginal Prusa MINI."
-msgstr "Hallo, hier ist Ihr\nOriginal Prusa MINI."
+#: src/gui/guimain.cpp:228
+msgid ""
+"Hi, this is your\n"
+"Original Prusa MINI."
+msgstr ""
+"Hallo, hier ist Ihr\n"
+"Original Prusa MINI."
 
-#: src/gui/screen_home.cpp:68
+#: src/gui/screen_home.cpp:72
 msgid "HOME"
 msgstr "HOME"
 
 #. special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
 #. and will get a nice house-like icon
-#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:45
+#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:46
 msgid "Home"
 msgstr "Home"
 
-#: src/gui/dialogs/DialogFactory.cpp:40
+#: src/gui/dialogs/DialogFactory.cpp:53
 msgid "HOME TO MAX"
 msgstr "HOME TO MAX"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:18
+#: src/gui/dialogs/DialogSelftestFans.cpp:19
 #: src/gui/dialogs/DialogSelftestResult.cpp:40
 msgid "Hotend Fan"
 msgstr "Hotend Lüfter"
@@ -324,45 +357,48 @@ msgstr "Hotend Lüfter"
 msgid "Hotend fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "Lüfter am Hotend dreht sich nicht. Überprüfen Sie ihn auf mögliche Verschmutzungen und dann die Verkabelung."
 
-#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:159
+#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:169
 msgid "HW Setup"
 msgstr "HW Setup"
 
 #. Filament_removed
-#: src/gui/dialogs/dialog_response.cpp:16
+#. FLEX filament, do not translate
+#. HIPS filament, do not translate
+#: src/common/client_response_texts.cpp:22
 msgid "IGNORE"
 msgstr "ignorieren"
 
 #. static const char en_text[] = N_("Observe the pattern and turn the knob to adjust the nozzle height in real time. Extruded plastic must stick to the print surface.");
-#: src/gui/wizard/firstlay.cpp:128
+#: src/gui/wizard/firstlay.cpp:132
 msgid "In the next step, use the knob to adjust the nozzle height. Check the pictures in the handbook for reference."
 msgstr "Im nächsten Schritt, den Knopf verwenden, um die Höhe der Düse einzustellen. Siehe Bilder im Handbuch als Referenz."
 
-#: src/gui/screen_menu_info.cpp:20
+#: src/gui/screen_menu_info.cpp:19
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:31
 msgid "INFO"
 msgstr "Info"
 
-#: src/gui/screen_home.cpp:38
+#: src/gui/screen_home.cpp:39
 msgid "Info"
 msgstr "Info"
 
-#: src/guiapi/src/window_msgbox.cpp:172
+#: src/guiapi/src/window_msgbox.cpp:171
 msgid "Information"
 msgstr "Informationen"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:25
+#: src/gui/dialogs/DialogLoadUnload.cpp:26
 msgid "Inserting"
 msgstr "Einführen"
 
-#: src/gui/screen_menu_lan_settings.cpp:292
+#: src/gui/screen_menu_lan_settings.cpp:294
 msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
 msgstr "IP-Adressen oder Parameter sind nicht gültig oder die Datei \"lan_settings.ini\" befindet sich nicht im Stammverzeichnis des USB-Laufwerks."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:30
+#: src/gui/dialogs/DialogLoadUnload.cpp:31
 msgid "Is color correct?"
 msgstr "Farbe korrekt?"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:26
+#: src/gui/dialogs/DialogLoadUnload.cpp:27
 msgid "Is filament in extruder gear?"
 msgstr "Filament im Extruder Antrieb? "
 
@@ -370,15 +406,15 @@ msgstr "Filament im Extruder Antrieb? "
 msgid "Is steel sheet on heatbed?"
 msgstr "Ist Stahlblech auf dem Heizbett?"
 
-#: src/gui/screen_menu_lan_settings.cpp:221
+#: src/gui/screen_menu_lan_settings.cpp:217
 msgid "LAN SETTINGS"
 msgstr "LAN Einstellungen"
 
-#: src/guiapi/include/MItem_menus.hpp:129
+#: src/guiapi/include/MItem_menus.hpp:139
 msgid "Lan Settings"
 msgstr "LAN Einstellungen"
 
-#: src/guiapi/include/MItem_menus.hpp:149
+#: src/guiapi/include/MItem_menus.hpp:159
 msgid "Language"
 msgstr "Sprache"
 
@@ -391,15 +427,15 @@ msgid "Live Adjust Z"
 msgstr "Live Z Anpassen"
 
 #. Ignore
-#: src/gui/dialogs/dialog_response.cpp:17
+#: src/common/client_response_texts.cpp:23
 msgid "LOAD"
 msgstr "Laden"
 
-#: src/gui/dialogs/DialogFactory.cpp:13 src/gui/screen_menu_filament.cpp:52
+#: src/gui/dialogs/DialogFactory.cpp:9
 msgid "LOAD FILAMENT"
 msgstr "Filament laden"
 
-#: src/gui/screen_menu_filament.cpp:51
+#: src/gui/screen_menu_filament.cpp:40
 msgid "Load Filament"
 msgstr "Filament laden"
 
@@ -407,11 +443,11 @@ msgstr "Filament laden"
 msgid "Load Settings"
 msgstr "Ladeeinstellungen"
 
-#: src/gui/screen_splash.cpp:43
+#: src/gui/screen_splash.cpp:38
 msgid "Loading ..."
 msgstr "Lade ..."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:28
+#: src/gui/dialogs/DialogLoadUnload.cpp:29
 msgid "Loading to nozzle"
 msgstr "Zur Düse laden"
 
@@ -423,11 +459,11 @@ msgstr "Laut"
 msgid "M.I.N.D.A."
 msgstr "M.I.N.D.A."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:24
+#: src/gui/dialogs/DialogLoadUnload.cpp:25
 msgid "Make sure the filament is inserted through the sensor."
 msgstr "Sicherstellen, dass das Filament durch den Sensor  geführt wird."
 
-#: src/gui/screen_print_preview.cpp:128
+#: src/gui/gcode_description.cpp:37
 msgid "Material"
 msgstr "Material"
 
@@ -438,8 +474,14 @@ msgid "MAXTEMP ERROR"
 msgstr "MAXTEMP FEHLER"
 
 #: src/gui/wizard/xyzcalib.cpp:192
-msgid "Measuring reference\nheight of calib.\npoints"
-msgstr "Messe Referenz-\nHöhe der Kalibr.\nPunkte"
+msgid ""
+"Measuring reference\n"
+"height of calib.\n"
+"points"
+msgstr ""
+"Messe Referenz-\n"
+"Höhe der Kalibr.\n"
+"Punkte"
 
 #: src/guiapi/include/MItem_tools.hpp:289
 msgid "Menu Timeout"
@@ -458,7 +500,7 @@ msgstr "BETTNIVELLIEREN"
 msgid "MESSAGES"
 msgstr "MELDUNGEN"
 
-#: src/guiapi/include/MItem_menus.hpp:139
+#: src/guiapi/include/MItem_menus.hpp:149
 msgid "Messages"
 msgstr "Meldungen"
 
@@ -473,7 +515,7 @@ msgstr "MINTEMP FEHLER"
 msgid "Mon"
 msgstr "Mo."
 
-#: src/guiapi/include/MItem_menus.hpp:89
+#: src/guiapi/include/MItem_menus.hpp:99
 msgid "Move Axis"
 msgstr "Achsen Bewegen"
 
@@ -502,12 +544,12 @@ msgid "Name"
 msgstr "Name"
 
 #. Load
-#: src/gui/dialogs/dialog_response.cpp:18
+#: src/common/client_response_texts.cpp:24
 msgid "NEXT"
 msgstr "Weiter"
 
 #. Next
-#: src/gui/dialogs/dialog_response.cpp:19
+#: src/common/client_response_texts.cpp:25
 msgid "NO"
 msgstr "Nein"
 
@@ -515,14 +557,15 @@ msgstr "Nein"
 msgid "No filament sensor detected. Verify that the sensor is connected and try again."
 msgstr "Kein Filamentsensor erkannt. Überprüfen Sie, ob der Sensor angeschlossen ist, und versuchen Sie es erneut."
 
-#: src/gui/screen_home.cpp:39
+#: src/gui/screen_home.cpp:40
 msgid "No USB"
 msgstr "Kein USB"
 
-#: src/gui/wizard/firstlay.cpp:98
+#: src/gui/wizard/firstlay.cpp:102
 msgid "Now, let's calibrate the distance between the tip of the nozzle and the print sheet."
 msgstr "Jetzt kalibrieren wir die Entfernung zwischen der Spitze der Düse und dem Druckblech."
 
+#: src/gui/screen_menu_footer_settings.cpp:58
 #: src/gui/dialogs/DialogSelftestResult.cpp:47
 #: src/guiapi/include/MItem_print.hpp:8
 msgid "Nozzle"
@@ -532,17 +575,18 @@ msgstr "Düse"
 msgid "Nozzle and Heatbed"
 msgstr "Düse und Heizbett"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:24
+#: src/gui/dialogs/DialogSelftestTemp.cpp:25
 msgid "Nozzle heater check"
 msgstr "Düsenheizung prüfen"
 
 #: src/gui/screen_menu_fw_update.cpp:28
 #: src/guiapi/include/WindowMenuItems.hpp:19
+#: src/guiapi/include/WindowMenuSpin.hpp:21
 msgid "Off"
 msgstr "Aus"
 
 #. No
-#: src/gui/screen_sheet_rename.cpp:17 src/gui/dialogs/dialog_response.cpp:20
+#: src/common/client_response_texts.cpp:26 src/gui/screen_sheet_rename.cpp:17
 msgid "OK"
 msgstr "OK"
 
@@ -560,17 +604,17 @@ msgstr "Einmal"
 
 #: src/gui/ScreenFirstLayer.hpp:14
 msgid "Once the printer starts extruding plastic, adjust the nozzle height by turning the knob until the filament sticks to the print sheet."
-msgstr "Sobald der Drucker beginnt, Kunststoff zu extrudieren, die Höhe der Düse durch Knopfdrehen einstellen, bis Filament am Druckblech haftet."
+msgstr "Sobald der Kunststoff zu extrudieren beginnt, ändern Sie die Düsenhöhe durch Drehen des Knopfes, bis das Filament am Druckblech haftet."
 
 #: src/gui/dialogs/DialogG162.cpp:9 src/gui/dialogs/DialogLoadUnload.cpp:15
 msgid "Parking"
 msgstr "Parke"
 
-#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:38
+#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:39
 msgid "Pause"
 msgstr "Pause"
 
-#: src/gui/screen_printing.cpp:39
+#: src/gui/screen_printing.cpp:40
 msgid "Pausing..."
 msgstr "Pausiert..."
 
@@ -582,15 +626,27 @@ msgstr "Legen Sie während der Kalibrierung der ersten 4 Punkte ein Blatt Papier
 msgid "Please clean the nozzle for calibration. Click NEXT when done."
 msgstr "Bitte reinigen Sie die Düse zur Kalibrierung. Klicken Sie auf WEITER, wenn Sie fertig sind."
 
-#: src/gui/screen_menu_lan_settings.cpp:280
+#: src/gui/screen_menu_lan_settings.cpp:282
 msgid "Please insert a USB drive and try again."
 msgstr "Bitte schließen Sie ein USB-Laufwerk an und versuchen Sie es erneut."
 
-#: src/gui/guimain.cpp:206
-msgid "Please insert the USB\ndrive that came with\nyour MINI and reset\nthe printer to flash\nthe firmware"
-msgstr "Bitte schließen Sie den USB-Stick an, der mit Ihrem MINI geliefert wurde und resetten den Drucker zum Firmwareflashen"
+#: src/gui/guimain.cpp:229
+msgid ""
+"Please insert the USB\n"
+"drive that came with\n"
+"your MINI and reset\n"
+"the printer to flash\n"
+"the firmware"
+msgstr ""
+"Bitte stecken Sie den\n"
+"USB-Stick, den Sie\n"
+"mit Ihrem MINI er-\n"
+"halten haben und\n"
+"setzen Sie den Drucker\n"
+"zurück, um die Firm-\n"
+"ware zu flashen."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:22
+#: src/gui/dialogs/DialogLoadUnload.cpp:23
 msgid "Please open idler and remove filament manually"
 msgstr "Bitte Leerlaufrad öffnen und Filament manuell entfernen"
 
@@ -606,11 +662,11 @@ msgstr "Bitte entfernen Sie Stahlblech vom Heizbett."
 msgid "Please wait"
 msgstr "Bitte warten"
 
-#: src/gui/screen_menu_preheat.cpp:25 src/gui/screen_menu_preheat.cpp:47
+#: src/gui/screen_menu_preheat.cpp:26 src/gui/screen_menu_preheat.cpp:49
 msgid "PREHEAT"
 msgstr "VORHEIZEN"
 
-#: src/gui/screen_home.cpp:34
+#: src/gui/screen_home.cpp:35
 msgid "Preheat"
 msgstr "Vorheizen"
 
@@ -618,19 +674,17 @@ msgstr "Vorheizen"
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:42
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:48
 msgid "PREHEAT ERROR"
-msgstr "Vorheizfehler"
+msgstr "VORHEIZFEHLER"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:34
+#: src/gui/dialogs/DialogFactory.cpp:12
 msgid "PREHEAT for LOAD"
 msgstr "VORHEIZEN zum LADEN"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:54
+#: src/gui/dialogs/DialogFactory.cpp:13
 msgid "PREHEAT for UNLOAD"
 msgstr "VORHEIZEN zum ENTLADEN"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:26
+#: src/gui/dialogs/DialogSelftestTemp.cpp:27
 msgid "Preparing"
 msgstr "Vorbereiten"
 
@@ -638,7 +692,7 @@ msgstr "Vorbereiten"
 msgid "Preparing to ram"
 msgstr "Bereite Rammen vor"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:23
+#: src/gui/dialogs/DialogLoadUnload.cpp:24
 msgid "Press CONTINUE and push filament into the extruder."
 msgstr "WEITER drücken und Filament in den Extruder schieben."
 
@@ -646,11 +700,11 @@ msgstr "WEITER drücken und Filament in den Extruder schieben."
 msgid "Press NEXT to run the Selftest, which checks for potential issues related to the assembly."
 msgstr "WEITER drücken, um den Selbsttest auszuführen, der potenzielle Probleme der Montage prüft."
 
-#: src/gui/screen_print_preview.cpp:185 src/gui/screen_home.cpp:33
+#: src/gui/screen_print_preview.cpp:64 src/gui/screen_home.cpp:34
 msgid "Print"
 msgstr "Drucken"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:19
+#: src/gui/dialogs/DialogSelftestFans.cpp:20
 #: src/gui/dialogs/DialogSelftestResult.cpp:41
 #: src/guiapi/include/MItem_print.hpp:24
 msgid "Print Fan"
@@ -660,42 +714,46 @@ msgstr "Drucklüfter"
 msgid "Print fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "Drucklüfter dreht sich nicht. Überprüfen Sie ihn auf mögliche Verschmutzungen und dann die Verkabelung."
 
-#: src/gui/screen_print_preview.cpp:127
+#: src/gui/gcode_description.cpp:36
 msgid "Print Time"
 msgstr "Druckzeit"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #. theoretically it can be removed completely in case the string is constant for the whole run of the screen
-#: src/gui/screen_printing.cpp:222
+#: src/gui/screen_printing.cpp:244
 msgid "Print will end"
 msgstr "Druckende"
 
-#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:360
+#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:370
 msgid "PRINTING"
 msgstr "DRUCKEN"
 
-#: src/gui/screen_printing.cpp:158
+#: src/gui/screen_printing.cpp:160
 msgid "Printing time"
 msgstr "Druckzeit"
 
-#: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
+#: src/gui/dialogs/DialogFactory.cpp:11 src/gui/screen_menu_filament.cpp:87
 msgid "PURGE FILAMENT"
 msgstr "FILAMENT REINIGEN"
 
-#: src/gui/screen_menu_filament.cpp:109
+#: src/gui/screen_menu_filament.cpp:86
 msgid "Purge Filament"
 msgstr "Filament reinigen"
 
 #. Ok
-#: src/gui/dialogs/dialog_response.cpp:21
+#. PC filament, do not translate
+#. PETG filament, do not translate
+#. PLA filament, do not translate
+#. PP filament, do not translate
+#: src/common/client_response_texts.cpp:31
 msgid "PURGE MORE"
 msgstr "MEHR REINIGEN"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:29
+#: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Purging"
 msgstr "Reinigen"
 
-#: src/guiapi/src/window_msgbox.cpp:156
+#: src/guiapi/src/window_msgbox.cpp:157
 msgid "Question"
 msgstr "Frage"
 
@@ -703,18 +761,18 @@ msgstr "Frage"
 msgid "Ramming"
 msgstr "Ramme"
 
-#: src/gui/screen_printing_serial.cpp:45
+#: src/gui/screen_printing_serial.cpp:43
 msgid "Really Disconnect?"
 msgstr "Wirklich Trennen?"
 
 #. Purge_more
-#: src/gui/dialogs/dialog_response.cpp:22
+#: src/common/client_response_texts.cpp:32
 msgid "REHEAT"
 msgstr "erneut Heizen"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
-#: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
-#: src/gui/screen_printing.cpp:355
+#: src/gui/screen_printing.cpp:149 src/gui/screen_printing.cpp:248
+#: src/gui/screen_printing.cpp:365
 msgid "Remaining Time"
 msgstr "Restzeit"
 
@@ -726,7 +784,7 @@ msgstr "UMBENENNEN"
 msgid "Rename"
 msgstr "Ubenennen"
 
-#: src/gui/screen_printing.cpp:44
+#: src/gui/screen_printing.cpp:45
 msgid "Reprint"
 msgstr "Druck wiederholen"
 
@@ -734,23 +792,24 @@ msgstr "Druck wiederholen"
 msgid "Reset"
 msgstr "Reset"
 
-#: src/common/MindaRedscreen.cpp:175 src/gui/guimain.cpp:207
+#: src/common/MindaRedscreen.cpp:175
 msgid "RESET PRINTER"
 msgstr "Reset Drucker"
 
-#: src/gui/screen_printing.cpp:41
+#: src/gui/screen_printing.cpp:42
 msgid "Resume"
 msgstr "Fortsetzen"
 
-#: src/gui/screen_printing.cpp:42
+#: src/gui/screen_printing.cpp:43
 msgid "Resuming..."
 msgstr "Fortfahren..."
 
 #. Reheat
-#: src/gui/dialogs/dialog_response.cpp:23
+#: src/common/client_response_texts.cpp:33
 msgid "RETRY"
 msgstr "Wiederholen"
 
+#: src/gui/dialogs/window_dlg_preheat.hpp:39
 #: src/guiapi/include/WindowMenuItems.hpp:54
 msgid "Return"
 msgstr "Zurück"
@@ -769,8 +828,12 @@ msgid "Save Settings"
 msgstr "Einstellung sichern"
 
 #: src/gui/wizard/xyzcalib.cpp:180
-msgid "Searching bed\ncalibration points"
-msgstr "Suche Bett-\nKalibrierpunkte"
+msgid ""
+"Searching bed\n"
+"calibration points"
+msgstr ""
+"Suche Bett-\n"
+"Kalibrierpunkte"
 
 #: src/gui/screen_menu_steel_sheets.cpp:33
 msgid "Select"
@@ -778,9 +841,9 @@ msgstr "Wählen"
 
 #: src/gui/wizard/firstlay.cpp:71
 msgid "Select Filament Type"
-msgstr "Filamenttyp wählen"
+msgstr "Filament Typ wählen"
 
-#: src/gui/screen_filebrowser.cpp:42
+#: src/gui/screen_filebrowser.cpp:43
 msgid "SELECT FILE"
 msgstr "Datei wählen"
 
@@ -788,7 +851,7 @@ msgstr "Datei wählen"
 msgid "SELECT LANGUAGE"
 msgstr "Sprache wählen"
 
-#: src/gui/screen_menu_fw_update.cpp:74
+#: src/gui/screen_menu_fw_update.cpp:96
 msgid "Select when you want to automatically flash updated firmware from USB flash disk."
 msgstr "Aktivieren, wenn Sie automatisch aktualisierte Firmware von einem USB-Stick installieren möchten."
 
@@ -808,23 +871,24 @@ msgstr "SENSOR INFO"
 msgid "Sensor Info"
 msgstr "Sensor Info"
 
-#: src/gui/screen_printing_serial.hpp:13
+#. filament sensor will think printer is in printing state
+#: src/gui/screen_printing_serial.hpp:15
 msgid "SERIAL PRINTING"
 msgstr "SERIELLE SCHNITTSTELLE"
 
-#: src/guiapi/include/MItem_menus.hpp:99
+#: src/guiapi/include/MItem_menus.hpp:109
 msgid "Service"
 msgstr "Service"
 
-#: src/gui/screen_home.cpp:37
+#: src/gui/screen_home.cpp:38
 msgid "Settings"
 msgstr "Einstellen"
 
-#: src/gui/screen_menu_settings.cpp:107
+#: src/gui/screen_menu_settings.cpp:108
 msgid "SETTINGS"
 msgstr "Einstellen"
 
-#: src/gui/screen_menu_lan_settings.cpp:289
+#: src/gui/screen_menu_lan_settings.cpp:291
 msgid "Settings successfully loaded"
 msgstr "Einstellungen erfolgreich geladen"
 
@@ -852,28 +916,34 @@ msgstr "Ton Modus"
 msgid "Sound Volume"
 msgstr "Lautstärke"
 
+#. ItemFilament
+#: src/gui/screen_menu_footer_settings.cpp:61
 #: src/guiapi/include/MItem_print.hpp:32
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
-#: src/gui/screen_menu_lan_settings.cpp:277
+#: src/gui/screen_menu_lan_settings.cpp:279
 msgid "Static IPv4 addresses were not set."
 msgstr "Statische IPv4-Adressen wurden nicht festgelegt."
 
-#: src/guiapi/include/MItem_menus.hpp:49
-msgid "Statistic"
-msgstr "Statistik"
+#: src/gui/screen_menu_odometer.cpp:15
+msgid "STATISTICS"
+msgstr "STASTISTIK"
+
+#: src/guiapi/include/MItem_menus.hpp:29
+msgid "Statistics"
+msgstr "Statistiken "
 
 #: src/gui/screen_menu_steel_sheets.cpp:176 src/gui/screen_menu_hw_setup.cpp:16
 msgid "Steel Sheets"
 msgstr "Stahlbleche"
 
 #. Retry
-#: src/gui/dialogs/dialog_response.cpp:24
+#: src/common/client_response_texts.cpp:34
 msgid "STOP"
 msgstr "STOP"
 
-#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:40
+#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:41
 msgid "Stop"
 msgstr "Stop"
 
@@ -882,11 +952,11 @@ msgstr "Stop"
 msgid "Sun"
 msgstr "So."
 
-#: src/guiapi/include/MItem_menus.hpp:69
+#: src/guiapi/include/MItem_menus.hpp:79
 msgid "Support"
 msgstr "Support"
 
-#: src/guiapi/include/MItem_menus.hpp:39
+#: src/guiapi/include/MItem_menus.hpp:49
 msgid "System Info"
 msgstr "System Info"
 
@@ -894,11 +964,11 @@ msgstr "System Info"
 msgid "TEMPERATURE"
 msgstr "Temperatur"
 
-#: src/guiapi/include/MItem_menus.hpp:79
+#: src/guiapi/include/MItem_menus.hpp:89
 msgid "Temperature"
 msgstr "Temperatur"
 
-#: src/guiapi/include/MItem_menus.hpp:109
+#: src/guiapi/include/MItem_menus.hpp:119
 msgid "Test"
 msgstr "Test"
 
@@ -915,7 +985,7 @@ msgid "Test XYZ-Axis"
 msgstr "Test XYZ-Achse"
 
 #. save eeprom flag
-#: src/gui/wizard/firstlay.cpp:184
+#: src/gui/wizard/firstlay.cpp:189
 msgid "The first layer calibration failed to finish. Double-check the printer's wiring, nozzle and axes, then restart the calibration."
 msgstr "Die Kalibrierung der ersten Schicht konnte nicht abgeschlossen werden. Bitte Verkabelung, Düse und Achsen des Druckers überprüfen und starten Sie dann die Kalibrierung erneut."
 
@@ -923,19 +993,31 @@ msgstr "Die Kalibrierung der ersten Schicht konnte nicht abgeschlossen werden. B
 msgid "The selftest failed to finish. Double-check the printer's wiring and axes. Then restart the Selftest."
 msgstr "Der Selbsttest wurde nicht beendet. Überprüfen Sie die Verkabelung und die Achsen des Druckers. Starten Sie dann den Selbsttest erneut."
 
-#: src/gui/screen_menu_lan_settings.cpp:283
+#: src/gui/screen_menu_lan_settings.cpp:285
 msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
 msgstr "Die Einstellungen wurden erfolgreich in der Datei \"lan_settings.ini\" gespeichert."
 
 #: src/gui/wizard/screen_wizard.cpp:170
-msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
-msgstr "Die Statusleiste am unteren Rand des Bildschirms enthält Informationen über:\n- Düsentemp.\n- Heizbett-Temp.\n- Drucktempo\n- Z-Achsenhöhe\n- Filamenttyp"
+msgid ""
+"The status bar is at the bottom of the screen. It contains information about:\n"
+"- Nozzle temp.\n"
+"- Heatbed temp.\n"
+"- Printing speed\n"
+"- Z-axis height\n"
+"- Selected filament"
+msgstr ""
+"Die Statusleiste am unteren Rand des Bildschirms enthält Informationen über:\n"
+"- Düsentemp.\n"
+"- Heizbett-Temp.\n"
+"- Drucktempo\n"
+"- Z-Achsenhöhe\n"
+"- Filamenttyp"
 
 #: src/gui/wizard/xyzcalib.cpp:298
 msgid "The XYZ calibration failed to finish. Double-check the printer's wiring and axes, then restart the XYZ calibration."
 msgstr "Die XYZ-Kalibrierung konnte nicht abgeschlossen werden. Bitte Verkabelung und Achsen des Druckers überprüfen und starten Sie dann die XYZ-Kalibrierung erneut."
 
-#: src/gui/screen_menu_lan_settings.cpp:286
+#: src/gui/screen_menu_lan_settings.cpp:288
 msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
 msgstr "Es gab einen Fehler beim Speichern der Einstellungen in der Datei \"lan_settings.ini\"."
 
@@ -945,14 +1027,22 @@ msgstr "Es gab einen Fehler beim Speichern der Einstellungen in der Datei \"lan_
 msgid "THERMAL RUNAWAY"
 msgstr "THERMAL RUNAWAY"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26
 msgid "This G-CODE was set up for another printer type."
 msgstr "Dieser G-Code ist für einen anderen Druckertyp."
 
 #. window_menu
 #: src/guiapi/src/MItem_tools.cpp:185
 msgid "This operation can't be undone, current configuration will be lost! Are you really sure to reset printer to factory defaults?"
-msgstr "Diese Operation kann nicht rückgängig ge- macht werden und die aktuelle Konfiguration geht verloren! Den Drucker auf die Werkseinstellungen zurücksetzen?"
+msgstr ""
+"Diese Operation kann\n"
+"nicht rückgängig ge-\n"
+"macht werden und die\n"
+"aktuelle Konfiguration\n"
+"geht verloren!\n"
+"Den Drucker auf die\n"
+"Werkseinstellungen\n"
+"zurücksetzen?"
 
 #. abbreviated Thursday - max 3 characters
 #: src/lang/format_print_will_end.cpp:51
@@ -985,20 +1075,20 @@ msgstr "Di."
 msgid "TUNE"
 msgstr "Tunen"
 
-#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:37
+#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:38
 msgid "Tune"
 msgstr "Tunen"
 
 #. Stop
-#: src/gui/dialogs/dialog_response.cpp:25
+#: src/common/client_response_texts.cpp:35
 msgid "UNLOAD"
 msgstr "Entladen"
 
-#: src/gui/dialogs/DialogFactory.cpp:14 src/gui/screen_menu_filament.cpp:72
+#: src/gui/dialogs/DialogFactory.cpp:10 src/gui/screen_menu_filament.cpp:57
 msgid "UNLOAD FILAMENT"
 msgstr "Filament entladen"
 
-#: src/gui/screen_menu_filament.cpp:71
+#: src/gui/screen_menu_filament.cpp:56
 msgid "Unload Filament"
 msgstr "Filament entladen"
 
@@ -1014,11 +1104,11 @@ msgstr "Entparke"
 msgid "USB drive error, the print is now paused. Reconnect the drive."
 msgstr "USB-Laufwerksfehler, der Druck ist jetzt angehalten. Schließen Sie das Laufwerk wieder an."
 
-#: src/gui/screen_print_preview.cpp:129
+#: src/gui/gcode_description.cpp:38
 msgid "Used Filament"
 msgstr "Genutztes Filament"
 
-#: src/gui/screen_menu_version_info.cpp:31
+#: src/gui/version_info_ST7789V.cpp:27
 msgid "VERSION INFO"
 msgstr "VERSION INFO"
 
@@ -1034,7 +1124,7 @@ msgstr "Warte auf Temperatur"
 msgid "Warning"
 msgstr "Warnung"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26 src/gui/screen_print_preview.cpp:113
 msgid "WARNING:"
 msgstr "WARNUNG:"
 
@@ -1064,7 +1154,7 @@ msgid "WIZARD - OK"
 msgstr "Assistent - OK"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:43
-#: src/gui/dialogs/DialogSelftestAxis.cpp:19
+#: src/gui/dialogs/DialogSelftestAxis.cpp:25
 msgid "X-axis"
 msgstr "X-Achse"
 
@@ -1073,12 +1163,12 @@ msgid "XYZ CALIBRATION"
 msgstr "XYZ KALIBRIERUNG"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:44
-#: src/gui/dialogs/DialogSelftestAxis.cpp:20
+#: src/gui/dialogs/DialogSelftestAxis.cpp:26
 msgid "Y-axis"
 msgstr "Y-Achse"
 
 #. Unload
-#: src/gui/dialogs/dialog_response.cpp:26
+#: src/common/client_response_texts.cpp:36
 msgid "YES"
 msgstr "Ja"
 
@@ -1087,6 +1177,6 @@ msgid "Z height:"
 msgstr "Z Höhe:"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:45
-#: src/gui/dialogs/DialogSelftestAxis.cpp:21
+#: src/gui/dialogs/DialogSelftestAxis.cpp:27
 msgid "Z-axis"
 msgstr "Z-Achse"

--- a/src/lang/po/en/Prusa-Firmware-Buddy_en.po
+++ b/src/lang/po/en/Prusa-Firmware-Buddy_en.po
@@ -5,25 +5,39 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
+"X-Generator: Phrase (phrase.com)\n"
 
 #. c=20 r=4
-#: src/gui/screen_menu_version_info.cpp:82
+#: src/gui/version_info_ST7789V.cpp:102
 #, c-format
-msgid "\nBootloader Version\n%d.%d.%d\n\nBuddy Board\n%d.%d.%d\n%s"
-msgstr "\nBootloader Version\n%d.%d.%d\n\nBuddy Board\n%d.%d.%d\n%s"
+msgid ""
+"\n"
+"Bootloader Version\n"
+"%d.%d.%d\n"
+"\n"
+"Buddy Board\n"
+"%d.%d.%d\n"
+"%s"
+msgstr ""
+"\n"
+"Bootloader Version\n"
+"%d.%d.%d\n"
+"\n"
+"Buddy Board\n"
+"%d.%d.%d\n"
+"%s"
 
 #: src/guiapi/src/MItem_tools.cpp:200
 msgid "A crash dump report (file dump.bin) has been saved to the USB drive."
 msgstr "A crash dump report (file dump.bin) has been saved to the USB drive."
 
 #. _none
-#: src/gui/dialogs/dialog_response.cpp:11
+#: src/common/client_response_texts.cpp:11
 msgid "ABORT"
 msgstr "ABORT"
 
 #. / title text
-#: src/gui/dialogs/liveadjust_z.cpp:205
+#: src/gui/dialogs/liveadjust_z.cpp:207
 msgid "Adjust the nozzle height above the heatbed by turning the knob"
 msgstr "Adjust the nozzle height above the heatbed by turning the knob"
 
@@ -35,7 +49,7 @@ msgstr "All tests finished successfully!"
 msgid "Always"
 msgstr "Always"
 
-#: src/gui/screen_printing.cpp:103
+#: src/gui/screen_printing.cpp:104
 msgid "Are you sure to stop this printing?"
 msgstr "Are you sure to stop this printing?"
 
@@ -48,15 +62,17 @@ msgid "Auto Home"
 msgstr "Auto Home"
 
 #. Abort
-#: src/gui/dialogs/dialog_response.cpp:12
+#. ABS filament, do not translate
+#. ASA filament, do not translate
+#: src/common/client_response_texts.cpp:14
 msgid "BACK"
 msgstr "BACK"
 
-#: src/gui/screen_print_preview.cpp:189
+#: src/gui/screen_print_preview.cpp:68
 msgid "Back"
 msgstr "Back"
 
-#: src/gui/screen_printing.cpp:205
+#: src/gui/screen_printing.cpp:208
 msgid "Bed leveling failed. Try again?"
 msgstr "Bed leveling failed. Try again?"
 
@@ -64,7 +80,7 @@ msgstr "Bed leveling failed. Try again?"
 msgid "Calibrating Z"
 msgstr "Calibrating Z"
 
-#: src/gui/screen_home.cpp:36
+#: src/gui/screen_home.cpp:37
 msgid "Calibration"
 msgstr "Calibration"
 
@@ -81,15 +97,15 @@ msgid "Calibration XY"
 msgstr "Calibration XY"
 
 #. Back
-#: src/gui/screen_sheet_rename.cpp:18 src/gui/dialogs/dialog_response.cpp:13
+#: src/common/client_response_texts.cpp:15 src/gui/screen_sheet_rename.cpp:18
 msgid "CANCEL"
 msgstr "CANCEL"
 
-#: src/gui/dialogs/DialogFactory.cpp:12 src/gui/screen_menu_filament.cpp:90
+#: src/gui/dialogs/DialogFactory.cpp:8 src/gui/screen_menu_filament.cpp:72
 msgid "CHANGE FILAMENT"
 msgstr "CHANGE FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:89 src/guiapi/include/MItem_tools.hpp:279
+#: src/gui/screen_menu_filament.cpp:71 src/guiapi/include/MItem_tools.hpp:279
 msgid "Change Filament"
 msgstr "Change Filament"
 
@@ -118,11 +134,11 @@ msgid "Check the print head thermistor wiring for possible damage."
 msgstr "Check the print head thermistor wiring for possible damage."
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:42
-#: src/gui/dialogs/DialogSelftestAxis.cpp:18
+#: src/gui/dialogs/DialogSelftestAxis.cpp:24
 msgid "Checking axes"
 msgstr "Checking axes"
 
-#: src/gui/wizard/firstlay.cpp:168
+#: src/gui/wizard/firstlay.cpp:173
 msgid "Clean steel sheet."
 msgstr "Clean steel sheet."
 
@@ -130,12 +146,12 @@ msgstr "Clean steel sheet."
 msgid "Congratulations! XYZ calibration is ok. XY axes are perpendicular."
 msgstr "Congratulations! XYZ calibration is ok. XY axes are perpendicular."
 
-#. Cancel
-#: src/gui/dialogs/dialog_response.cpp:14
+#. Change
+#: src/common/client_response_texts.cpp:17
 msgid "CONTINUE"
 msgstr "CONTINUE"
 
-#: src/common/filament.cpp:13 src/gui/screen_menu_temperature.cpp:12
+#: src/gui/screen_menu_temperature.cpp:12
 msgid "Cooldown"
 msgstr "Cooldown"
 
@@ -143,16 +159,16 @@ msgstr "Cooldown"
 msgid "CPU load"
 msgstr "CPU load"
 
-#: src/guiapi/include/MItem_menus.hpp:169
+#: src/guiapi/include/MItem_menus.hpp:179
 msgid "Current Profile"
 msgstr "Current Profile"
 
-#: src/guiapi/include/MItem_menus.hpp:192
+#: src/guiapi/include/MItem_menus.hpp:202
 msgid "Device hash in QR"
 msgstr "Device hash in QR"
 
-#. Continue
-#: src/gui/dialogs/dialog_response.cpp:15
+#. Cooldown
+#: src/common/client_response_texts.cpp:19
 msgid "DISABLE SENSOR"
 msgstr "DISABLE SENSOR"
 
@@ -160,25 +176,33 @@ msgstr "DISABLE SENSOR"
 msgid "Disable Steppers"
 msgstr "Disable Steppers"
 
-#: src/gui/screen_printing_serial.hpp:10
+#: src/gui/screen_printing_serial.hpp:11
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: src/gui/wizard/firstlay.cpp:160
+#: src/gui/wizard/firstlay.cpp:165
 msgid "Do you want to repeat the last step and readjust the distance between the nozzle and heatbed?"
 msgstr "Do you want to repeat the last step and readjust the distance between the nozzle and heatbed?"
 
-#. c=20 r=6
-#: src/gui/wizard/firstlay.cpp:112
+#. c=21 r=9
+#: src/gui/wizard/firstlay.cpp:116
 #, c-format
-msgid "Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)"
-msgstr "Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)"
+msgid ""
+"Do you want to use the current value?\n"
+"Current: %0.3f.\n"
+"Default: %0.3f.\n"
+"Click NO to use the default value (recommended)"
+msgstr ""
+"Do you want to use the current value?\n"
+"Current: %0.3f.\n"
+"Default: %0.3f.\n"
+"Click NO to use the default value (recommended)"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:27
+#: src/gui/dialogs/DialogLoadUnload.cpp:28
 msgid "Ejecting"
 msgstr "Ejecting"
 
-#: src/guiapi/src/window_msgbox.cpp:150
+#: src/guiapi/src/window_msgbox.cpp:152
 msgid "Error"
 msgstr "Error"
 
@@ -202,11 +226,11 @@ msgstr "Factory defaults loaded. The system will now restart."
 msgid "Factory Reset"
 msgstr "Factory Reset"
 
-#: src/guiapi/include/MItem_menus.hpp:59
+#: src/guiapi/include/MItem_menus.hpp:69
 msgid "Fail Stats"
 msgstr "Fail Stats"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:17
+#: src/gui/dialogs/DialogSelftestFans.cpp:18
 #: src/gui/dialogs/DialogSelftestResult.cpp:39
 msgid "Fan Test"
 msgstr "Fan Test"
@@ -219,19 +243,22 @@ msgstr "Fan0 RPM"
 msgid "Fan1 RPM"
 msgstr "Fan1 RPM"
 
-#: src/gui/screen_menu_filament.cpp:127
+#: src/gui/screen_menu_filament.cpp:101
 msgid "FILAMENT"
 msgstr "FILAMENT"
 
-#: src/gui/screen_home.cpp:35 src/guiapi/include/MItem_menus.hpp:29
+#. ItemBed
+#: src/gui/screen_menu_odometer.cpp:18
+#: src/gui/screen_menu_footer_settings.cpp:60 src/gui/screen_home.cpp:36
+#: src/guiapi/include/MItem_menus.hpp:39
 msgid "Filament"
 msgstr "Filament"
 
-#: src/gui/screen_menu_filament.cpp:53
+#: src/gui/screen_menu_filament.cpp:41
 msgid "Filament appears to be already loaded, are you sure you want to load it anyway?"
 msgstr "Filament appears to be already loaded, are you sure you want to load it anyway?"
 
-#: src/gui/screen_print_preview.cpp:223
+#: src/gui/screen_print_preview.cpp:95
 msgid "Filament not detected. Load filament now? Select NO to cancel, or IGNORE to disable the filament sensor and continue."
 msgstr "Filament not detected. Load filament now? Select NO to cancel, or IGNORE to disable the filament sensor and continue."
 
@@ -246,7 +273,7 @@ msgid "Finishing buffered gcodes."
 msgstr "Finishing buffered gcodes."
 
 #. r=1 c=20
-#: src/gui/screen_menu_version_info.cpp:60
+#: src/gui/version_info_ST7789V.cpp:80
 msgid "Firmware Version\n"
 msgstr "Firmware Version\n"
 
@@ -268,11 +295,11 @@ msgstr "Flow Factor"
 msgid "Fri"
 msgstr "Fri"
 
-#: src/gui/screen_menu_fw_update.cpp:70
+#: src/gui/screen_menu_fw_update.cpp:69
 msgid "FW UPDATE"
 msgstr "FW UPDATE"
 
-#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:119
+#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:129
 msgid "FW Update"
 msgstr "FW Update"
 
@@ -281,41 +308,45 @@ msgstr "FW Update"
 msgid "Heatbed"
 msgstr "Heatbed"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:25
+#: src/gui/dialogs/DialogSelftestTemp.cpp:26
 msgid "Heatbed heater check"
 msgstr "Heatbed heater check"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:27
+#: src/gui/dialogs/DialogSelftestTemp.cpp:28
 msgid "Heater testing"
 msgstr "Heater testing"
 
-#: src/gui/guimain.cpp:194
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:34
 msgid "Heating disabled due to 30 minutes of inactivity."
 msgstr "Heating disabled due to 30 minutes of inactivity."
 
-#: src/gui/screen_printing.cpp:43
+#: src/gui/screen_printing.cpp:44
 msgid "Heating..."
 msgstr "Heating..."
 
-#: src/gui/guimain.cpp:205
-msgid "Hi, this is your\nOriginal Prusa MINI."
-msgstr "Hi, this is your\nOriginal Prusa MINI."
+#: src/gui/guimain.cpp:228
+msgid ""
+"Hi, this is your\n"
+"Original Prusa MINI."
+msgstr ""
+"Hi, this is your\n"
+"Original Prusa MINI."
 
-#: src/gui/screen_home.cpp:68
+#: src/gui/screen_home.cpp:72
 msgid "HOME"
 msgstr "HOME"
 
 #. special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
 #. and will get a nice house-like icon
-#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:45
+#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:46
 msgid "Home"
 msgstr "Home"
 
-#: src/gui/dialogs/DialogFactory.cpp:40
+#: src/gui/dialogs/DialogFactory.cpp:53
 msgid "HOME TO MAX"
 msgstr "HOME TO MAX"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:18
+#: src/gui/dialogs/DialogSelftestFans.cpp:19
 #: src/gui/dialogs/DialogSelftestResult.cpp:40
 msgid "Hotend Fan"
 msgstr "Hotend Fan"
@@ -324,45 +355,48 @@ msgstr "Hotend Fan"
 msgid "Hotend fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "Hotend fan not spinning. Check it for possible debris, then inspect the wiring."
 
-#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:159
+#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:169
 msgid "HW Setup"
 msgstr "HW Setup"
 
 #. Filament_removed
-#: src/gui/dialogs/dialog_response.cpp:16
+#. FLEX filament, do not translate
+#. HIPS filament, do not translate
+#: src/common/client_response_texts.cpp:22
 msgid "IGNORE"
 msgstr "IGNORE"
 
 #. static const char en_text[] = N_("Observe the pattern and turn the knob to adjust the nozzle height in real time. Extruded plastic must stick to the print surface.");
-#: src/gui/wizard/firstlay.cpp:128
+#: src/gui/wizard/firstlay.cpp:132
 msgid "In the next step, use the knob to adjust the nozzle height. Check the pictures in the handbook for reference."
 msgstr "In the next step, use the knob to adjust the nozzle height. Check the pictures in the handbook for reference."
 
-#: src/gui/screen_menu_info.cpp:20
+#: src/gui/screen_menu_info.cpp:19
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:31
 msgid "INFO"
 msgstr "INFO"
 
-#: src/gui/screen_home.cpp:38
+#: src/gui/screen_home.cpp:39
 msgid "Info"
 msgstr "Info"
 
-#: src/guiapi/src/window_msgbox.cpp:172
+#: src/guiapi/src/window_msgbox.cpp:171
 msgid "Information"
 msgstr "Information"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:25
+#: src/gui/dialogs/DialogLoadUnload.cpp:26
 msgid "Inserting"
 msgstr "Inserting"
 
-#: src/gui/screen_menu_lan_settings.cpp:292
+#: src/gui/screen_menu_lan_settings.cpp:294
 msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
 msgstr "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:30
+#: src/gui/dialogs/DialogLoadUnload.cpp:31
 msgid "Is color correct?"
 msgstr "Is color correct?"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:26
+#: src/gui/dialogs/DialogLoadUnload.cpp:27
 msgid "Is filament in extruder gear?"
 msgstr "Is filament in extruder gear?"
 
@@ -370,15 +404,15 @@ msgstr "Is filament in extruder gear?"
 msgid "Is steel sheet on heatbed?"
 msgstr "Is steel sheet on heatbed?"
 
-#: src/gui/screen_menu_lan_settings.cpp:221
+#: src/gui/screen_menu_lan_settings.cpp:217
 msgid "LAN SETTINGS"
 msgstr "LAN SETTINGS"
 
-#: src/guiapi/include/MItem_menus.hpp:129
+#: src/guiapi/include/MItem_menus.hpp:139
 msgid "Lan Settings"
 msgstr "Lan Settings"
 
-#: src/guiapi/include/MItem_menus.hpp:149
+#: src/guiapi/include/MItem_menus.hpp:159
 msgid "Language"
 msgstr "Language"
 
@@ -391,15 +425,15 @@ msgid "Live Adjust Z"
 msgstr "Live Adjust Z"
 
 #. Ignore
-#: src/gui/dialogs/dialog_response.cpp:17
+#: src/common/client_response_texts.cpp:23
 msgid "LOAD"
 msgstr "LOAD"
 
-#: src/gui/dialogs/DialogFactory.cpp:13 src/gui/screen_menu_filament.cpp:52
+#: src/gui/dialogs/DialogFactory.cpp:9
 msgid "LOAD FILAMENT"
 msgstr "LOAD FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:51
+#: src/gui/screen_menu_filament.cpp:40
 msgid "Load Filament"
 msgstr "Load Filament"
 
@@ -407,11 +441,11 @@ msgstr "Load Filament"
 msgid "Load Settings"
 msgstr "Load Settings"
 
-#: src/gui/screen_splash.cpp:43
+#: src/gui/screen_splash.cpp:38
 msgid "Loading ..."
 msgstr "Loading ..."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:28
+#: src/gui/dialogs/DialogLoadUnload.cpp:29
 msgid "Loading to nozzle"
 msgstr "Loading to nozzle"
 
@@ -423,11 +457,11 @@ msgstr "Loud"
 msgid "M.I.N.D.A."
 msgstr "M.I.N.D.A."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:24
+#: src/gui/dialogs/DialogLoadUnload.cpp:25
 msgid "Make sure the filament is inserted through the sensor."
 msgstr "Make sure the filament is inserted through the sensor."
 
-#: src/gui/screen_print_preview.cpp:128
+#: src/gui/gcode_description.cpp:37
 msgid "Material"
 msgstr "Material"
 
@@ -438,8 +472,14 @@ msgid "MAXTEMP ERROR"
 msgstr "MAXTEMP ERROR"
 
 #: src/gui/wizard/xyzcalib.cpp:192
-msgid "Measuring reference\nheight of calib.\npoints"
-msgstr "Measuring reference\nheight of calib.\npoints"
+msgid ""
+"Measuring reference\n"
+"height of calib.\n"
+"points"
+msgstr ""
+"Measuring reference\n"
+"height of calib.\n"
+"points"
 
 #: src/guiapi/include/MItem_tools.hpp:289
 msgid "Menu Timeout"
@@ -458,7 +498,7 @@ msgstr "MESH BED LEVELING"
 msgid "MESSAGES"
 msgstr "MESSAGES"
 
-#: src/guiapi/include/MItem_menus.hpp:139
+#: src/guiapi/include/MItem_menus.hpp:149
 msgid "Messages"
 msgstr "Messages"
 
@@ -473,7 +513,7 @@ msgstr "MINTEMP ERROR"
 msgid "Mon"
 msgstr "Mon"
 
-#: src/guiapi/include/MItem_menus.hpp:89
+#: src/guiapi/include/MItem_menus.hpp:99
 msgid "Move Axis"
 msgstr "Move Axis"
 
@@ -502,12 +542,12 @@ msgid "Name"
 msgstr "Name"
 
 #. Load
-#: src/gui/dialogs/dialog_response.cpp:18
+#: src/common/client_response_texts.cpp:24
 msgid "NEXT"
 msgstr "NEXT"
 
 #. Next
-#: src/gui/dialogs/dialog_response.cpp:19
+#: src/common/client_response_texts.cpp:25
 msgid "NO"
 msgstr "NO"
 
@@ -515,14 +555,15 @@ msgstr "NO"
 msgid "No filament sensor detected. Verify that the sensor is connected and try again."
 msgstr "No filament sensor detected. Verify that the sensor is connected and try again."
 
-#: src/gui/screen_home.cpp:39
+#: src/gui/screen_home.cpp:40
 msgid "No USB"
 msgstr "No USB"
 
-#: src/gui/wizard/firstlay.cpp:98
+#: src/gui/wizard/firstlay.cpp:102
 msgid "Now, let's calibrate the distance between the tip of the nozzle and the print sheet."
 msgstr "Now, let's calibrate the distance between the tip of the nozzle and the print sheet."
 
+#: src/gui/screen_menu_footer_settings.cpp:58
 #: src/gui/dialogs/DialogSelftestResult.cpp:47
 #: src/guiapi/include/MItem_print.hpp:8
 msgid "Nozzle"
@@ -532,17 +573,18 @@ msgstr "Nozzle"
 msgid "Nozzle and Heatbed"
 msgstr "Nozzle and Heatbed"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:24
+#: src/gui/dialogs/DialogSelftestTemp.cpp:25
 msgid "Nozzle heater check"
 msgstr "Nozzle heater check"
 
 #: src/gui/screen_menu_fw_update.cpp:28
 #: src/guiapi/include/WindowMenuItems.hpp:19
+#: src/guiapi/include/WindowMenuSpin.hpp:21
 msgid "Off"
 msgstr "Off"
 
 #. No
-#: src/gui/screen_sheet_rename.cpp:17 src/gui/dialogs/dialog_response.cpp:20
+#: src/common/client_response_texts.cpp:26 src/gui/screen_sheet_rename.cpp:17
 msgid "OK"
 msgstr "OK"
 
@@ -566,11 +608,11 @@ msgstr "Once the printer starts extruding plastic, adjust the nozzle height by t
 msgid "Parking"
 msgstr "Parking"
 
-#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:38
+#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:39
 msgid "Pause"
 msgstr "Pause"
 
-#: src/gui/screen_printing.cpp:39
+#: src/gui/screen_printing.cpp:40
 msgid "Pausing..."
 msgstr "Pausing..."
 
@@ -582,15 +624,25 @@ msgstr "Place a sheet of paper under the nozzle during the calibration of first 
 msgid "Please clean the nozzle for calibration. Click NEXT when done."
 msgstr "Please clean the nozzle for calibration. Click NEXT when done."
 
-#: src/gui/screen_menu_lan_settings.cpp:280
+#: src/gui/screen_menu_lan_settings.cpp:282
 msgid "Please insert a USB drive and try again."
 msgstr "Please insert a USB drive and try again."
 
-#: src/gui/guimain.cpp:206
-msgid "Please insert the USB\ndrive that came with\nyour MINI and reset\nthe printer to flash\nthe firmware"
-msgstr "Please insert the USB\ndrive that came with\nyour MINI and reset\nthe printer to flash\nthe firmware"
+#: src/gui/guimain.cpp:229
+msgid ""
+"Please insert the USB\n"
+"drive that came with\n"
+"your MINI and reset\n"
+"the printer to flash\n"
+"the firmware"
+msgstr ""
+"Please insert the USB\n"
+"drive that came with\n"
+"your MINI and reset\n"
+"the printer to flash\n"
+"the firmware"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:22
+#: src/gui/dialogs/DialogLoadUnload.cpp:23
 msgid "Please open idler and remove filament manually"
 msgstr "Please open idler and remove filament manually"
 
@@ -606,11 +658,11 @@ msgstr "Please remove steel sheet from heatbed."
 msgid "Please wait"
 msgstr "Please wait"
 
-#: src/gui/screen_menu_preheat.cpp:25 src/gui/screen_menu_preheat.cpp:47
+#: src/gui/screen_menu_preheat.cpp:26 src/gui/screen_menu_preheat.cpp:49
 msgid "PREHEAT"
 msgstr "PREHEAT"
 
-#: src/gui/screen_home.cpp:34
+#: src/gui/screen_home.cpp:35
 msgid "Preheat"
 msgstr "Preheat"
 
@@ -620,17 +672,15 @@ msgstr "Preheat"
 msgid "PREHEAT ERROR"
 msgstr "PREHEAT ERROR"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:34
+#: src/gui/dialogs/DialogFactory.cpp:12
 msgid "PREHEAT for LOAD"
 msgstr "PREHEAT for LOAD"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:54
+#: src/gui/dialogs/DialogFactory.cpp:13
 msgid "PREHEAT for UNLOAD"
 msgstr "PREHEAT for UNLOAD"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:26
+#: src/gui/dialogs/DialogSelftestTemp.cpp:27
 msgid "Preparing"
 msgstr "Preparing"
 
@@ -638,7 +688,7 @@ msgstr "Preparing"
 msgid "Preparing to ram"
 msgstr "Preparing to ram"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:23
+#: src/gui/dialogs/DialogLoadUnload.cpp:24
 msgid "Press CONTINUE and push filament into the extruder."
 msgstr "Press CONTINUE and push filament into the extruder."
 
@@ -646,11 +696,11 @@ msgstr "Press CONTINUE and push filament into the extruder."
 msgid "Press NEXT to run the Selftest, which checks for potential issues related to the assembly."
 msgstr "Press NEXT to run the Selftest, which checks for potential issues related to the assembly."
 
-#: src/gui/screen_print_preview.cpp:185 src/gui/screen_home.cpp:33
+#: src/gui/screen_print_preview.cpp:64 src/gui/screen_home.cpp:34
 msgid "Print"
 msgstr "Print"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:19
+#: src/gui/dialogs/DialogSelftestFans.cpp:20
 #: src/gui/dialogs/DialogSelftestResult.cpp:41
 #: src/guiapi/include/MItem_print.hpp:24
 msgid "Print Fan"
@@ -660,42 +710,46 @@ msgstr "Print Fan"
 msgid "Print fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "Print fan not spinning. Check it for possible debris, then inspect the wiring."
 
-#: src/gui/screen_print_preview.cpp:127
+#: src/gui/gcode_description.cpp:36
 msgid "Print Time"
 msgstr "Print Time"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #. theoretically it can be removed completely in case the string is constant for the whole run of the screen
-#: src/gui/screen_printing.cpp:222
+#: src/gui/screen_printing.cpp:244
 msgid "Print will end"
 msgstr "Print will end"
 
-#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:360
+#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:370
 msgid "PRINTING"
 msgstr "PRINTING"
 
-#: src/gui/screen_printing.cpp:158
+#: src/gui/screen_printing.cpp:160
 msgid "Printing time"
 msgstr "Printing time"
 
-#: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
+#: src/gui/dialogs/DialogFactory.cpp:11 src/gui/screen_menu_filament.cpp:87
 msgid "PURGE FILAMENT"
 msgstr "PURGE FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:109
+#: src/gui/screen_menu_filament.cpp:86
 msgid "Purge Filament"
 msgstr "Purge Filament"
 
 #. Ok
-#: src/gui/dialogs/dialog_response.cpp:21
+#. PC filament, do not translate
+#. PETG filament, do not translate
+#. PLA filament, do not translate
+#. PP filament, do not translate
+#: src/common/client_response_texts.cpp:31
 msgid "PURGE MORE"
 msgstr "PURGE MORE"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:29
+#: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Purging"
 msgstr "Purging"
 
-#: src/guiapi/src/window_msgbox.cpp:156
+#: src/guiapi/src/window_msgbox.cpp:157
 msgid "Question"
 msgstr "Question"
 
@@ -703,18 +757,18 @@ msgstr "Question"
 msgid "Ramming"
 msgstr "Ramming"
 
-#: src/gui/screen_printing_serial.cpp:45
+#: src/gui/screen_printing_serial.cpp:43
 msgid "Really Disconnect?"
 msgstr "Really Disconnect?"
 
 #. Purge_more
-#: src/gui/dialogs/dialog_response.cpp:22
+#: src/common/client_response_texts.cpp:32
 msgid "REHEAT"
 msgstr "REHEAT"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
-#: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
-#: src/gui/screen_printing.cpp:355
+#: src/gui/screen_printing.cpp:149 src/gui/screen_printing.cpp:248
+#: src/gui/screen_printing.cpp:365
 msgid "Remaining Time"
 msgstr "Remaining Time"
 
@@ -726,7 +780,7 @@ msgstr "RENAME"
 msgid "Rename"
 msgstr "Rename"
 
-#: src/gui/screen_printing.cpp:44
+#: src/gui/screen_printing.cpp:45
 msgid "Reprint"
 msgstr "Reprint"
 
@@ -734,23 +788,24 @@ msgstr "Reprint"
 msgid "Reset"
 msgstr "Reset"
 
-#: src/common/MindaRedscreen.cpp:175 src/gui/guimain.cpp:207
+#: src/common/MindaRedscreen.cpp:175
 msgid "RESET PRINTER"
 msgstr "RESET PRINTER"
 
-#: src/gui/screen_printing.cpp:41
+#: src/gui/screen_printing.cpp:42
 msgid "Resume"
 msgstr "Resume"
 
-#: src/gui/screen_printing.cpp:42
+#: src/gui/screen_printing.cpp:43
 msgid "Resuming..."
 msgstr "Resuming..."
 
 #. Reheat
-#: src/gui/dialogs/dialog_response.cpp:23
+#: src/common/client_response_texts.cpp:33
 msgid "RETRY"
 msgstr "RETRY"
 
+#: src/gui/dialogs/window_dlg_preheat.hpp:39
 #: src/guiapi/include/WindowMenuItems.hpp:54
 msgid "Return"
 msgstr "Return"
@@ -769,8 +824,12 @@ msgid "Save Settings"
 msgstr "Save Settings"
 
 #: src/gui/wizard/xyzcalib.cpp:180
-msgid "Searching bed\ncalibration points"
-msgstr "Searching bed\ncalibration points"
+msgid ""
+"Searching bed\n"
+"calibration points"
+msgstr ""
+"Searching bed\n"
+"calibration points"
 
 #: src/gui/screen_menu_steel_sheets.cpp:33
 msgid "Select"
@@ -780,7 +839,7 @@ msgstr "Select"
 msgid "Select Filament Type"
 msgstr "Select Filament Type"
 
-#: src/gui/screen_filebrowser.cpp:42
+#: src/gui/screen_filebrowser.cpp:43
 msgid "SELECT FILE"
 msgstr "SELECT FILE"
 
@@ -788,7 +847,7 @@ msgstr "SELECT FILE"
 msgid "SELECT LANGUAGE"
 msgstr "SELECT LANGUAGE"
 
-#: src/gui/screen_menu_fw_update.cpp:74
+#: src/gui/screen_menu_fw_update.cpp:96
 msgid "Select when you want to automatically flash updated firmware from USB flash disk."
 msgstr "Select when you want to automatically flash updated firmware from USB flash disk."
 
@@ -808,23 +867,24 @@ msgstr "SENSOR INFO"
 msgid "Sensor Info"
 msgstr "Sensor Info"
 
-#: src/gui/screen_printing_serial.hpp:13
+#. filament sensor will think printer is in printing state
+#: src/gui/screen_printing_serial.hpp:15
 msgid "SERIAL PRINTING"
 msgstr "SERIAL PRINTING"
 
-#: src/guiapi/include/MItem_menus.hpp:99
+#: src/guiapi/include/MItem_menus.hpp:109
 msgid "Service"
 msgstr "Service"
 
-#: src/gui/screen_home.cpp:37
+#: src/gui/screen_home.cpp:38
 msgid "Settings"
 msgstr "Settings"
 
-#: src/gui/screen_menu_settings.cpp:107
+#: src/gui/screen_menu_settings.cpp:108
 msgid "SETTINGS"
 msgstr "SETTINGS"
 
-#: src/gui/screen_menu_lan_settings.cpp:289
+#: src/gui/screen_menu_lan_settings.cpp:291
 msgid "Settings successfully loaded"
 msgstr "Settings successfully loaded"
 
@@ -852,28 +912,34 @@ msgstr "Sound Mode"
 msgid "Sound Volume"
 msgstr "Sound Volume"
 
+#. ItemFilament
+#: src/gui/screen_menu_footer_settings.cpp:61
 #: src/guiapi/include/MItem_print.hpp:32
 msgid "Speed"
 msgstr "Speed"
 
-#: src/gui/screen_menu_lan_settings.cpp:277
+#: src/gui/screen_menu_lan_settings.cpp:279
 msgid "Static IPv4 addresses were not set."
 msgstr "Static IPv4 addresses were not set."
 
-#: src/guiapi/include/MItem_menus.hpp:49
-msgid "Statistic"
-msgstr "Statistic"
+#: src/gui/screen_menu_odometer.cpp:15
+msgid "STATISTICS"
+msgstr "STATISTICS"
+
+#: src/guiapi/include/MItem_menus.hpp:29
+msgid "Statistics"
+msgstr "Statistics"
 
 #: src/gui/screen_menu_steel_sheets.cpp:176 src/gui/screen_menu_hw_setup.cpp:16
 msgid "Steel Sheets"
 msgstr "Steel Sheets"
 
 #. Retry
-#: src/gui/dialogs/dialog_response.cpp:24
+#: src/common/client_response_texts.cpp:34
 msgid "STOP"
 msgstr "STOP"
 
-#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:40
+#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:41
 msgid "Stop"
 msgstr "Stop"
 
@@ -882,11 +948,11 @@ msgstr "Stop"
 msgid "Sun"
 msgstr "Sun"
 
-#: src/guiapi/include/MItem_menus.hpp:69
+#: src/guiapi/include/MItem_menus.hpp:79
 msgid "Support"
 msgstr "Support"
 
-#: src/guiapi/include/MItem_menus.hpp:39
+#: src/guiapi/include/MItem_menus.hpp:49
 msgid "System Info"
 msgstr "System Info"
 
@@ -894,11 +960,11 @@ msgstr "System Info"
 msgid "TEMPERATURE"
 msgstr "TEMPERATURE"
 
-#: src/guiapi/include/MItem_menus.hpp:79
+#: src/guiapi/include/MItem_menus.hpp:89
 msgid "Temperature"
 msgstr "Temperature"
 
-#: src/guiapi/include/MItem_menus.hpp:109
+#: src/guiapi/include/MItem_menus.hpp:119
 msgid "Test"
 msgstr "Test"
 
@@ -915,7 +981,7 @@ msgid "Test XYZ-Axis"
 msgstr "Test XYZ-Axis"
 
 #. save eeprom flag
-#: src/gui/wizard/firstlay.cpp:184
+#: src/gui/wizard/firstlay.cpp:189
 msgid "The first layer calibration failed to finish. Double-check the printer's wiring, nozzle and axes, then restart the calibration."
 msgstr "The first layer calibration failed to finish. Double-check the printer's wiring, nozzle and axes, then restart the calibration."
 
@@ -923,19 +989,31 @@ msgstr "The first layer calibration failed to finish. Double-check the printer's
 msgid "The selftest failed to finish. Double-check the printer's wiring and axes. Then restart the Selftest."
 msgstr "The selftest failed to finish. Double-check the printer's wiring and axes. Then restart the Selftest."
 
-#: src/gui/screen_menu_lan_settings.cpp:283
+#: src/gui/screen_menu_lan_settings.cpp:285
 msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
 msgstr "The settings have been saved successfully in the \"lan_settings.ini\" file."
 
 #: src/gui/wizard/screen_wizard.cpp:170
-msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
-msgstr "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
+msgid ""
+"The status bar is at the bottom of the screen. It contains information about:\n"
+"- Nozzle temp.\n"
+"- Heatbed temp.\n"
+"- Printing speed\n"
+"- Z-axis height\n"
+"- Selected filament"
+msgstr ""
+"The status bar is at the bottom of the screen. It contains information about:\n"
+"- Nozzle temp.\n"
+"- Heatbed temp.\n"
+"- Printing speed\n"
+"- Z-axis height\n"
+"- Selected filament"
 
 #: src/gui/wizard/xyzcalib.cpp:298
 msgid "The XYZ calibration failed to finish. Double-check the printer's wiring and axes, then restart the XYZ calibration."
 msgstr "The XYZ calibration failed to finish. Double-check the printer's wiring and axes, then restart the XYZ calibration."
 
-#: src/gui/screen_menu_lan_settings.cpp:286
+#: src/gui/screen_menu_lan_settings.cpp:288
 msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
 msgstr "There was an error saving the settings in the \"lan_settings.ini\" file."
 
@@ -945,7 +1023,7 @@ msgstr "There was an error saving the settings in the \"lan_settings.ini\" file.
 msgid "THERMAL RUNAWAY"
 msgstr "THERMAL RUNAWAY"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26
 msgid "This G-CODE was set up for another printer type."
 msgstr "This G-CODE was set up for another printer type."
 
@@ -985,20 +1063,20 @@ msgstr "Tue"
 msgid "TUNE"
 msgstr "TUNE"
 
-#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:37
+#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:38
 msgid "Tune"
 msgstr "Tune"
 
 #. Stop
-#: src/gui/dialogs/dialog_response.cpp:25
+#: src/common/client_response_texts.cpp:35
 msgid "UNLOAD"
 msgstr "UNLOAD"
 
-#: src/gui/dialogs/DialogFactory.cpp:14 src/gui/screen_menu_filament.cpp:72
+#: src/gui/dialogs/DialogFactory.cpp:10 src/gui/screen_menu_filament.cpp:57
 msgid "UNLOAD FILAMENT"
 msgstr "UNLOAD FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:71
+#: src/gui/screen_menu_filament.cpp:56
 msgid "Unload Filament"
 msgstr "Unload Filament"
 
@@ -1014,11 +1092,11 @@ msgstr "Unparking"
 msgid "USB drive error, the print is now paused. Reconnect the drive."
 msgstr "USB drive error, the print is now paused. Reconnect the drive."
 
-#: src/gui/screen_print_preview.cpp:129
+#: src/gui/gcode_description.cpp:38
 msgid "Used Filament"
 msgstr "Used Filament"
 
-#: src/gui/screen_menu_version_info.cpp:31
+#: src/gui/version_info_ST7789V.cpp:27
 msgid "VERSION INFO"
 msgstr "VERSION INFO"
 
@@ -1034,7 +1112,7 @@ msgstr "Waiting for temperature"
 msgid "Warning"
 msgstr "Warning"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26 src/gui/screen_print_preview.cpp:113
 msgid "WARNING:"
 msgstr "WARNING:"
 
@@ -1064,7 +1142,7 @@ msgid "WIZARD - OK"
 msgstr "WIZARD - OK"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:43
-#: src/gui/dialogs/DialogSelftestAxis.cpp:19
+#: src/gui/dialogs/DialogSelftestAxis.cpp:25
 msgid "X-axis"
 msgstr "X-axis"
 
@@ -1073,12 +1151,12 @@ msgid "XYZ CALIBRATION"
 msgstr "XYZ CALIBRATION"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:44
-#: src/gui/dialogs/DialogSelftestAxis.cpp:20
+#: src/gui/dialogs/DialogSelftestAxis.cpp:26
 msgid "Y-axis"
 msgstr "Y-axis"
 
 #. Unload
-#: src/gui/dialogs/dialog_response.cpp:26
+#: src/common/client_response_texts.cpp:36
 msgid "YES"
 msgstr "YES"
 
@@ -1087,6 +1165,6 @@ msgid "Z height:"
 msgstr "Z height:"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:45
-#: src/gui/dialogs/DialogSelftestAxis.cpp:21
+#: src/gui/dialogs/DialogSelftestAxis.cpp:27
 msgid "Z-axis"
 msgstr "Z-axis"

--- a/src/lang/po/es/Prusa-Firmware-Buddy_es.po
+++ b/src/lang/po/es/Prusa-Firmware-Buddy_es.po
@@ -5,25 +5,39 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
+"X-Generator: Phrase (phrase.com)\n"
 
 #. c=20 r=4
-#: src/gui/screen_menu_version_info.cpp:82
+#: src/gui/version_info_ST7789V.cpp:102
 #, c-format
-msgid "\nBootloader Version\n%d.%d.%d\n\nBuddy Board\n%d.%d.%d\n%s"
-msgstr "\nVer. de bootloader\n%d.%d.%d\n\nPlaca Buddy\n%d.%d.%d\n %s"
+msgid ""
+"\n"
+"Bootloader Version\n"
+"%d.%d.%d\n"
+"\n"
+"Buddy Board\n"
+"%d.%d.%d\n"
+"%s"
+msgstr ""
+"\n"
+"Ver. de bootloader\n"
+"%d.%d.%d\n"
+"\n"
+"Placa Buddy\n"
+"%d.%d.%d\n"
+" %s"
 
 #: src/guiapi/src/MItem_tools.cpp:200
 msgid "A crash dump report (file dump.bin) has been saved to the USB drive."
 msgstr "Se ha guardado un informe con detalles del error (dump.bin) en la unidad USB."
 
 #. _none
-#: src/gui/dialogs/dialog_response.cpp:11
+#: src/common/client_response_texts.cpp:11
 msgid "ABORT"
 msgstr "ABORTAR"
 
 #. / title text
-#: src/gui/dialogs/liveadjust_z.cpp:205
+#: src/gui/dialogs/liveadjust_z.cpp:207
 msgid "Adjust the nozzle height above the heatbed by turning the knob"
 msgstr "Ajusta la altura de la boquilla sobre la base girando el dial"
 
@@ -35,7 +49,7 @@ msgstr "¡Todas las pruebas terminaron con éxito!"
 msgid "Always"
 msgstr "Siempre"
 
-#: src/gui/screen_printing.cpp:103
+#: src/gui/screen_printing.cpp:104
 msgid "Are you sure to stop this printing?"
 msgstr "¿Estás seguro de detener esta impresión?"
 
@@ -48,15 +62,17 @@ msgid "Auto Home"
 msgstr "Homing automático"
 
 #. Abort
-#: src/gui/dialogs/dialog_response.cpp:12
+#. ABS filament, do not translate
+#. ASA filament, do not translate
+#: src/common/client_response_texts.cpp:14
 msgid "BACK"
 msgstr "ATRÁS"
 
-#: src/gui/screen_print_preview.cpp:189
+#: src/gui/screen_print_preview.cpp:68
 msgid "Back"
 msgstr "Atrás"
 
-#: src/gui/screen_printing.cpp:205
+#: src/gui/screen_printing.cpp:208
 msgid "Bed leveling failed. Try again?"
 msgstr "Falló la nivelación. ¿Reintentar?"
 
@@ -64,7 +80,7 @@ msgstr "Falló la nivelación. ¿Reintentar?"
 msgid "Calibrating Z"
 msgstr "Calibrando Z"
 
-#: src/gui/screen_home.cpp:36
+#: src/gui/screen_home.cpp:37
 msgid "Calibration"
 msgstr "Calibración"
 
@@ -74,55 +90,57 @@ msgstr "CALIBRACIÓN"
 
 #: src/gui/wizard/screen_wizard.cpp:192
 msgid "Calibration successful! Happy printing!"
-msgstr "¡Calibrada con éxito!\n¡Felices impresiones!"
+msgstr ""
+"¡Calibrada con éxito!\n"
+"¡Felices impresiones!"
 
 #: src/gui/wizard/xyzcalib.cpp:230
 msgid "Calibration XY"
 msgstr "Calibración XY"
 
 #. Back
-#: src/gui/screen_sheet_rename.cpp:18 src/gui/dialogs/dialog_response.cpp:13
+#: src/common/client_response_texts.cpp:15 src/gui/screen_sheet_rename.cpp:18
 msgid "CANCEL"
 msgstr "CANCELAR"
 
-#: src/gui/dialogs/DialogFactory.cpp:12 src/gui/screen_menu_filament.cpp:90
+#: src/gui/dialogs/DialogFactory.cpp:8 src/gui/screen_menu_filament.cpp:72
 msgid "CHANGE FILAMENT"
 msgstr "CAMBIAR FILAMENTO"
 
-#: src/gui/screen_menu_filament.cpp:89 src/guiapi/include/MItem_tools.hpp:279
+#: src/gui/screen_menu_filament.cpp:71 src/guiapi/include/MItem_tools.hpp:279
 msgid "Change Filament"
 msgstr "Cambiar Filamento"
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:44
 msgid "Check the heatbed heater & thermistor wiring for possible damage."
-msgstr "Revisa el cableado del termistor y el calentador de la base para detectar posibles daños."
+msgstr "Comprueba que el cableado del calentador y del termistor de la base calefactable no esté dañado."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:56
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:68
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:80
 msgid "Check the heatbed thermistor wiring for possible damage."
-msgstr "Revisa el cableado del termistor de la base calefactada buscando posibles daños."
+msgstr "Comprueba que el cableado del termistor de la base calefactable no esté dañado."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:50
 msgid "Check the print head heater & thermistor wiring for possible damage."
-msgstr "Revisa el cableado del termistor y del calentador del fusor para ver si hay daños."
+msgstr "Comprueba que el cableado del calentador y del termistor del cabezal de impresión no esté dañado."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:62
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:74
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:86
 msgid "Check the print head thermistor wiring for possible damage."
-msgstr "Revisa el cableado del termistor del fusor para ver si hay daños."
+msgstr "Comprueba que el cableado del termistor del cabezal de impresión no esté dañado."
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:42
-#: src/gui/dialogs/DialogSelftestAxis.cpp:18
+#: src/gui/dialogs/DialogSelftestAxis.cpp:24
 msgid "Checking axes"
 msgstr "Comprobando ejes"
 
-#: src/gui/wizard/firstlay.cpp:168
+#: src/gui/wizard/firstlay.cpp:173
 msgid "Clean steel sheet."
 msgstr "Limpia la superficie de la lámina de acero."
 
@@ -130,12 +148,12 @@ msgstr "Limpia la superficie de la lámina de acero."
 msgid "Congratulations! XYZ calibration is ok. XY axes are perpendicular."
 msgstr "¡Felicidades! La calibración XYZ finalizó correctamente. Los ejes XY son perpendiculares."
 
-#. Cancel
-#: src/gui/dialogs/dialog_response.cpp:14
+#. Change
+#: src/common/client_response_texts.cpp:17
 msgid "CONTINUE"
 msgstr "CONTINUAR"
 
-#: src/common/filament.cpp:13 src/gui/screen_menu_temperature.cpp:12
+#: src/gui/screen_menu_temperature.cpp:12
 msgid "Cooldown"
 msgstr "Enfriando"
 
@@ -143,16 +161,16 @@ msgstr "Enfriando"
 msgid "CPU load"
 msgstr "Carga del procesador"
 
-#: src/guiapi/include/MItem_menus.hpp:169
+#: src/guiapi/include/MItem_menus.hpp:179
 msgid "Current Profile"
 msgstr "Perfil Actual"
 
-#: src/guiapi/include/MItem_menus.hpp:192
+#: src/guiapi/include/MItem_menus.hpp:202
 msgid "Device hash in QR"
 msgstr "Identificar unidad en QR"
 
-#. Continue
-#: src/gui/dialogs/dialog_response.cpp:15
+#. Cooldown
+#: src/common/client_response_texts.cpp:19
 msgid "DISABLE SENSOR"
 msgstr "DESACTIVAR SENSOR"
 
@@ -160,25 +178,33 @@ msgstr "DESACTIVAR SENSOR"
 msgid "Disable Steppers"
 msgstr "Desactivar motores"
 
-#: src/gui/screen_printing_serial.hpp:10
+#: src/gui/screen_printing_serial.hpp:11
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: src/gui/wizard/firstlay.cpp:160
+#: src/gui/wizard/firstlay.cpp:165
 msgid "Do you want to repeat the last step and readjust the distance between the nozzle and heatbed?"
 msgstr "¿Quieres repetir el último paso y reajustar la distancia entre la boquilla y base?"
 
-#. c=20 r=6
-#: src/gui/wizard/firstlay.cpp:112
+#. c=21 r=9
+#: src/gui/wizard/firstlay.cpp:116
 #, c-format
-msgid "Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)"
-msgstr "¿Quiere utilizar el valor actual?\nActual: %0.3f.\nPor defecto: %0.3f.\nHaz clic en NO para usar el valor por defecto (recomendado)"
+msgid ""
+"Do you want to use the current value?\n"
+"Current: %0.3f.\n"
+"Default: %0.3f.\n"
+"Click NO to use the default value (recommended)"
+msgstr ""
+"¿Quiere utilizar el valor actual?\n"
+"Actual: %0.3f.\n"
+"Por defecto: %0.3f.\n"
+"Haz clic en NO para usar el valor por defecto (recomendado)"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:27
+#: src/gui/dialogs/DialogLoadUnload.cpp:28
 msgid "Ejecting"
 msgstr "Extrayendo"
 
-#: src/guiapi/src/window_msgbox.cpp:150
+#: src/guiapi/src/window_msgbox.cpp:152
 msgid "Error"
 msgstr "Error"
 
@@ -202,11 +228,11 @@ msgstr "Valores predefinidos de fábrica cargados. Reiniciando el sistema."
 msgid "Factory Reset"
 msgstr "Restaurar valores de fábrica"
 
-#: src/guiapi/include/MItem_menus.hpp:59
+#: src/guiapi/include/MItem_menus.hpp:69
 msgid "Fail Stats"
 msgstr "Registro de errores"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:17
+#: src/gui/dialogs/DialogSelftestFans.cpp:18
 #: src/gui/dialogs/DialogSelftestResult.cpp:39
 msgid "Fan Test"
 msgstr "Prueba del ventilador"
@@ -219,19 +245,22 @@ msgstr "RPM Ventilador0 "
 msgid "Fan1 RPM"
 msgstr "RPM Ventilador1"
 
-#: src/gui/screen_menu_filament.cpp:127
+#: src/gui/screen_menu_filament.cpp:101
 msgid "FILAMENT"
 msgstr "FILAMENTO"
 
-#: src/gui/screen_home.cpp:35 src/guiapi/include/MItem_menus.hpp:29
+#. ItemBed
+#: src/gui/screen_menu_odometer.cpp:18
+#: src/gui/screen_menu_footer_settings.cpp:60 src/gui/screen_home.cpp:36
+#: src/guiapi/include/MItem_menus.hpp:39
 msgid "Filament"
 msgstr "Filamento"
 
-#: src/gui/screen_menu_filament.cpp:53
+#: src/gui/screen_menu_filament.cpp:41
 msgid "Filament appears to be already loaded, are you sure you want to load it anyway?"
 msgstr "El filamento parece estar cargado, ¿estás seguro de volver a cargarlo?"
 
-#: src/gui/screen_print_preview.cpp:223
+#: src/gui/screen_print_preview.cpp:95
 msgid "Filament not detected. Load filament now? Select NO to cancel, or IGNORE to disable the filament sensor and continue."
 msgstr "No se ha detectado filamento. ¿Cargar filamento ahora? Seleccione NO para cancelar, o IGNORAR para desactivar el sensor de filamento y continuar."
 
@@ -243,10 +272,12 @@ msgstr "Sensor fil."
 #. clang-format off
 #: src/gui/dialogs/DialogG162.cpp:8 src/gui/dialogs/DialogLoadUnload.cpp:14
 msgid "Finishing buffered gcodes."
-msgstr "Finalizando Cod. G en memoria."
+msgstr ""
+"Finalizando \n"
+"Cod. G en memoria.\n"
 
 #. r=1 c=20
-#: src/gui/screen_menu_version_info.cpp:60
+#: src/gui/version_info_ST7789V.cpp:80
 msgid "Firmware Version\n"
 msgstr "Ver. de Firmware\n"
 
@@ -268,11 +299,11 @@ msgstr "Factor de flujo"
 msgid "Fri"
 msgstr "Vie"
 
-#: src/gui/screen_menu_fw_update.cpp:70
+#: src/gui/screen_menu_fw_update.cpp:69
 msgid "FW UPDATE"
 msgstr "ACTUALIZAR FW"
 
-#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:119
+#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:129
 msgid "FW Update"
 msgstr "Actualizar FW"
 
@@ -281,41 +312,45 @@ msgstr "Actualizar FW"
 msgid "Heatbed"
 msgstr "Base Calefactora"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:25
+#: src/gui/dialogs/DialogSelftestTemp.cpp:26
 msgid "Heatbed heater check"
 msgstr "Comp. calor base"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:27
+#: src/gui/dialogs/DialogSelftestTemp.cpp:28
 msgid "Heater testing"
 msgstr "Probando Calent."
 
-#: src/gui/guimain.cpp:194
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:34
 msgid "Heating disabled due to 30 minutes of inactivity."
 msgstr "Calentamiento deshabilitado debido a 30 minutos de inactividad."
 
-#: src/gui/screen_printing.cpp:43
+#: src/gui/screen_printing.cpp:44
 msgid "Heating..."
 msgstr "Calentando..."
 
-#: src/gui/guimain.cpp:205
-msgid "Hi, this is your\nOriginal Prusa MINI."
-msgstr "Hola, esta es tu Original Prusa MINI."
+#: src/gui/guimain.cpp:228
+msgid ""
+"Hi, this is your\n"
+"Original Prusa MINI."
+msgstr ""
+"Hola, esta es tu\n"
+"Original Prusa MINI."
 
-#: src/gui/screen_home.cpp:68
+#: src/gui/screen_home.cpp:72
 msgid "HOME"
 msgstr "INICIO"
 
 #. special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
 #. and will get a nice house-like icon
-#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:45
+#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:46
 msgid "Home"
 msgstr "Inicio"
 
-#: src/gui/dialogs/DialogFactory.cpp:40
+#: src/gui/dialogs/DialogFactory.cpp:53
 msgid "HOME TO MAX"
 msgstr "HOME TO MAX"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:18
+#: src/gui/dialogs/DialogSelftestFans.cpp:19
 #: src/gui/dialogs/DialogSelftestResult.cpp:40
 msgid "Hotend Fan"
 msgstr "Vent. del fusor"
@@ -324,61 +359,69 @@ msgstr "Vent. del fusor"
 msgid "Hotend fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "El ventilador del fusor no gira. Comprueba que no hay residuos, luego inspecciona el cableado."
 
-#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:159
+#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:169
 msgid "HW Setup"
 msgstr "Ajuste de HW"
 
 #. Filament_removed
-#: src/gui/dialogs/dialog_response.cpp:16
+#. FLEX filament, do not translate
+#. HIPS filament, do not translate
+#: src/common/client_response_texts.cpp:22
 msgid "IGNORE"
 msgstr "IGNORAR"
 
 #. static const char en_text[] = N_("Observe the pattern and turn the knob to adjust the nozzle height in real time. Extruded plastic must stick to the print surface.");
-#: src/gui/wizard/firstlay.cpp:128
+#: src/gui/wizard/firstlay.cpp:132
 msgid "In the next step, use the knob to adjust the nozzle height. Check the pictures in the handbook for reference."
 msgstr "En el siguiente paso usa el dial para ajustar la altura de la boquilla. Mira las fotos en el manual como referencia."
 
-#: src/gui/screen_menu_info.cpp:20
+#: src/gui/screen_menu_info.cpp:19
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:31
 msgid "INFO"
 msgstr "INFO"
 
-#: src/gui/screen_home.cpp:38
+#: src/gui/screen_home.cpp:39
 msgid "Info"
 msgstr "Info"
 
-#: src/guiapi/src/window_msgbox.cpp:172
+#: src/guiapi/src/window_msgbox.cpp:171
 msgid "Information"
 msgstr "Información"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:25
+#: src/gui/dialogs/DialogLoadUnload.cpp:26
 msgid "Inserting"
 msgstr "Cargando"
 
-#: src/gui/screen_menu_lan_settings.cpp:292
+#: src/gui/screen_menu_lan_settings.cpp:294
 msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
 msgstr "Las direcciones IP o los parámetros no son válidos o el archivo \"lan_settings.ini\" no está en el directorio raíz de la unidad USB."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:30
+#: src/gui/dialogs/DialogLoadUnload.cpp:31
 msgid "Is color correct?"
-msgstr "¿Está bien el color?"
+msgstr ""
+"¿Está bien\n"
+"el color?"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:26
+#: src/gui/dialogs/DialogLoadUnload.cpp:27
 msgid "Is filament in extruder gear?"
-msgstr "¿Está el filamento en los engranajes del extrusor?"
+msgstr ""
+"¿Está el filamento \n"
+"en los engranajes \n"
+"del extrusor?"
 
 #: src/gui/wizard/xyzcalib.cpp:47 src/gui/wizard/xyzcalib.cpp:240
 msgid "Is steel sheet on heatbed?"
 msgstr "¿Está la lámina de acero en la base?"
 
-#: src/gui/screen_menu_lan_settings.cpp:221
+#: src/gui/screen_menu_lan_settings.cpp:217
 msgid "LAN SETTINGS"
 msgstr "AJUSTES DE RED"
 
-#: src/guiapi/include/MItem_menus.hpp:129
+#: src/guiapi/include/MItem_menus.hpp:139
 msgid "Lan Settings"
 msgstr "Ajustes de Red"
 
-#: src/guiapi/include/MItem_menus.hpp:149
+#: src/guiapi/include/MItem_menus.hpp:159
 msgid "Language"
 msgstr "Idioma"
 
@@ -391,15 +434,15 @@ msgid "Live Adjust Z"
 msgstr "Ajuste en Vivo de Z"
 
 #. Ignore
-#: src/gui/dialogs/dialog_response.cpp:17
+#: src/common/client_response_texts.cpp:23
 msgid "LOAD"
 msgstr "CARGAR"
 
-#: src/gui/dialogs/DialogFactory.cpp:13 src/gui/screen_menu_filament.cpp:52
+#: src/gui/dialogs/DialogFactory.cpp:9
 msgid "LOAD FILAMENT"
 msgstr "CARGAR FILAMENTO"
 
-#: src/gui/screen_menu_filament.cpp:51
+#: src/gui/screen_menu_filament.cpp:40
 msgid "Load Filament"
 msgstr "Cargar filamento"
 
@@ -407,13 +450,15 @@ msgstr "Cargar filamento"
 msgid "Load Settings"
 msgstr "Cargar configuración"
 
-#: src/gui/screen_splash.cpp:43
+#: src/gui/screen_splash.cpp:38
 msgid "Loading ..."
 msgstr "Cargando..."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:28
+#: src/gui/dialogs/DialogLoadUnload.cpp:29
 msgid "Loading to nozzle"
-msgstr "Cargando a la boquilla"
+msgstr ""
+"Cargando     \n"
+"a la boquilla"
 
 #: src/guiapi/include/MItem_tools.hpp:305
 msgid "Loud"
@@ -423,11 +468,15 @@ msgstr "Alto"
 msgid "M.I.N.D.A."
 msgstr "M.I.N.D.A."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:24
+#: src/gui/dialogs/DialogLoadUnload.cpp:25
 msgid "Make sure the filament is inserted through the sensor."
-msgstr "Asegúrate que filamento está insertado a través del sensor."
+msgstr ""
+"Asegúrate que     \n"
+"filamento está    \n"
+"insertado a través\n"
+"del sensor.       "
 
-#: src/gui/screen_print_preview.cpp:128
+#: src/gui/gcode_description.cpp:37
 msgid "Material"
 msgstr "Material"
 
@@ -438,8 +487,14 @@ msgid "MAXTEMP ERROR"
 msgstr "ERROR MAXTEMP"
 
 #: src/gui/wizard/xyzcalib.cpp:192
-msgid "Measuring reference\nheight of calib.\npoints"
-msgstr "Midiendo referencia\naltura de calibra.\npuntos"
+msgid ""
+"Measuring reference\n"
+"height of calib.\n"
+"points"
+msgstr ""
+"Midiendo referencia\n"
+"altura de calibra.\n"
+"puntos"
 
 #: src/guiapi/include/MItem_tools.hpp:289
 msgid "Menu Timeout"
@@ -458,7 +513,7 @@ msgstr "NIVELADO MEDIANTE MALLA"
 msgid "MESSAGES"
 msgstr "MENSAJES"
 
-#: src/guiapi/include/MItem_menus.hpp:139
+#: src/guiapi/include/MItem_menus.hpp:149
 msgid "Messages"
 msgstr "Mensajes"
 
@@ -473,7 +528,7 @@ msgstr "ERROR MINTEMP"
 msgid "Mon"
 msgstr "Lun"
 
-#: src/guiapi/include/MItem_menus.hpp:89
+#: src/guiapi/include/MItem_menus.hpp:99
 msgid "Move Axis"
 msgstr "Mover Ejes"
 
@@ -502,12 +557,12 @@ msgid "Name"
 msgstr "Nombre"
 
 #. Load
-#: src/gui/dialogs/dialog_response.cpp:18
+#: src/common/client_response_texts.cpp:24
 msgid "NEXT"
 msgstr "SIGUIENTE"
 
 #. Next
-#: src/gui/dialogs/dialog_response.cpp:19
+#: src/common/client_response_texts.cpp:25
 msgid "NO"
 msgstr "NO"
 
@@ -515,14 +570,15 @@ msgstr "NO"
 msgid "No filament sensor detected. Verify that the sensor is connected and try again."
 msgstr "No se detectó sensor de filamento. Verifica que el sensor esté conectado e intente nuevamente."
 
-#: src/gui/screen_home.cpp:39
+#: src/gui/screen_home.cpp:40
 msgid "No USB"
 msgstr "No hay USB"
 
-#: src/gui/wizard/firstlay.cpp:98
+#: src/gui/wizard/firstlay.cpp:102
 msgid "Now, let's calibrate the distance between the tip of the nozzle and the print sheet."
 msgstr "Ahora, calibremos la distancia entre la punta de la boquilla y la lámina de impresión."
 
+#: src/gui/screen_menu_footer_settings.cpp:58
 #: src/gui/dialogs/DialogSelftestResult.cpp:47
 #: src/guiapi/include/MItem_print.hpp:8
 msgid "Nozzle"
@@ -532,17 +588,18 @@ msgstr "Boquilla"
 msgid "Nozzle and Heatbed"
 msgstr "Base y Boquilla"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:24
+#: src/gui/dialogs/DialogSelftestTemp.cpp:25
 msgid "Nozzle heater check"
 msgstr "Comp. calor boquilla"
 
 #: src/gui/screen_menu_fw_update.cpp:28
 #: src/guiapi/include/WindowMenuItems.hpp:19
+#: src/guiapi/include/WindowMenuSpin.hpp:21
 msgid "Off"
 msgstr "Off"
 
 #. No
-#: src/gui/screen_sheet_rename.cpp:17 src/gui/dialogs/dialog_response.cpp:20
+#: src/common/client_response_texts.cpp:26 src/gui/screen_sheet_rename.cpp:17
 msgid "OK"
 msgstr "OK"
 
@@ -566,11 +623,11 @@ msgstr "Una vez que la impresora comienza a extruir plástico, ajusta la altura 
 msgid "Parking"
 msgstr "Parking"
 
-#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:38
+#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:39
 msgid "Pause"
 msgstr "Pausa"
 
-#: src/gui/screen_printing.cpp:39
+#: src/gui/screen_printing.cpp:40
 msgid "Pausing..."
 msgstr "Pausando..."
 
@@ -582,15 +639,25 @@ msgstr "Coloca una hoja de papel debajo de la boquilla durante la calibración d
 msgid "Please clean the nozzle for calibration. Click NEXT when done."
 msgstr "Limpie la boquilla para la calibración. Haga clic en SIGUIENTE cuando haya terminado."
 
-#: src/gui/screen_menu_lan_settings.cpp:280
+#: src/gui/screen_menu_lan_settings.cpp:282
 msgid "Please insert a USB drive and try again."
 msgstr "Inserta una unidad USB e intenta nuevamente."
 
-#: src/gui/guimain.cpp:206
-msgid "Please insert the USB\ndrive that came with\nyour MINI and reset\nthe printer to flash\nthe firmware"
-msgstr "Por favor inserte la unidad USB que vino con tu MINI y reinicia la impresora para flashear el firmware"
+#: src/gui/guimain.cpp:229
+msgid ""
+"Please insert the USB\n"
+"drive that came with\n"
+"your MINI and reset\n"
+"the printer to flash\n"
+"the firmware"
+msgstr ""
+"Por favor inserta la unidad\n"
+"USB que viene con\n"
+"tu MINI y reinicia\n"
+"la impresora para flashear\n"
+"el firmware"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:22
+#: src/gui/dialogs/DialogLoadUnload.cpp:23
 msgid "Please open idler and remove filament manually"
 msgstr "Abre el tensor y retira el filamento manualmente"
 
@@ -606,11 +673,11 @@ msgstr "Retira la lámina de la base."
 msgid "Please wait"
 msgstr "Por favor espere"
 
-#: src/gui/screen_menu_preheat.cpp:25 src/gui/screen_menu_preheat.cpp:47
+#: src/gui/screen_menu_preheat.cpp:26 src/gui/screen_menu_preheat.cpp:49
 msgid "PREHEAT"
 msgstr "PRECALENTAR"
 
-#: src/gui/screen_home.cpp:34
+#: src/gui/screen_home.cpp:35
 msgid "Preheat"
 msgstr "Precalentar"
 
@@ -618,19 +685,17 @@ msgstr "Precalentar"
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:42
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:48
 msgid "PREHEAT ERROR"
-msgstr "ERROR DE PRECALENTAMIENTO"
+msgstr "ERROR PRECALENTAMIENTO"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:34
+#: src/gui/dialogs/DialogFactory.cpp:12
 msgid "PREHEAT for LOAD"
 msgstr "PRECALENTAR para CARGAR"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:54
+#: src/gui/dialogs/DialogFactory.cpp:13
 msgid "PREHEAT for UNLOAD"
 msgstr "PRECALENTAR para DESCARGAR"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:26
+#: src/gui/dialogs/DialogSelftestTemp.cpp:27
 msgid "Preparing"
 msgstr "Preparando"
 
@@ -638,19 +703,23 @@ msgstr "Preparando"
 msgid "Preparing to ram"
 msgstr "Preparando para expulsar"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:23
+#: src/gui/dialogs/DialogLoadUnload.cpp:24
 msgid "Press CONTINUE and push filament into the extruder."
-msgstr "Presiona CONTINUAR y empuja el filamento en el extrusor."
+msgstr ""
+"Presiona CONTINUAR\n"
+"y empuja el       \n"
+"filamento en      \n"
+"el extrusor.      "
 
 #: src/gui/wizard/screen_wizard.cpp:185
 msgid "Press NEXT to run the Selftest, which checks for potential issues related to the assembly."
 msgstr "Pulsa SIGUIENTE para ejecutar el Selftest, que comprueba potenciales problemas  con el montaje."
 
-#: src/gui/screen_print_preview.cpp:185 src/gui/screen_home.cpp:33
+#: src/gui/screen_print_preview.cpp:64 src/gui/screen_home.cpp:34
 msgid "Print"
 msgstr "Imprimir"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:19
+#: src/gui/dialogs/DialogSelftestFans.cpp:20
 #: src/gui/dialogs/DialogSelftestResult.cpp:41
 #: src/guiapi/include/MItem_print.hpp:24
 msgid "Print Fan"
@@ -660,42 +729,46 @@ msgstr "Vent. de impresión"
 msgid "Print fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "El ventilador de impresión no gira. Comprueba que no hay residuos, luego inspecciona el cableado."
 
-#: src/gui/screen_print_preview.cpp:127
+#: src/gui/gcode_description.cpp:36
 msgid "Print Time"
 msgstr "Duración de la impresión"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #. theoretically it can be removed completely in case the string is constant for the whole run of the screen
-#: src/gui/screen_printing.cpp:222
+#: src/gui/screen_printing.cpp:244
 msgid "Print will end"
 msgstr "La impresión finalizará"
 
-#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:360
+#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:370
 msgid "PRINTING"
 msgstr "IMPRIMIENDO"
 
-#: src/gui/screen_printing.cpp:158
+#: src/gui/screen_printing.cpp:160
 msgid "Printing time"
 msgstr "Tiempo de impresión"
 
-#: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
+#: src/gui/dialogs/DialogFactory.cpp:11 src/gui/screen_menu_filament.cpp:87
 msgid "PURGE FILAMENT"
 msgstr "PURGAR FILAMENTO"
 
-#: src/gui/screen_menu_filament.cpp:109
+#: src/gui/screen_menu_filament.cpp:86
 msgid "Purge Filament"
 msgstr "Purgar filamento"
 
 #. Ok
-#: src/gui/dialogs/dialog_response.cpp:21
+#. PC filament, do not translate
+#. PETG filament, do not translate
+#. PLA filament, do not translate
+#. PP filament, do not translate
+#: src/common/client_response_texts.cpp:31
 msgid "PURGE MORE"
 msgstr "PURGAR MÁS"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:29
+#: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Purging"
 msgstr "Purgando"
 
-#: src/guiapi/src/window_msgbox.cpp:156
+#: src/guiapi/src/window_msgbox.cpp:157
 msgid "Question"
 msgstr "Pregunta"
 
@@ -703,18 +776,18 @@ msgstr "Pregunta"
 msgid "Ramming"
 msgstr "Ramming"
 
-#: src/gui/screen_printing_serial.cpp:45
+#: src/gui/screen_printing_serial.cpp:43
 msgid "Really Disconnect?"
 msgstr "¿Seguro desconectar?"
 
 #. Purge_more
-#: src/gui/dialogs/dialog_response.cpp:22
+#: src/common/client_response_texts.cpp:32
 msgid "REHEAT"
 msgstr "RECALENTAR"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
-#: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
-#: src/gui/screen_printing.cpp:355
+#: src/gui/screen_printing.cpp:149 src/gui/screen_printing.cpp:248
+#: src/gui/screen_printing.cpp:365
 msgid "Remaining Time"
 msgstr "Tiempo Restante"
 
@@ -726,7 +799,7 @@ msgstr "RENOMBRAR"
 msgid "Rename"
 msgstr "Renombrar"
 
-#: src/gui/screen_printing.cpp:44
+#: src/gui/screen_printing.cpp:45
 msgid "Reprint"
 msgstr "Volver a imprimir"
 
@@ -734,23 +807,24 @@ msgstr "Volver a imprimir"
 msgid "Reset"
 msgstr "Reset"
 
-#: src/common/MindaRedscreen.cpp:175 src/gui/guimain.cpp:207
+#: src/common/MindaRedscreen.cpp:175
 msgid "RESET PRINTER"
 msgstr "RESET IMPRESORA"
 
-#: src/gui/screen_printing.cpp:41
+#: src/gui/screen_printing.cpp:42
 msgid "Resume"
 msgstr "Continuar"
 
-#: src/gui/screen_printing.cpp:42
+#: src/gui/screen_printing.cpp:43
 msgid "Resuming..."
 msgstr "Continuando..."
 
 #. Reheat
-#: src/gui/dialogs/dialog_response.cpp:23
+#: src/common/client_response_texts.cpp:33
 msgid "RETRY"
 msgstr "REINTENTAR"
 
+#: src/gui/dialogs/window_dlg_preheat.hpp:39
 #: src/guiapi/include/WindowMenuItems.hpp:54
 msgid "Return"
 msgstr "Volver"
@@ -769,8 +843,12 @@ msgid "Save Settings"
 msgstr "Guardar ajustes"
 
 #: src/gui/wizard/xyzcalib.cpp:180
-msgid "Searching bed\ncalibration points"
-msgstr "Buscando la base\npuntos de calibración"
+msgid ""
+"Searching bed\n"
+"calibration points"
+msgstr ""
+"Buscando la base\n"
+"puntos de calibración"
 
 #: src/gui/screen_menu_steel_sheets.cpp:33
 msgid "Select"
@@ -778,9 +856,9 @@ msgstr "Seleccionar"
 
 #: src/gui/wizard/firstlay.cpp:71
 msgid "Select Filament Type"
-msgstr "Selecc. tipo de filamento"
+msgstr "Selecciona el Tipo de Filamento"
 
-#: src/gui/screen_filebrowser.cpp:42
+#: src/gui/screen_filebrowser.cpp:43
 msgid "SELECT FILE"
 msgstr "SELECC. ARCHIVO"
 
@@ -788,9 +866,15 @@ msgstr "SELECC. ARCHIVO"
 msgid "SELECT LANGUAGE"
 msgstr "SELECC. IDIOMA"
 
-#: src/gui/screen_menu_fw_update.cpp:74
+#: src/gui/screen_menu_fw_update.cpp:96
 msgid "Select when you want to automatically flash updated firmware from USB flash disk."
-msgstr "Selecciona donde quieres flashear automáticamente el firmware actualizado desde una memoria USB."
+msgstr ""
+"Selecciona donde\n"
+"quieres flashear\n"
+"automáticamente\n"
+"el firmware\n"
+"actualizado desde\n"
+"una memoria USB."
 
 #: src/guiapi/include/MItem_tools.hpp:49
 msgid "SelfTest"
@@ -808,23 +892,24 @@ msgstr "INFO SENSOR"
 msgid "Sensor Info"
 msgstr "Info Sensor"
 
-#: src/gui/screen_printing_serial.hpp:13
+#. filament sensor will think printer is in printing state
+#: src/gui/screen_printing_serial.hpp:15
 msgid "SERIAL PRINTING"
 msgstr "IMPRESIÓN SERIE"
 
-#: src/guiapi/include/MItem_menus.hpp:99
+#: src/guiapi/include/MItem_menus.hpp:109
 msgid "Service"
 msgstr "Mantenimiento"
 
-#: src/gui/screen_home.cpp:37
+#: src/gui/screen_home.cpp:38
 msgid "Settings"
 msgstr "Ajustes"
 
-#: src/gui/screen_menu_settings.cpp:107
+#: src/gui/screen_menu_settings.cpp:108
 msgid "SETTINGS"
 msgstr "AJUSTES"
 
-#: src/gui/screen_menu_lan_settings.cpp:289
+#: src/gui/screen_menu_lan_settings.cpp:291
 msgid "Settings successfully loaded"
 msgstr "Configuración cargada correctamente"
 
@@ -852,28 +937,34 @@ msgstr "Modo Sonido"
 msgid "Sound Volume"
 msgstr "Volumen sonido"
 
+#. ItemFilament
+#: src/gui/screen_menu_footer_settings.cpp:61
 #: src/guiapi/include/MItem_print.hpp:32
 msgid "Speed"
 msgstr "Velocidad"
 
-#: src/gui/screen_menu_lan_settings.cpp:277
+#: src/gui/screen_menu_lan_settings.cpp:279
 msgid "Static IPv4 addresses were not set."
 msgstr "Las direcciones IPv4 estáticas no se configuraron."
 
-#: src/guiapi/include/MItem_menus.hpp:49
-msgid "Statistic"
-msgstr "Estadística"
+#: src/gui/screen_menu_odometer.cpp:15
+msgid "STATISTICS"
+msgstr "ESTADÍSTICAS"
+
+#: src/guiapi/include/MItem_menus.hpp:29
+msgid "Statistics"
+msgstr "Estadísticas"
 
 #: src/gui/screen_menu_steel_sheets.cpp:176 src/gui/screen_menu_hw_setup.cpp:16
 msgid "Steel Sheets"
 msgstr "Lámina Acero"
 
 #. Retry
-#: src/gui/dialogs/dialog_response.cpp:24
+#: src/common/client_response_texts.cpp:34
 msgid "STOP"
 msgstr "PARAR"
 
-#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:40
+#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:41
 msgid "Stop"
 msgstr "Parar"
 
@@ -882,11 +973,11 @@ msgstr "Parar"
 msgid "Sun"
 msgstr "Dom"
 
-#: src/guiapi/include/MItem_menus.hpp:69
+#: src/guiapi/include/MItem_menus.hpp:79
 msgid "Support"
 msgstr "Soporte"
 
-#: src/guiapi/include/MItem_menus.hpp:39
+#: src/guiapi/include/MItem_menus.hpp:49
 msgid "System Info"
 msgstr "Info Sistema"
 
@@ -894,11 +985,11 @@ msgstr "Info Sistema"
 msgid "TEMPERATURE"
 msgstr "TEMPERATURA"
 
-#: src/guiapi/include/MItem_menus.hpp:79
+#: src/guiapi/include/MItem_menus.hpp:89
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: src/guiapi/include/MItem_menus.hpp:109
+#: src/guiapi/include/MItem_menus.hpp:119
 msgid "Test"
 msgstr "Test"
 
@@ -915,7 +1006,7 @@ msgid "Test XYZ-Axis"
 msgstr "Test Ejes XYZ"
 
 #. save eeprom flag
-#: src/gui/wizard/firstlay.cpp:184
+#: src/gui/wizard/firstlay.cpp:189
 msgid "The first layer calibration failed to finish. Double-check the printer's wiring, nozzle and axes, then restart the calibration."
 msgstr "La calibración de la primera capa no pudo finalizar. Vuelva a verificar el cableado, la boquilla y los ejes de la impresora, luego reinicia la calibración."
 
@@ -923,19 +1014,31 @@ msgstr "La calibración de la primera capa no pudo finalizar. Vuelva a verificar
 msgid "The selftest failed to finish. Double-check the printer's wiring and axes. Then restart the Selftest."
 msgstr "El selftest falló al terminar. Verifica dos veces el cableado de la impresora y los ejes. Luego reinicie el Selftest."
 
-#: src/gui/screen_menu_lan_settings.cpp:283
+#: src/gui/screen_menu_lan_settings.cpp:285
 msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
 msgstr "La configuración se ha guardado correctamente en el archivo \"lan_settings.ini\"."
 
 #: src/gui/wizard/screen_wizard.cpp:170
-msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
-msgstr "La barra de estado está en el fondo de la pantalla. Contiene Información sobre:\n- Temp. de la boquilla\n- Temp. de la base\n- Vel. de impresión\n- Alt. del eje Z\n- Fil. seleccionado"
+msgid ""
+"The status bar is at the bottom of the screen. It contains information about:\n"
+"- Nozzle temp.\n"
+"- Heatbed temp.\n"
+"- Printing speed\n"
+"- Z-axis height\n"
+"- Selected filament"
+msgstr ""
+"La barra de estado está en el fondo de la pantalla. Contiene Información sobre:\n"
+"- Temp. de la boquilla\n"
+"- Temp. de la base\n"
+"- Vel. de impresión\n"
+"- Alt. del eje Z\n"
+"- Fil. seleccionado"
 
 #: src/gui/wizard/xyzcalib.cpp:298
 msgid "The XYZ calibration failed to finish. Double-check the printer's wiring and axes, then restart the XYZ calibration."
 msgstr "La calibración XYZ no pudo finalizar. Vuelva a verificar el cableado y los ejes de la impresora, luego reinicia la calibración XYZ."
 
-#: src/gui/screen_menu_lan_settings.cpp:286
+#: src/gui/screen_menu_lan_settings.cpp:288
 msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
 msgstr "Se produjo un error al guardar la configuración en el archivo \"lan_settings.ini\"."
 
@@ -943,9 +1046,9 @@ msgstr "Se produjo un error al guardar la configuración en el archivo \"lan_set
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:54
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:60
 msgid "THERMAL RUNAWAY"
-msgstr "DERIVA TÉRMICA"
+msgstr "THERMAL RUNAWAY"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26
 msgid "This G-CODE was set up for another printer type."
 msgstr "Este G-CODE se configuró para otro tipo de impresora."
 
@@ -985,20 +1088,20 @@ msgstr "Mar"
 msgid "TUNE"
 msgstr "AJUSTES"
 
-#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:37
+#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:38
 msgid "Tune"
 msgstr "Ajustes"
 
 #. Stop
-#: src/gui/dialogs/dialog_response.cpp:25
+#: src/common/client_response_texts.cpp:35
 msgid "UNLOAD"
 msgstr "DESCARGAR"
 
-#: src/gui/dialogs/DialogFactory.cpp:14 src/gui/screen_menu_filament.cpp:72
+#: src/gui/dialogs/DialogFactory.cpp:10 src/gui/screen_menu_filament.cpp:57
 msgid "UNLOAD FILAMENT"
 msgstr "DESCARGAR FILAMENTO"
 
-#: src/gui/screen_menu_filament.cpp:71
+#: src/gui/screen_menu_filament.cpp:56
 msgid "Unload Filament"
 msgstr "Descargar filamento"
 
@@ -1014,11 +1117,11 @@ msgstr "Unparking"
 msgid "USB drive error, the print is now paused. Reconnect the drive."
 msgstr "Error de la unidad USB, la impresión ahora está en pausa. Vuelve a conectar la unidad."
 
-#: src/gui/screen_print_preview.cpp:129
+#: src/gui/gcode_description.cpp:38
 msgid "Used Filament"
 msgstr "Filamento Consumido"
 
-#: src/gui/screen_menu_version_info.cpp:31
+#: src/gui/version_info_ST7789V.cpp:27
 msgid "VERSION INFO"
 msgstr "INFO VERSION"
 
@@ -1034,7 +1137,7 @@ msgstr "Esperando temp."
 msgid "Warning"
 msgstr "Cuidado"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26 src/gui/screen_print_preview.cpp:113
 msgid "WARNING:"
 msgstr "CUIDADO:"
 
@@ -1064,7 +1167,7 @@ msgid "WIZARD - OK"
 msgstr "ASISTENTE - OK"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:43
-#: src/gui/dialogs/DialogSelftestAxis.cpp:19
+#: src/gui/dialogs/DialogSelftestAxis.cpp:25
 msgid "X-axis"
 msgstr "Eje X"
 
@@ -1073,12 +1176,12 @@ msgid "XYZ CALIBRATION"
 msgstr "CALIBRACIÓN XYZ"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:44
-#: src/gui/dialogs/DialogSelftestAxis.cpp:20
+#: src/gui/dialogs/DialogSelftestAxis.cpp:26
 msgid "Y-axis"
 msgstr "Eje Y"
 
 #. Unload
-#: src/gui/dialogs/dialog_response.cpp:26
+#: src/common/client_response_texts.cpp:36
 msgid "YES"
 msgstr "SÍ"
 
@@ -1087,6 +1190,6 @@ msgid "Z height:"
 msgstr "Altura en Z:"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:45
-#: src/gui/dialogs/DialogSelftestAxis.cpp:21
+#: src/gui/dialogs/DialogSelftestAxis.cpp:27
 msgid "Z-axis"
 msgstr "Eje Z"

--- a/src/lang/po/fr/Prusa-Firmware-Buddy_fr.po
+++ b/src/lang/po/fr/Prusa-Firmware-Buddy_fr.po
@@ -5,25 +5,39 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
+"X-Generator: Phrase (phrase.com)\n"
 
 #. c=20 r=4
-#: src/gui/screen_menu_version_info.cpp:82
+#: src/gui/version_info_ST7789V.cpp:102
 #, c-format
-msgid "\nBootloader Version\n%d.%d.%d\n\nBuddy Board\n%d.%d.%d\n%s"
-msgstr "\nBootloader Version\n %d.%d.%d\n\nBuddy Board\n%d.%d.%d\n %s"
+msgid ""
+"\n"
+"Bootloader Version\n"
+"%d.%d.%d\n"
+"\n"
+"Buddy Board\n"
+"%d.%d.%d\n"
+"%s"
+msgstr ""
+"\n"
+"Bootloader Version\n"
+" %d.%d.%d\n"
+"\n"
+"Buddy Board\n"
+"%d.%d.%d\n"
+" %s"
 
 #: src/guiapi/src/MItem_tools.cpp:200
 msgid "A crash dump report (file dump.bin) has been saved to the USB drive."
 msgstr "Un rapport de vidage de mémoire suite à une panne (file dump.bin) a été sauvegardé sur la clé USB."
 
 #. _none
-#: src/gui/dialogs/dialog_response.cpp:11
+#: src/common/client_response_texts.cpp:11
 msgid "ABORT"
 msgstr "STOPPER"
 
 #. / title text
-#: src/gui/dialogs/liveadjust_z.cpp:205
+#: src/gui/dialogs/liveadjust_z.cpp:207
 msgid "Adjust the nozzle height above the heatbed by turning the knob"
 msgstr "Ajustez la hauteur de la buse au dessus du plateau en tournant le bouton"
 
@@ -35,28 +49,30 @@ msgstr "Tous les tests ont été passés avec succès !"
 msgid "Always"
 msgstr "Toujours"
 
-#: src/gui/screen_printing.cpp:103
+#: src/gui/screen_printing.cpp:104
 msgid "Are you sure to stop this printing?"
 msgstr "Êtes-vous certain de vouloir stopper cette impression ?"
 
 #: src/guiapi/include/MItem_tools.hpp:307
 msgid "Assist"
-msgstr "Aider"
+msgstr "Assisté"
 
 #: src/guiapi/include/MItem_tools.hpp:29
 msgid "Auto Home"
-msgstr "Repositionner Auto"
+msgstr "Mise a 0 des axes"
 
 #. Abort
-#: src/gui/dialogs/dialog_response.cpp:12
+#. ABS filament, do not translate
+#. ASA filament, do not translate
+#: src/common/client_response_texts.cpp:14
 msgid "BACK"
 msgstr "ARRIÈRE"
 
-#: src/gui/screen_print_preview.cpp:189
+#: src/gui/screen_print_preview.cpp:68
 msgid "Back"
 msgstr "Retour"
 
-#: src/gui/screen_printing.cpp:205
+#: src/gui/screen_printing.cpp:208
 msgid "Bed leveling failed. Try again?"
 msgstr "Échec nivelage plateau. Réessayer ?"
 
@@ -64,7 +80,7 @@ msgstr "Échec nivelage plateau. Réessayer ?"
 msgid "Calibrating Z"
 msgstr "Calibration Z"
 
-#: src/gui/screen_home.cpp:36
+#: src/gui/screen_home.cpp:37
 msgid "Calibration"
 msgstr "Calibration"
 
@@ -74,55 +90,57 @@ msgstr "CALIBRATION"
 
 #: src/gui/wizard/screen_wizard.cpp:192
 msgid "Calibration successful! Happy printing!"
-msgstr "Calibration réussie!\nBonnes impressions!"
+msgstr ""
+"Calibration réussie!\n"
+"Bonnes impressions!"
 
 #: src/gui/wizard/xyzcalib.cpp:230
 msgid "Calibration XY"
 msgstr "Calibration XY"
 
 #. Back
-#: src/gui/screen_sheet_rename.cpp:18 src/gui/dialogs/dialog_response.cpp:13
+#: src/common/client_response_texts.cpp:15 src/gui/screen_sheet_rename.cpp:18
 msgid "CANCEL"
 msgstr "ANNULER"
 
-#: src/gui/dialogs/DialogFactory.cpp:12 src/gui/screen_menu_filament.cpp:90
+#: src/gui/dialogs/DialogFactory.cpp:8 src/gui/screen_menu_filament.cpp:72
 msgid "CHANGE FILAMENT"
 msgstr "CHANGER LE FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:89 src/guiapi/include/MItem_tools.hpp:279
+#: src/gui/screen_menu_filament.cpp:71 src/guiapi/include/MItem_tools.hpp:279
 msgid "Change Filament"
 msgstr "Changer le Filament"
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:44
 msgid "Check the heatbed heater & thermistor wiring for possible damage."
-msgstr "Vérifier dommages possibles sur câbles bloc de chauffe et thermistance du plateau chauf."
+msgstr "Vérifiez que le câblage du chauffage et de la thermistance n'est pas endommagé."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:56
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:68
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:80
 msgid "Check the heatbed thermistor wiring for possible damage."
-msgstr "Vérifier dommages possibles sur câbles de thermistance du plateau chauf."
+msgstr "Vérifiez que le câblage de la thermistance du plateau chauffant n'est pas endommagé."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:50
 msgid "Check the print head heater & thermistor wiring for possible damage."
-msgstr "Vérifier dommages possibles sur câbles du bloc de chauf. & thermistance de tête d'extr."
+msgstr "Vérifiez le câblage du chauffage de la tête d'impression et de la thermistance pour détecter d'éventuels dommages."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:62
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:74
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:86
 msgid "Check the print head thermistor wiring for possible damage."
-msgstr "Vérifier dommages possibles sur câbles de thermistance de tête d'extr."
+msgstr "Vérifiez que le câblage de la thermistance de la tête d'impression n'est pas endommagé."
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:42
-#: src/gui/dialogs/DialogSelftestAxis.cpp:18
+#: src/gui/dialogs/DialogSelftestAxis.cpp:24
 msgid "Checking axes"
 msgstr "Vérification axes"
 
-#: src/gui/wizard/firstlay.cpp:168
+#: src/gui/wizard/firstlay.cpp:173
 msgid "Clean steel sheet."
 msgstr "Nettoyez la plaque d'acier."
 
@@ -130,12 +148,12 @@ msgstr "Nettoyez la plaque d'acier."
 msgid "Congratulations! XYZ calibration is ok. XY axes are perpendicular."
 msgstr "Félicitations ! La calibration XYZ est bonne. Les axes XY sont perpendiculaires."
 
-#. Cancel
-#: src/gui/dialogs/dialog_response.cpp:14
+#. Change
+#: src/common/client_response_texts.cpp:17
 msgid "CONTINUE"
 msgstr "CONTINUER"
 
-#: src/common/filament.cpp:13 src/gui/screen_menu_temperature.cpp:12
+#: src/gui/screen_menu_temperature.cpp:12
 msgid "Cooldown"
 msgstr "Refroidissement"
 
@@ -143,16 +161,16 @@ msgstr "Refroidissement"
 msgid "CPU load"
 msgstr "Charge CPU"
 
-#: src/guiapi/include/MItem_menus.hpp:169
+#: src/guiapi/include/MItem_menus.hpp:179
 msgid "Current Profile"
 msgstr "Profil Actuel"
 
-#: src/guiapi/include/MItem_menus.hpp:192
+#: src/guiapi/include/MItem_menus.hpp:202
 msgid "Device hash in QR"
 msgstr "ID de l'appareil dans QR"
 
-#. Continue
-#: src/gui/dialogs/dialog_response.cpp:15
+#. Cooldown
+#: src/common/client_response_texts.cpp:19
 msgid "DISABLE SENSOR"
 msgstr "DÉSACTIVER CAPTEUR"
 
@@ -160,25 +178,33 @@ msgstr "DÉSACTIVER CAPTEUR"
 msgid "Disable Steppers"
 msgstr "Désactiver Moteurs"
 
-#: src/gui/screen_printing_serial.hpp:10
+#: src/gui/screen_printing_serial.hpp:11
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: src/gui/wizard/firstlay.cpp:160
+#: src/gui/wizard/firstlay.cpp:165
 msgid "Do you want to repeat the last step and readjust the distance between the nozzle and heatbed?"
 msgstr "Répéter la dernière étape et réajuster la distance entre la buse et le plateau chauffant ?"
 
-#. c=20 r=6
-#: src/gui/wizard/firstlay.cpp:112
+#. c=21 r=9
+#: src/gui/wizard/firstlay.cpp:116
 #, c-format
-msgid "Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)"
-msgstr "Voulez-vous utiliser les valeurs actuelles ?\nActuelles : %0.3f.\nDéfaut : %0.3f.\nCliquez sur NON pour utiliser la valeur par défaut (recommandé)"
+msgid ""
+"Do you want to use the current value?\n"
+"Current: %0.3f.\n"
+"Default: %0.3f.\n"
+"Click NO to use the default value (recommended)"
+msgstr ""
+"Voulez-vous utiliser les valeurs actuelles ?\n"
+"Actuelles : %0.3f.\n"
+"Défaut : %0.3f.\n"
+"Cliquez sur NON pour utiliser la valeur par défaut (recommandé)"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:27
+#: src/gui/dialogs/DialogLoadUnload.cpp:28
 msgid "Ejecting"
 msgstr "Éjection"
 
-#: src/guiapi/src/window_msgbox.cpp:150
+#: src/guiapi/src/window_msgbox.cpp:152
 msgid "Error"
 msgstr "Erreur"
 
@@ -202,11 +228,11 @@ msgstr "Réglages d'usine chargés. Le système va redémarrer."
 msgid "Factory Reset"
 msgstr "Réinitalisation d'Usine"
 
-#: src/guiapi/include/MItem_menus.hpp:59
+#: src/guiapi/include/MItem_menus.hpp:69
 msgid "Fail Stats"
 msgstr "Statistiques Échec"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:17
+#: src/gui/dialogs/DialogSelftestFans.cpp:18
 #: src/gui/dialogs/DialogSelftestResult.cpp:39
 msgid "Fan Test"
 msgstr "Test Ventilateur"
@@ -219,19 +245,22 @@ msgstr "RPM Vent0"
 msgid "Fan1 RPM"
 msgstr "RPM Vent1"
 
-#: src/gui/screen_menu_filament.cpp:127
+#: src/gui/screen_menu_filament.cpp:101
 msgid "FILAMENT"
 msgstr "FILAMENT"
 
-#: src/gui/screen_home.cpp:35 src/guiapi/include/MItem_menus.hpp:29
+#. ItemBed
+#: src/gui/screen_menu_odometer.cpp:18
+#: src/gui/screen_menu_footer_settings.cpp:60 src/gui/screen_home.cpp:36
+#: src/guiapi/include/MItem_menus.hpp:39
 msgid "Filament"
 msgstr "Filament"
 
-#: src/gui/screen_menu_filament.cpp:53
+#: src/gui/screen_menu_filament.cpp:41
 msgid "Filament appears to be already loaded, are you sure you want to load it anyway?"
 msgstr "Le filament semble être déjà chargé, êtes-vous certain de vouloir le charger malgré cela ?"
 
-#: src/gui/screen_print_preview.cpp:223
+#: src/gui/screen_print_preview.cpp:95
 msgid "Filament not detected. Load filament now? Select NO to cancel, or IGNORE to disable the filament sensor and continue."
 msgstr "Filament non détecté. Charger filament maintenant ? Sélectionnez NON pour annuler, ou IGNORER pour désactiver le capteur de filament et continuer."
 
@@ -246,18 +275,22 @@ msgid "Finishing buffered gcodes."
 msgstr "Finalisation G-Codes en mémoire tampon."
 
 #. r=1 c=20
-#: src/gui/screen_menu_version_info.cpp:60
+#: src/gui/version_info_ST7789V.cpp:80
 msgid "Firmware Version\n"
 msgstr "Version Firmware\n"
 
 #: src/gui/screen_menu_steel_sheets.cpp:46 src/gui/ScreenFirstLayer.hpp:12
 #: src/guiapi/include/MItem_tools.hpp:69
 msgid "First Layer Calibration"
-msgstr "Calibration Première Couche"
+msgstr ""
+"Calibration\n"
+"Première Couche"
 
 #: src/gui/wizard/screen_wizard.cpp:31
 msgid "FIRST LAYER CALIBRATION"
-msgstr "CALIBRATION PREMIÈRE COUCHE"
+msgstr ""
+"CALIBRATION\n"
+"PREMIÈRE COUCHE"
 
 #: src/guiapi/include/MItem_print.hpp:40
 msgid "Flow Factor"
@@ -268,11 +301,11 @@ msgstr "Facteur de Débit"
 msgid "Fri"
 msgstr "ven"
 
-#: src/gui/screen_menu_fw_update.cpp:70
+#: src/gui/screen_menu_fw_update.cpp:69
 msgid "FW UPDATE"
 msgstr "MISE À JOUR FW"
 
-#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:119
+#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:129
 msgid "FW Update"
 msgstr "Mise à jour FW"
 
@@ -281,41 +314,45 @@ msgstr "Mise à jour FW"
 msgid "Heatbed"
 msgstr "Plateau Chauffant"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:25
+#: src/gui/dialogs/DialogSelftestTemp.cpp:26
 msgid "Heatbed heater check"
 msgstr "Test chauf. plateau"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:27
+#: src/gui/dialogs/DialogSelftestTemp.cpp:28
 msgid "Heater testing"
 msgstr "Test chauf."
 
-#: src/gui/guimain.cpp:194
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:34
 msgid "Heating disabled due to 30 minutes of inactivity."
 msgstr "Chauffe désactivée du fait d'une inactivité de plus de 30 minutes."
 
-#: src/gui/screen_printing.cpp:43
+#: src/gui/screen_printing.cpp:44
 msgid "Heating..."
 msgstr "En chauffe..."
 
-#: src/gui/guimain.cpp:205
-msgid "Hi, this is your\nOriginal Prusa MINI."
-msgstr "Bonjour, voici votre\nOriginal Prusa MINI."
+#: src/gui/guimain.cpp:228
+msgid ""
+"Hi, this is your\n"
+"Original Prusa MINI."
+msgstr ""
+"Bonjour, voici votre\n"
+"Original Prusa MINI."
 
-#: src/gui/screen_home.cpp:68
+#: src/gui/screen_home.cpp:72
 msgid "HOME"
 msgstr "ACCUEIL"
 
 #. special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
 #. and will get a nice house-like icon
-#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:45
+#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:46
 msgid "Home"
 msgstr "Accueil"
 
-#: src/gui/dialogs/DialogFactory.cpp:40
+#: src/gui/dialogs/DialogFactory.cpp:53
 msgid "HOME TO MAX"
 msgstr "HOME TO MAX"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:18
+#: src/gui/dialogs/DialogSelftestFans.cpp:19
 #: src/gui/dialogs/DialogSelftestResult.cpp:40
 msgid "Hotend Fan"
 msgstr "Vent. hotend"
@@ -324,45 +361,48 @@ msgstr "Vent. hotend"
 msgid "Hotend fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "Le ventilateur de hotend ne tourne pas. Vérifiez s'il n'y a pas de débris, puis inspectez le câblage."
 
-#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:159
+#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:169
 msgid "HW Setup"
 msgstr "Réglage Matériel"
 
 #. Filament_removed
-#: src/gui/dialogs/dialog_response.cpp:16
+#. FLEX filament, do not translate
+#. HIPS filament, do not translate
+#: src/common/client_response_texts.cpp:22
 msgid "IGNORE"
 msgstr "IGNORER"
 
 #. static const char en_text[] = N_("Observe the pattern and turn the knob to adjust the nozzle height in real time. Extruded plastic must stick to the print surface.");
-#: src/gui/wizard/firstlay.cpp:128
+#: src/gui/wizard/firstlay.cpp:132
 msgid "In the next step, use the knob to adjust the nozzle height. Check the pictures in the handbook for reference."
 msgstr "Au cours de la prochaine étape, utilisez le bouton pour ajuster la hauteur de la buse. Consultez les photos dans le manuel comme référence."
 
-#: src/gui/screen_menu_info.cpp:20
+#: src/gui/screen_menu_info.cpp:19
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:31
 msgid "INFO"
 msgstr "INFO"
 
-#: src/gui/screen_home.cpp:38
+#: src/gui/screen_home.cpp:39
 msgid "Info"
 msgstr "Info"
 
-#: src/guiapi/src/window_msgbox.cpp:172
+#: src/guiapi/src/window_msgbox.cpp:171
 msgid "Information"
 msgstr "Information"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:25
+#: src/gui/dialogs/DialogLoadUnload.cpp:26
 msgid "Inserting"
 msgstr "Insertion"
 
-#: src/gui/screen_menu_lan_settings.cpp:292
+#: src/gui/screen_menu_lan_settings.cpp:294
 msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
 msgstr "Les adresses IP ou les paramètres ne sont pas valides ou alors le fichier \"lan_settings.ini\" ne se trouve pas dans le répertoire racine de la clé USB."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:30
+#: src/gui/dialogs/DialogLoadUnload.cpp:31
 msgid "Is color correct?"
 msgstr "La couleur est-elle correcte ?"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:26
+#: src/gui/dialogs/DialogLoadUnload.cpp:27
 msgid "Is filament in extruder gear?"
 msgstr "Le filament est-il dans l'extrudeur ?"
 
@@ -370,15 +410,15 @@ msgstr "Le filament est-il dans l'extrudeur ?"
 msgid "Is steel sheet on heatbed?"
 msgstr "La plaque d'acier est-elle sur le plateau chauffant ?"
 
-#: src/gui/screen_menu_lan_settings.cpp:221
+#: src/gui/screen_menu_lan_settings.cpp:217
 msgid "LAN SETTINGS"
 msgstr "RÉGLAGES LAN"
 
-#: src/guiapi/include/MItem_menus.hpp:129
+#: src/guiapi/include/MItem_menus.hpp:139
 msgid "Lan Settings"
 msgstr "Réglages Lan"
 
-#: src/guiapi/include/MItem_menus.hpp:149
+#: src/guiapi/include/MItem_menus.hpp:159
 msgid "Language"
 msgstr "Langue"
 
@@ -391,27 +431,27 @@ msgid "Live Adjust Z"
 msgstr "Live Adjust Z"
 
 #. Ignore
-#: src/gui/dialogs/dialog_response.cpp:17
+#: src/common/client_response_texts.cpp:23
 msgid "LOAD"
 msgstr "CHARGER"
 
-#: src/gui/dialogs/DialogFactory.cpp:13 src/gui/screen_menu_filament.cpp:52
+#: src/gui/dialogs/DialogFactory.cpp:9
 msgid "LOAD FILAMENT"
 msgstr "CHARGER FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:51
+#: src/gui/screen_menu_filament.cpp:40
 msgid "Load Filament"
-msgstr "Charger le Filament"
+msgstr "Charger filament"
 
 #: src/gui/screen_menu_lan_settings.cpp:202
 msgid "Load Settings"
 msgstr "Charger les Réglages"
 
-#: src/gui/screen_splash.cpp:43
+#: src/gui/screen_splash.cpp:38
 msgid "Loading ..."
 msgstr "Chargement..."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:28
+#: src/gui/dialogs/DialogLoadUnload.cpp:29
 msgid "Loading to nozzle"
 msgstr "Chargement de la buse"
 
@@ -423,11 +463,11 @@ msgstr "Fort"
 msgid "M.I.N.D.A."
 msgstr "M.I.N.D.A."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:24
+#: src/gui/dialogs/DialogLoadUnload.cpp:25
 msgid "Make sure the filament is inserted through the sensor."
 msgstr "Vérifiez que le filament est bien inséré dans le capteur."
 
-#: src/gui/screen_print_preview.cpp:128
+#: src/gui/gcode_description.cpp:37
 msgid "Material"
 msgstr "Matériau"
 
@@ -438,8 +478,14 @@ msgid "MAXTEMP ERROR"
 msgstr "ERREUR MAXTEMP"
 
 #: src/gui/wizard/xyzcalib.cpp:192
-msgid "Measuring reference\nheight of calib.\npoints"
-msgstr "Mesure des hauteurs\ndé référence des\npoints de calib."
+msgid ""
+"Measuring reference\n"
+"height of calib.\n"
+"points"
+msgstr ""
+"Mesure des hauteurs\n"
+"dé référence des\n"
+"points de calib."
 
 #: src/guiapi/include/MItem_tools.hpp:289
 msgid "Menu Timeout"
@@ -458,7 +504,7 @@ msgstr "MESH BED LEVEL."
 msgid "MESSAGES"
 msgstr "MESSAGES"
 
-#: src/guiapi/include/MItem_menus.hpp:139
+#: src/guiapi/include/MItem_menus.hpp:149
 msgid "Messages"
 msgstr "Messages"
 
@@ -473,7 +519,7 @@ msgstr "ERREUR MINTEMP"
 msgid "Mon"
 msgstr "lun"
 
-#: src/guiapi/include/MItem_menus.hpp:89
+#: src/guiapi/include/MItem_menus.hpp:99
 msgid "Move Axis"
 msgstr "Déplacer l'Axe"
 
@@ -502,12 +548,12 @@ msgid "Name"
 msgstr "Nom"
 
 #. Load
-#: src/gui/dialogs/dialog_response.cpp:18
+#: src/common/client_response_texts.cpp:24
 msgid "NEXT"
 msgstr "SUIVANT"
 
 #. Next
-#: src/gui/dialogs/dialog_response.cpp:19
+#: src/common/client_response_texts.cpp:25
 msgid "NO"
 msgstr "NON"
 
@@ -515,14 +561,15 @@ msgstr "NON"
 msgid "No filament sensor detected. Verify that the sensor is connected and try again."
 msgstr "Aucun capteur de filament n'a été détecté. Vérifiez que le capteur est bien branché et réessayez."
 
-#: src/gui/screen_home.cpp:39
+#: src/gui/screen_home.cpp:40
 msgid "No USB"
 msgstr "Pas d'USB"
 
-#: src/gui/wizard/firstlay.cpp:98
+#: src/gui/wizard/firstlay.cpp:102
 msgid "Now, let's calibrate the distance between the tip of the nozzle and the print sheet."
 msgstr "À présent calibrons la distance entre l'extrémité de la buse et la plaque d'impression."
 
+#: src/gui/screen_menu_footer_settings.cpp:58
 #: src/gui/dialogs/DialogSelftestResult.cpp:47
 #: src/guiapi/include/MItem_print.hpp:8
 msgid "Nozzle"
@@ -532,17 +579,18 @@ msgstr "Buse"
 msgid "Nozzle and Heatbed"
 msgstr "Buse et Plateau"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:24
+#: src/gui/dialogs/DialogSelftestTemp.cpp:25
 msgid "Nozzle heater check"
 msgstr "Test chauf. buse"
 
 #: src/gui/screen_menu_fw_update.cpp:28
 #: src/guiapi/include/WindowMenuItems.hpp:19
+#: src/guiapi/include/WindowMenuSpin.hpp:21
 msgid "Off"
 msgstr "Off"
 
 #. No
-#: src/gui/screen_sheet_rename.cpp:17 src/gui/dialogs/dialog_response.cpp:20
+#: src/common/client_response_texts.cpp:26 src/gui/screen_sheet_rename.cpp:17
 msgid "OK"
 msgstr "OK"
 
@@ -566,11 +614,11 @@ msgstr "Lorsque l'imprimante commence à extruder le plastique ajustez la hauteu
 msgid "Parking"
 msgstr "Parking"
 
-#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:38
+#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:39
 msgid "Pause"
 msgstr "Pause"
 
-#: src/gui/screen_printing.cpp:39
+#: src/gui/screen_printing.cpp:40
 msgid "Pausing..."
 msgstr "Mise en pause..."
 
@@ -582,17 +630,30 @@ msgstr "Positionnez une feuille de papier sous la buse pendant la calibration de
 msgid "Please clean the nozzle for calibration. Click NEXT when done."
 msgstr "Veuillez nettoyer la buse en vue de la calibration. Cliquez sur NEXT une fois cela fait."
 
-#: src/gui/screen_menu_lan_settings.cpp:280
+#: src/gui/screen_menu_lan_settings.cpp:282
 msgid "Please insert a USB drive and try again."
 msgstr "Veuillez insérer une clé USB et réessayer."
 
-#: src/gui/guimain.cpp:206
-msgid "Please insert the USB\ndrive that came with\nyour MINI and reset\nthe printer to flash\nthe firmware"
-msgstr "Veuillez insérer la clé USB fournie avec votre MINI et redémarrez l'imprimante pour flasher le firmware"
+#: src/gui/guimain.cpp:229
+msgid ""
+"Please insert the USB\n"
+"drive that came with\n"
+"your MINI and reset\n"
+"the printer to flash\n"
+"the firmware"
+msgstr ""
+"Veuillez insérer la clé USB\n"
+"fournie avec votre MINI\n"
+"et réinitialisez l'imprimante\n"
+"pour flasher\n"
+"le firmware."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:22
+#: src/gui/dialogs/DialogLoadUnload.cpp:23
 msgid "Please open idler and remove filament manually"
-msgstr "Ouvrez l'idler et retirez le filament manuellement"
+msgstr ""
+"Ouvrez l'idler et\n"
+"retirez le filament\n"
+"manuellement"
 
 #: src/gui/wizard/xyzcalib.cpp:85 src/gui/wizard/xyzcalib.cpp:273
 msgid "Please place steel sheet on heatbed."
@@ -606,11 +667,11 @@ msgstr "Veuillez retirer la feuille d'impression du plateau."
 msgid "Please wait"
 msgstr "Veuillez patienter"
 
-#: src/gui/screen_menu_preheat.cpp:25 src/gui/screen_menu_preheat.cpp:47
+#: src/gui/screen_menu_preheat.cpp:26 src/gui/screen_menu_preheat.cpp:49
 msgid "PREHEAT"
 msgstr "PRÉCHAUFFER"
 
-#: src/gui/screen_home.cpp:34
+#: src/gui/screen_home.cpp:35
 msgid "Preheat"
 msgstr "Préchauffage"
 
@@ -620,17 +681,15 @@ msgstr "Préchauffage"
 msgid "PREHEAT ERROR"
 msgstr "ERREUR DE PRÉCHAUFFAGE"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:34
+#: src/gui/dialogs/DialogFactory.cpp:12
 msgid "PREHEAT for LOAD"
 msgstr "PRÉCHAUF. av. CHARG."
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:54
+#: src/gui/dialogs/DialogFactory.cpp:13
 msgid "PREHEAT for UNLOAD"
 msgstr "PRÉCHAUFFER pour DÉCHARGER"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:26
+#: src/gui/dialogs/DialogSelftestTemp.cpp:27
 msgid "Preparing"
 msgstr "En préparation"
 
@@ -638,7 +697,7 @@ msgstr "En préparation"
 msgid "Preparing to ram"
 msgstr "Expulsion en préparation"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:23
+#: src/gui/dialogs/DialogLoadUnload.cpp:24
 msgid "Press CONTINUE and push filament into the extruder."
 msgstr "Appuyez sur CONTINUER et insérez le filament dans l'extrudeur."
 
@@ -646,11 +705,11 @@ msgstr "Appuyez sur CONTINUER et insérez le filament dans l'extrudeur."
 msgid "Press NEXT to run the Selftest, which checks for potential issues related to the assembly."
 msgstr "Appuyez sur SUIVANT pour lancer le Selftest détectant les éventuels problèmes liés à l'assemblage."
 
-#: src/gui/screen_print_preview.cpp:185 src/gui/screen_home.cpp:33
+#: src/gui/screen_print_preview.cpp:64 src/gui/screen_home.cpp:34
 msgid "Print"
 msgstr "Impression"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:19
+#: src/gui/dialogs/DialogSelftestFans.cpp:20
 #: src/gui/dialogs/DialogSelftestResult.cpp:41
 #: src/guiapi/include/MItem_print.hpp:24
 msgid "Print Fan"
@@ -660,42 +719,46 @@ msgstr "Ventil. d'impression"
 msgid "Print fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "Le ventilateur d'impression ne tourne pas. Vérifiez s'il n'y a pas de débris, puis inspectez le câblage."
 
-#: src/gui/screen_print_preview.cpp:127
+#: src/gui/gcode_description.cpp:36
 msgid "Print Time"
 msgstr "Temps d'Impression"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #. theoretically it can be removed completely in case the string is constant for the whole run of the screen
-#: src/gui/screen_printing.cpp:222
+#: src/gui/screen_printing.cpp:244
 msgid "Print will end"
 msgstr "L'impression va s'arrêter"
 
-#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:360
+#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:370
 msgid "PRINTING"
 msgstr "IMPRESSION"
 
-#: src/gui/screen_printing.cpp:158
+#: src/gui/screen_printing.cpp:160
 msgid "Printing time"
 msgstr "Temps d'impression"
 
-#: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
+#: src/gui/dialogs/DialogFactory.cpp:11 src/gui/screen_menu_filament.cpp:87
 msgid "PURGE FILAMENT"
 msgstr "PURGER LE FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:109
+#: src/gui/screen_menu_filament.cpp:86
 msgid "Purge Filament"
-msgstr "Purger le Filament"
+msgstr "Purger filament"
 
 #. Ok
-#: src/gui/dialogs/dialog_response.cpp:21
+#. PC filament, do not translate
+#. PETG filament, do not translate
+#. PLA filament, do not translate
+#. PP filament, do not translate
+#: src/common/client_response_texts.cpp:31
 msgid "PURGE MORE"
 msgstr "PURGER PLUS"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:29
+#: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Purging"
 msgstr "Purge"
 
-#: src/guiapi/src/window_msgbox.cpp:156
+#: src/guiapi/src/window_msgbox.cpp:157
 msgid "Question"
 msgstr "Question"
 
@@ -703,18 +766,18 @@ msgstr "Question"
 msgid "Ramming"
 msgstr "Expulsion"
 
-#: src/gui/screen_printing_serial.cpp:45
+#: src/gui/screen_printing_serial.cpp:43
 msgid "Really Disconnect?"
 msgstr "Valider Déconnexion?"
 
 #. Purge_more
-#: src/gui/dialogs/dialog_response.cpp:22
+#: src/common/client_response_texts.cpp:32
 msgid "REHEAT"
 msgstr "RE-CHAUFFER"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
-#: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
-#: src/gui/screen_printing.cpp:355
+#: src/gui/screen_printing.cpp:149 src/gui/screen_printing.cpp:248
+#: src/gui/screen_printing.cpp:365
 msgid "Remaining Time"
 msgstr "Temps restant"
 
@@ -726,7 +789,7 @@ msgstr "RENOMMER"
 msgid "Rename"
 msgstr "Renommer"
 
-#: src/gui/screen_printing.cpp:44
+#: src/gui/screen_printing.cpp:45
 msgid "Reprint"
 msgstr "Ré-imprimer"
 
@@ -734,23 +797,24 @@ msgstr "Ré-imprimer"
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: src/common/MindaRedscreen.cpp:175 src/gui/guimain.cpp:207
+#: src/common/MindaRedscreen.cpp:175
 msgid "RESET PRINTER"
 msgstr "REDÉMARRER L'IMPR."
 
-#: src/gui/screen_printing.cpp:41
+#: src/gui/screen_printing.cpp:42
 msgid "Resume"
 msgstr "Relancer"
 
-#: src/gui/screen_printing.cpp:42
+#: src/gui/screen_printing.cpp:43
 msgid "Resuming..."
 msgstr "Relance..."
 
 #. Reheat
-#: src/gui/dialogs/dialog_response.cpp:23
+#: src/common/client_response_texts.cpp:33
 msgid "RETRY"
 msgstr "RÉESSAYER"
 
+#: src/gui/dialogs/window_dlg_preheat.hpp:39
 #: src/guiapi/include/WindowMenuItems.hpp:54
 msgid "Return"
 msgstr "Retour"
@@ -769,8 +833,12 @@ msgid "Save Settings"
 msgstr "Sauvegarder Réglages"
 
 #: src/gui/wizard/xyzcalib.cpp:180
-msgid "Searching bed\ncalibration points"
-msgstr "Recherche des points\nde calib. du plateau"
+msgid ""
+"Searching bed\n"
+"calibration points"
+msgstr ""
+"Recherche des points\n"
+"de calib. du plateau"
 
 #: src/gui/screen_menu_steel_sheets.cpp:33
 msgid "Select"
@@ -778,9 +846,9 @@ msgstr "Sélectionner"
 
 #: src/gui/wizard/firstlay.cpp:71
 msgid "Select Filament Type"
-msgstr "Sélectionner le Type de Filament"
+msgstr "Sélectionnez le Type de Filament"
 
-#: src/gui/screen_filebrowser.cpp:42
+#: src/gui/screen_filebrowser.cpp:43
 msgid "SELECT FILE"
 msgstr "SÉLECTIONNER FICHIER"
 
@@ -788,7 +856,7 @@ msgstr "SÉLECTIONNER FICHIER"
 msgid "SELECT LANGUAGE"
 msgstr "SÉLECTIONNER LANGUE"
 
-#: src/gui/screen_menu_fw_update.cpp:74
+#: src/gui/screen_menu_fw_update.cpp:96
 msgid "Select when you want to automatically flash updated firmware from USB flash disk."
 msgstr "Sélectionnez quand vous voulez flasher automatiquement une version mise à jour du firmware depuis une clé USB."
 
@@ -806,25 +874,26 @@ msgstr "INFO CAPTEUR"
 
 #: src/guiapi/include/MItem_menus.hpp:19
 msgid "Sensor Info"
-msgstr "Info Capteur"
+msgstr "Infos Capteur"
 
-#: src/gui/screen_printing_serial.hpp:13
+#. filament sensor will think printer is in printing state
+#: src/gui/screen_printing_serial.hpp:15
 msgid "SERIAL PRINTING"
 msgstr "IMPRESSION SÉRIE"
 
-#: src/guiapi/include/MItem_menus.hpp:99
+#: src/guiapi/include/MItem_menus.hpp:109
 msgid "Service"
 msgstr "Maintenance"
 
-#: src/gui/screen_home.cpp:37
+#: src/gui/screen_home.cpp:38
 msgid "Settings"
 msgstr "Réglages"
 
-#: src/gui/screen_menu_settings.cpp:107
+#: src/gui/screen_menu_settings.cpp:108
 msgid "SETTINGS"
 msgstr "RÉGLAGES"
 
-#: src/gui/screen_menu_lan_settings.cpp:289
+#: src/gui/screen_menu_lan_settings.cpp:291
 msgid "Settings successfully loaded"
 msgstr "Chargement des réglages réussi"
 
@@ -852,28 +921,34 @@ msgstr "Mode Sonore"
 msgid "Sound Volume"
 msgstr "Volume Sonore"
 
+#. ItemFilament
+#: src/gui/screen_menu_footer_settings.cpp:61
 #: src/guiapi/include/MItem_print.hpp:32
 msgid "Speed"
 msgstr "Vitesse"
 
-#: src/gui/screen_menu_lan_settings.cpp:277
+#: src/gui/screen_menu_lan_settings.cpp:279
 msgid "Static IPv4 addresses were not set."
 msgstr "Adresses IPv4 statiques non définies."
 
-#: src/guiapi/include/MItem_menus.hpp:49
-msgid "Statistic"
-msgstr "Statistique"
+#: src/gui/screen_menu_odometer.cpp:15
+msgid "STATISTICS"
+msgstr "STATISTIQUES"
+
+#: src/guiapi/include/MItem_menus.hpp:29
+msgid "Statistics"
+msgstr "Statistiques"
 
 #: src/gui/screen_menu_steel_sheets.cpp:176 src/gui/screen_menu_hw_setup.cpp:16
 msgid "Steel Sheets"
 msgstr "Feuilles d'Acier"
 
 #. Retry
-#: src/gui/dialogs/dialog_response.cpp:24
+#: src/common/client_response_texts.cpp:34
 msgid "STOP"
 msgstr "STOP"
 
-#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:40
+#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:41
 msgid "Stop"
 msgstr "Stop"
 
@@ -882,11 +957,11 @@ msgstr "Stop"
 msgid "Sun"
 msgstr "dim"
 
-#: src/guiapi/include/MItem_menus.hpp:69
+#: src/guiapi/include/MItem_menus.hpp:79
 msgid "Support"
 msgstr "Assistance"
 
-#: src/guiapi/include/MItem_menus.hpp:39
+#: src/guiapi/include/MItem_menus.hpp:49
 msgid "System Info"
 msgstr "Infos Système"
 
@@ -894,11 +969,11 @@ msgstr "Infos Système"
 msgid "TEMPERATURE"
 msgstr "TEMPÉRATURE"
 
-#: src/guiapi/include/MItem_menus.hpp:79
+#: src/guiapi/include/MItem_menus.hpp:89
 msgid "Temperature"
 msgstr "Température"
 
-#: src/guiapi/include/MItem_menus.hpp:109
+#: src/guiapi/include/MItem_menus.hpp:119
 msgid "Test"
 msgstr "Test"
 
@@ -908,34 +983,46 @@ msgstr "Test VENTILATEURs"
 
 #: src/guiapi/include/MItem_tools.hpp:99
 msgid "Test Heaters"
-msgstr "Tester Chauffe"
+msgstr "Test Chauffe"
 
 #: src/guiapi/include/MItem_tools.hpp:89
 msgid "Test XYZ-Axis"
-msgstr "Test XYZ-Axis"
+msgstr "Test Axes XYZ"
 
 #. save eeprom flag
-#: src/gui/wizard/firstlay.cpp:184
+#: src/gui/wizard/firstlay.cpp:189
 msgid "The first layer calibration failed to finish. Double-check the printer's wiring, nozzle and axes, then restart the calibration."
 msgstr "La calibration de première couche n'a pu aboutir. Vérifiez bien le câblage de l'imprimante, la buse et les axes, puis relancez la calibration."
 
 #: src/gui/wizard/selftest.cpp:44
 msgid "The selftest failed to finish. Double-check the printer's wiring and axes. Then restart the Selftest."
-msgstr "Le selftest pas pu aboutir. Vérifiez bien le câblage et les axes de l'imprimante. Puis relancez le selftest."
+msgstr "Le selftest n'a pas pu aboutir. Vérifiez bien le câblage et les axes de l'imprimante. Puis relancez le selftest."
 
-#: src/gui/screen_menu_lan_settings.cpp:283
+#: src/gui/screen_menu_lan_settings.cpp:285
 msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
 msgstr "Les réglages ont été sauvegardés avec succès dans le fichier \"lan_settings.ini\"."
 
 #: src/gui/wizard/screen_wizard.cpp:170
-msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
-msgstr "La barre de statut se trouve dans le bas de l'écran. Elle contient des infos concernant :\n-La temp. de la buse\n-La temp. du plateau\n-La vitesse d'impr.\n-La hauteur Z-axis\n-Le fil. sélectionné"
+msgid ""
+"The status bar is at the bottom of the screen. It contains information about:\n"
+"- Nozzle temp.\n"
+"- Heatbed temp.\n"
+"- Printing speed\n"
+"- Z-axis height\n"
+"- Selected filament"
+msgstr ""
+"La barre de statut se trouve dans le bas de l'écran. Elle contient des infos concernant :\n"
+"-La temp. de la buse\n"
+"-La temp. du plateau\n"
+"-La vitesse d'impr.\n"
+"-La hauteur Z-axis\n"
+"-Le fil. sélectionné"
 
 #: src/gui/wizard/xyzcalib.cpp:298
 msgid "The XYZ calibration failed to finish. Double-check the printer's wiring and axes, then restart the XYZ calibration."
 msgstr "La calibration XYZ n'a pas pu aboutir. Vérifiez bien le câblage et les axes de l'imprimante, puis relancez la calibration XYZ."
 
-#: src/gui/screen_menu_lan_settings.cpp:286
+#: src/gui/screen_menu_lan_settings.cpp:288
 msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
 msgstr "Une erreur s'est produite au moment de sauvegarder les réglages dans le fichier \"lan_settings.ini\"."
 
@@ -943,9 +1030,9 @@ msgstr "Une erreur s'est produite au moment de sauvegarder les réglages dans le
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:54
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:60
 msgid "THERMAL RUNAWAY"
-msgstr "EMBAL. THERMIQUE"
+msgstr "EMBALLEMENT THERMIQUE"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26
 msgid "This G-CODE was set up for another printer type."
 msgstr "Ce G-CODEa été paramétré pour un autre type d'imprimante."
 
@@ -985,22 +1072,22 @@ msgstr "mar"
 msgid "TUNE"
 msgstr "RÉGLER"
 
-#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:37
+#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:38
 msgid "Tune"
 msgstr "Régler"
 
 #. Stop
-#: src/gui/dialogs/dialog_response.cpp:25
+#: src/common/client_response_texts.cpp:35
 msgid "UNLOAD"
 msgstr "DÉCHARGER"
 
-#: src/gui/dialogs/DialogFactory.cpp:14 src/gui/screen_menu_filament.cpp:72
+#: src/gui/dialogs/DialogFactory.cpp:10 src/gui/screen_menu_filament.cpp:57
 msgid "UNLOAD FILAMENT"
 msgstr "DÉCHARGER FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:71
+#: src/gui/screen_menu_filament.cpp:56
 msgid "Unload Filament"
-msgstr "Décharger Filament"
+msgstr "Décharger filament"
 
 #: src/gui/dialogs/DialogLoadUnload.cpp:20
 msgid "Unloading"
@@ -1014,11 +1101,11 @@ msgstr "Unparking"
 msgid "USB drive error, the print is now paused. Reconnect the drive."
 msgstr "Erreur de clé USB, l'impression est actuellement mise en pause. Rebranchez la clé USB."
 
-#: src/gui/screen_print_preview.cpp:129
+#: src/gui/gcode_description.cpp:38
 msgid "Used Filament"
 msgstr "Filament Utilisé"
 
-#: src/gui/screen_menu_version_info.cpp:31
+#: src/gui/version_info_ST7789V.cpp:27
 msgid "VERSION INFO"
 msgstr "INFOS VERSION"
 
@@ -1034,7 +1121,7 @@ msgstr "En attente de temp."
 msgid "Warning"
 msgstr "Avertissement"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26 src/gui/screen_print_preview.cpp:113
 msgid "WARNING:"
 msgstr "ATTENTION :"
 
@@ -1064,7 +1151,7 @@ msgid "WIZARD - OK"
 msgstr "ASSISTANT - OK"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:43
-#: src/gui/dialogs/DialogSelftestAxis.cpp:19
+#: src/gui/dialogs/DialogSelftestAxis.cpp:25
 msgid "X-axis"
 msgstr "Axe X"
 
@@ -1073,12 +1160,12 @@ msgid "XYZ CALIBRATION"
 msgstr "CALIBRATION XYZ"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:44
-#: src/gui/dialogs/DialogSelftestAxis.cpp:20
+#: src/gui/dialogs/DialogSelftestAxis.cpp:26
 msgid "Y-axis"
 msgstr "Axe Y"
 
 #. Unload
-#: src/gui/dialogs/dialog_response.cpp:26
+#: src/common/client_response_texts.cpp:36
 msgid "YES"
 msgstr "OUI"
 
@@ -1087,6 +1174,6 @@ msgid "Z height:"
 msgstr "Hauteur Z :"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:45
-#: src/gui/dialogs/DialogSelftestAxis.cpp:21
+#: src/gui/dialogs/DialogSelftestAxis.cpp:27
 msgid "Z-axis"
 msgstr "Axe Z"

--- a/src/lang/po/it/Prusa-Firmware-Buddy_it.po
+++ b/src/lang/po/it/Prusa-Firmware-Buddy_it.po
@@ -5,25 +5,39 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
+"X-Generator: Phrase (phrase.com)\n"
 
 #. c=20 r=4
-#: src/gui/screen_menu_version_info.cpp:82
+#: src/gui/version_info_ST7789V.cpp:102
 #, c-format
-msgid "\nBootloader Version\n%d.%d.%d\n\nBuddy Board\n%d.%d.%d\n%s"
-msgstr "\nVers. Bootloader\n%d.%d.%d\n\nScheda Buddy\n%d.%d.%d\n%s"
+msgid ""
+"\n"
+"Bootloader Version\n"
+"%d.%d.%d\n"
+"\n"
+"Buddy Board\n"
+"%d.%d.%d\n"
+"%s"
+msgstr ""
+"\n"
+"Vers. Bootloader\n"
+"%d.%d.%d\n"
+"\n"
+"Scheda Buddy\n"
+"%d.%d.%d\n"
+"%s"
 
 #: src/guiapi/src/MItem_tools.cpp:200
 msgid "A crash dump report (file dump.bin) has been saved to the USB drive."
 msgstr "Un rapporto di crash dump (file dump.bin) è stato salvato sul drive USB."
 
 #. _none
-#: src/gui/dialogs/dialog_response.cpp:11
+#: src/common/client_response_texts.cpp:11
 msgid "ABORT"
 msgstr "INTERROMPI"
 
 #. / title text
-#: src/gui/dialogs/liveadjust_z.cpp:205
+#: src/gui/dialogs/liveadjust_z.cpp:207
 msgid "Adjust the nozzle height above the heatbed by turning the knob"
 msgstr "Regola l'altezza ugello sopra il piano ruotando la manopola"
 
@@ -35,28 +49,30 @@ msgstr "Tutti i test completati correttamente!"
 msgid "Always"
 msgstr "Sempre"
 
-#: src/gui/screen_printing.cpp:103
+#: src/gui/screen_printing.cpp:104
 msgid "Are you sure to stop this printing?"
 msgstr "Vuoi interrompere la stampa?"
 
 #: src/guiapi/include/MItem_tools.hpp:307
 msgid "Assist"
-msgstr "Assistenza"
+msgstr "Assistito"
 
 #: src/guiapi/include/MItem_tools.hpp:29
 msgid "Auto Home"
 msgstr "Auto Home"
 
 #. Abort
-#: src/gui/dialogs/dialog_response.cpp:12
+#. ABS filament, do not translate
+#. ASA filament, do not translate
+#: src/common/client_response_texts.cpp:14
 msgid "BACK"
 msgstr "INDIETRO"
 
-#: src/gui/screen_print_preview.cpp:189
+#: src/gui/screen_print_preview.cpp:68
 msgid "Back"
 msgstr "Indietro"
 
-#: src/gui/screen_printing.cpp:205
+#: src/gui/screen_printing.cpp:208
 msgid "Bed leveling failed. Try again?"
 msgstr "Livellamento del piano non riuscito. Riprovare?"
 
@@ -64,7 +80,7 @@ msgstr "Livellamento del piano non riuscito. Riprovare?"
 msgid "Calibrating Z"
 msgstr "Calibrazione Z"
 
-#: src/gui/screen_home.cpp:36
+#: src/gui/screen_home.cpp:37
 msgid "Calibration"
 msgstr "Calibraz."
 
@@ -81,48 +97,48 @@ msgid "Calibration XY"
 msgstr "Calibrazione XY"
 
 #. Back
-#: src/gui/screen_sheet_rename.cpp:18 src/gui/dialogs/dialog_response.cpp:13
+#: src/common/client_response_texts.cpp:15 src/gui/screen_sheet_rename.cpp:18
 msgid "CANCEL"
 msgstr "ANNULLA"
 
-#: src/gui/dialogs/DialogFactory.cpp:12 src/gui/screen_menu_filament.cpp:90
+#: src/gui/dialogs/DialogFactory.cpp:8 src/gui/screen_menu_filament.cpp:72
 msgid "CHANGE FILAMENT"
 msgstr "CAMBIO FILAMENTO"
 
-#: src/gui/screen_menu_filament.cpp:89 src/guiapi/include/MItem_tools.hpp:279
+#: src/gui/screen_menu_filament.cpp:71 src/guiapi/include/MItem_tools.hpp:279
 msgid "Change Filament"
 msgstr "Cambio filamento"
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:44
 msgid "Check the heatbed heater & thermistor wiring for possible damage."
-msgstr "Controllare eventuali danni sui cavi del piano riscaldato e del termistore."
+msgstr "Controllare il cablaggio del termistore e del riscaldamento del piano riscaldato per eventuali danni."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:56
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:68
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:80
 msgid "Check the heatbed thermistor wiring for possible damage."
-msgstr "Controllare eventuali danni sul cavo del termistore del piano riscaldato."
+msgstr "Controllare il cablaggio del termistore del piano riscaldato per eventuali danni."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:50
 msgid "Check the print head heater & thermistor wiring for possible damage."
-msgstr "Controllare eventuali danni sui cavi del hotend e del termistore."
+msgstr "Controllare il cablaggio del termistore e della cartuccia riscaldante della testina di stampa per eventuali danni."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:62
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:74
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:86
 msgid "Check the print head thermistor wiring for possible damage."
-msgstr "Controllare eventuali danni sul cavo del termistore del hotend."
+msgstr "Controllare il cablaggio del termistore della testina di stampa per eventuali danni."
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:42
-#: src/gui/dialogs/DialogSelftestAxis.cpp:18
+#: src/gui/dialogs/DialogSelftestAxis.cpp:24
 msgid "Checking axes"
 msgstr "Controllo assi"
 
-#: src/gui/wizard/firstlay.cpp:168
+#: src/gui/wizard/firstlay.cpp:173
 msgid "Clean steel sheet."
 msgstr "Pulire lastra d'acciaio."
 
@@ -130,12 +146,12 @@ msgstr "Pulire lastra d'acciaio."
 msgid "Congratulations! XYZ calibration is ok. XY axes are perpendicular."
 msgstr "Congratulazioni! Calibrazione XYZ ok. Assi XY sono perpendicolari."
 
-#. Cancel
-#: src/gui/dialogs/dialog_response.cpp:14
+#. Change
+#: src/common/client_response_texts.cpp:17
 msgid "CONTINUE"
 msgstr "CONTINUA"
 
-#: src/common/filament.cpp:13 src/gui/screen_menu_temperature.cpp:12
+#: src/gui/screen_menu_temperature.cpp:12
 msgid "Cooldown"
 msgstr "Raffreddamento"
 
@@ -143,16 +159,16 @@ msgstr "Raffreddamento"
 msgid "CPU load"
 msgstr "Carico CPU"
 
-#: src/guiapi/include/MItem_menus.hpp:169
+#: src/guiapi/include/MItem_menus.hpp:179
 msgid "Current Profile"
 msgstr "Profilo corrente"
 
-#: src/guiapi/include/MItem_menus.hpp:192
+#: src/guiapi/include/MItem_menus.hpp:202
 msgid "Device hash in QR"
 msgstr "Info stampante in QR"
 
-#. Continue
-#: src/gui/dialogs/dialog_response.cpp:15
+#. Cooldown
+#: src/common/client_response_texts.cpp:19
 msgid "DISABLE SENSOR"
 msgstr "DISATTIVA SENSORE"
 
@@ -160,25 +176,33 @@ msgstr "DISATTIVA SENSORE"
 msgid "Disable Steppers"
 msgstr "Disabilita motori"
 
-#: src/gui/screen_printing_serial.hpp:10
+#: src/gui/screen_printing_serial.hpp:11
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: src/gui/wizard/firstlay.cpp:160
+#: src/gui/wizard/firstlay.cpp:165
 msgid "Do you want to repeat the last step and readjust the distance between the nozzle and heatbed?"
 msgstr "Vuoi ripetere l'ultimo passo e regolare ancora la distanza tra ugello e piano riscaldato?"
 
-#. c=20 r=6
-#: src/gui/wizard/firstlay.cpp:112
+#. c=21 r=9
+#: src/gui/wizard/firstlay.cpp:116
 #, c-format
-msgid "Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)"
-msgstr "Vuoi usare il valore attuale?\nAttuale: %0.3f.\nDefault: %0.3f.\nFare clic su NO per utilizzare il valore predefinito (consigliato)"
+msgid ""
+"Do you want to use the current value?\n"
+"Current: %0.3f.\n"
+"Default: %0.3f.\n"
+"Click NO to use the default value (recommended)"
+msgstr ""
+"Vuoi usare il valore attuale?\n"
+"Attuale: %0.3f.\n"
+"Default: %0.3f.\n"
+"Fare clic su NO per utilizzare il valore predefinito (consigliato)"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:27
+#: src/gui/dialogs/DialogLoadUnload.cpp:28
 msgid "Ejecting"
 msgstr "Espulsione"
 
-#: src/guiapi/src/window_msgbox.cpp:150
+#: src/guiapi/src/window_msgbox.cpp:152
 msgid "Error"
 msgstr "Errore"
 
@@ -202,11 +226,11 @@ msgstr "Valori predefiniti di fabbrica caricati. Adeesso il sistema verrà riavv
 msgid "Factory Reset"
 msgstr "Ripristino impostazioni di fabbrica"
 
-#: src/guiapi/include/MItem_menus.hpp:59
+#: src/guiapi/include/MItem_menus.hpp:69
 msgid "Fail Stats"
 msgstr "Stat. fallimenti"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:17
+#: src/gui/dialogs/DialogSelftestFans.cpp:18
 #: src/gui/dialogs/DialogSelftestResult.cpp:39
 msgid "Fan Test"
 msgstr "Test ventola"
@@ -219,19 +243,22 @@ msgstr "RPM Fan0"
 msgid "Fan1 RPM"
 msgstr "RPM Fan1"
 
-#: src/gui/screen_menu_filament.cpp:127
+#: src/gui/screen_menu_filament.cpp:101
 msgid "FILAMENT"
 msgstr "FILAMENTO"
 
-#: src/gui/screen_home.cpp:35 src/guiapi/include/MItem_menus.hpp:29
+#. ItemBed
+#: src/gui/screen_menu_odometer.cpp:18
+#: src/gui/screen_menu_footer_settings.cpp:60 src/gui/screen_home.cpp:36
+#: src/guiapi/include/MItem_menus.hpp:39
 msgid "Filament"
 msgstr "Filamento"
 
-#: src/gui/screen_menu_filament.cpp:53
+#: src/gui/screen_menu_filament.cpp:41
 msgid "Filament appears to be already loaded, are you sure you want to load it anyway?"
 msgstr "Il filamento sembra essere già caricato, sei sicuro di volerlo caricare comunque?"
 
-#: src/gui/screen_print_preview.cpp:223
+#: src/gui/screen_print_preview.cpp:95
 msgid "Filament not detected. Load filament now? Select NO to cancel, or IGNORE to disable the filament sensor and continue."
 msgstr "Filamento non rilevato. Caricare il filamento ora? Selezionare NO per annullare o IGNORA per disabilitare il sensore del filamento e continuare."
 
@@ -246,7 +273,7 @@ msgid "Finishing buffered gcodes."
 msgstr "Completamento gcode bufferizzati."
 
 #. r=1 c=20
-#: src/gui/screen_menu_version_info.cpp:60
+#: src/gui/version_info_ST7789V.cpp:80
 msgid "Firmware Version\n"
 msgstr "Vers. firmware\n"
 
@@ -268,11 +295,11 @@ msgstr "Fattore di flusso"
 msgid "Fri"
 msgstr "Ve"
 
-#: src/gui/screen_menu_fw_update.cpp:70
+#: src/gui/screen_menu_fw_update.cpp:69
 msgid "FW UPDATE"
 msgstr "AGGIORNAMENTO FW"
 
-#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:119
+#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:129
 msgid "FW Update"
 msgstr "Aggiornamento FW"
 
@@ -281,41 +308,45 @@ msgstr "Aggiornamento FW"
 msgid "Heatbed"
 msgstr "Piano riscaldato"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:25
+#: src/gui/dialogs/DialogSelftestTemp.cpp:26
 msgid "Heatbed heater check"
 msgstr "Contr. risc. Piano"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:27
+#: src/gui/dialogs/DialogSelftestTemp.cpp:28
 msgid "Heater testing"
 msgstr "Test riscald."
 
-#: src/gui/guimain.cpp:194
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:34
 msgid "Heating disabled due to 30 minutes of inactivity."
 msgstr "Riscaldamento disattivato dopo 30 minuti di inattività."
 
-#: src/gui/screen_printing.cpp:43
+#: src/gui/screen_printing.cpp:44
 msgid "Heating..."
 msgstr "Riscaldamento..."
 
-#: src/gui/guimain.cpp:205
-msgid "Hi, this is your\nOriginal Prusa MINI."
-msgstr "Ciao, questa è la tua Original Prusa MINI."
+#: src/gui/guimain.cpp:228
+msgid ""
+"Hi, this is your\n"
+"Original Prusa MINI."
+msgstr ""
+"Ciao, sono la tua\n"
+"Original Prusa MINI."
 
-#: src/gui/screen_home.cpp:68
+#: src/gui/screen_home.cpp:72
 msgid "HOME"
 msgstr "HOME"
 
 #. special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
 #. and will get a nice house-like icon
-#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:45
+#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:46
 msgid "Home"
 msgstr "Home"
 
-#: src/gui/dialogs/DialogFactory.cpp:40
+#: src/gui/dialogs/DialogFactory.cpp:53
 msgid "HOME TO MAX"
 msgstr "HOME TO MAX"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:18
+#: src/gui/dialogs/DialogSelftestFans.cpp:19
 #: src/gui/dialogs/DialogSelftestResult.cpp:40
 msgid "Hotend Fan"
 msgstr "Ventola hotend"
@@ -324,45 +355,48 @@ msgstr "Ventola hotend"
 msgid "Hotend fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "La ventola dell'hotend non gira. Verifica la presenza di eventuali detriti, quindi ispeziona il cablaggio."
 
-#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:159
+#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:169
 msgid "HW Setup"
-msgstr "Installazione HW"
+msgstr "Impostazione HW"
 
 #. Filament_removed
-#: src/gui/dialogs/dialog_response.cpp:16
+#. FLEX filament, do not translate
+#. HIPS filament, do not translate
+#: src/common/client_response_texts.cpp:22
 msgid "IGNORE"
 msgstr "IGNORA"
 
 #. static const char en_text[] = N_("Observe the pattern and turn the knob to adjust the nozzle height in real time. Extruded plastic must stick to the print surface.");
-#: src/gui/wizard/firstlay.cpp:128
+#: src/gui/wizard/firstlay.cpp:132
 msgid "In the next step, use the knob to adjust the nozzle height. Check the pictures in the handbook for reference."
 msgstr "Nel prossimo passo, usa la manopola per regolare l'altezza ugello. Controlla le immagini sul manuale per rifer."
 
-#: src/gui/screen_menu_info.cpp:20
+#: src/gui/screen_menu_info.cpp:19
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:31
 msgid "INFO"
 msgstr "INFO"
 
-#: src/gui/screen_home.cpp:38
+#: src/gui/screen_home.cpp:39
 msgid "Info"
 msgstr "Info"
 
-#: src/guiapi/src/window_msgbox.cpp:172
+#: src/guiapi/src/window_msgbox.cpp:171
 msgid "Information"
 msgstr "Informazioni"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:25
+#: src/gui/dialogs/DialogLoadUnload.cpp:26
 msgid "Inserting"
 msgstr "Inserimento"
 
-#: src/gui/screen_menu_lan_settings.cpp:292
+#: src/gui/screen_menu_lan_settings.cpp:294
 msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
 msgstr "Indirizzi IP o parametri non validi o il file \"lan_settings.ini\" non presente nella directory principale del drive USB."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:30
+#: src/gui/dialogs/DialogLoadUnload.cpp:31
 msgid "Is color correct?"
 msgstr "Il colore è corretto?"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:26
+#: src/gui/dialogs/DialogLoadUnload.cpp:27
 msgid "Is filament in extruder gear?"
 msgstr "Il filamento è nell'ingranaggio dell'estrusore?"
 
@@ -370,15 +404,15 @@ msgstr "Il filamento è nell'ingranaggio dell'estrusore?"
 msgid "Is steel sheet on heatbed?"
 msgstr "La piastra d'acciaio è sul piano riscaldato?"
 
-#: src/gui/screen_menu_lan_settings.cpp:221
+#: src/gui/screen_menu_lan_settings.cpp:217
 msgid "LAN SETTINGS"
 msgstr "IMPOSTAZIONI LAN"
 
-#: src/guiapi/include/MItem_menus.hpp:129
+#: src/guiapi/include/MItem_menus.hpp:139
 msgid "Lan Settings"
 msgstr "Impostazioni Lan"
 
-#: src/guiapi/include/MItem_menus.hpp:149
+#: src/guiapi/include/MItem_menus.hpp:159
 msgid "Language"
 msgstr "Lingua"
 
@@ -391,15 +425,15 @@ msgid "Live Adjust Z"
 msgstr "Live Adjust Z"
 
 #. Ignore
-#: src/gui/dialogs/dialog_response.cpp:17
+#: src/common/client_response_texts.cpp:23
 msgid "LOAD"
 msgstr "CARICA"
 
-#: src/gui/dialogs/DialogFactory.cpp:13 src/gui/screen_menu_filament.cpp:52
+#: src/gui/dialogs/DialogFactory.cpp:9
 msgid "LOAD FILAMENT"
 msgstr "CARICA FILAMENTO"
 
-#: src/gui/screen_menu_filament.cpp:51
+#: src/gui/screen_menu_filament.cpp:40
 msgid "Load Filament"
 msgstr "Carica filamento"
 
@@ -407,11 +441,11 @@ msgstr "Carica filamento"
 msgid "Load Settings"
 msgstr "Carica impostazioni"
 
-#: src/gui/screen_splash.cpp:43
+#: src/gui/screen_splash.cpp:38
 msgid "Loading ..."
 msgstr "Caricamento..."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:28
+#: src/gui/dialogs/DialogLoadUnload.cpp:29
 msgid "Loading to nozzle"
 msgstr "Caricamento ugello"
 
@@ -423,11 +457,11 @@ msgstr "Forte"
 msgid "M.I.N.D.A."
 msgstr "M.I.N.D.A."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:24
+#: src/gui/dialogs/DialogLoadUnload.cpp:25
 msgid "Make sure the filament is inserted through the sensor."
 msgstr "Accertati che il filamento attraversi il sensore."
 
-#: src/gui/screen_print_preview.cpp:128
+#: src/gui/gcode_description.cpp:37
 msgid "Material"
 msgstr "Materiale"
 
@@ -438,8 +472,14 @@ msgid "MAXTEMP ERROR"
 msgstr "MAXTEMP ERROR"
 
 #: src/gui/wizard/xyzcalib.cpp:192
-msgid "Measuring reference\nheight of calib.\npoints"
-msgstr "Misurazione altezza\ndi riferimento dei\npunti di calibrazione"
+msgid ""
+"Measuring reference\n"
+"height of calib.\n"
+"points"
+msgstr ""
+"Misurazione altezza\n"
+"di riferimento dei\n"
+"punti di calibrazione"
 
 #: src/guiapi/include/MItem_tools.hpp:289
 msgid "Menu Timeout"
@@ -458,7 +498,7 @@ msgstr "MESH BED LEVELING"
 msgid "MESSAGES"
 msgstr "MESSAGGI"
 
-#: src/guiapi/include/MItem_menus.hpp:139
+#: src/guiapi/include/MItem_menus.hpp:149
 msgid "Messages"
 msgstr "Messaggi"
 
@@ -473,7 +513,7 @@ msgstr "MINTEMP ERROR"
 msgid "Mon"
 msgstr "Lu"
 
-#: src/guiapi/include/MItem_menus.hpp:89
+#: src/guiapi/include/MItem_menus.hpp:99
 msgid "Move Axis"
 msgstr "Sposta asse"
 
@@ -502,12 +542,12 @@ msgid "Name"
 msgstr "Nome"
 
 #. Load
-#: src/gui/dialogs/dialog_response.cpp:18
+#: src/common/client_response_texts.cpp:24
 msgid "NEXT"
 msgstr "SUCCESSIVO"
 
 #. Next
-#: src/gui/dialogs/dialog_response.cpp:19
+#: src/common/client_response_texts.cpp:25
 msgid "NO"
 msgstr "NO"
 
@@ -515,14 +555,15 @@ msgstr "NO"
 msgid "No filament sensor detected. Verify that the sensor is connected and try again."
 msgstr "Sensore filamento non rilevato. Verificare il collegamento e riprovare."
 
-#: src/gui/screen_home.cpp:39
+#: src/gui/screen_home.cpp:40
 msgid "No USB"
 msgstr "No USB"
 
-#: src/gui/wizard/firstlay.cpp:98
+#: src/gui/wizard/firstlay.cpp:102
 msgid "Now, let's calibrate the distance between the tip of the nozzle and the print sheet."
 msgstr "Ora, calibriamo la distanza tra la punta dell'ugello e il piano di stampa."
 
+#: src/gui/screen_menu_footer_settings.cpp:58
 #: src/gui/dialogs/DialogSelftestResult.cpp:47
 #: src/guiapi/include/MItem_print.hpp:8
 msgid "Nozzle"
@@ -532,17 +573,18 @@ msgstr "Ugello"
 msgid "Nozzle and Heatbed"
 msgstr "Ugello e Piano risc."
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:24
+#: src/gui/dialogs/DialogSelftestTemp.cpp:25
 msgid "Nozzle heater check"
 msgstr "Contr. risc. Ugello"
 
 #: src/gui/screen_menu_fw_update.cpp:28
 #: src/guiapi/include/WindowMenuItems.hpp:19
+#: src/guiapi/include/WindowMenuSpin.hpp:21
 msgid "Off"
 msgstr "Off"
 
 #. No
-#: src/gui/screen_sheet_rename.cpp:17 src/gui/dialogs/dialog_response.cpp:20
+#: src/common/client_response_texts.cpp:26 src/gui/screen_sheet_rename.cpp:17
 msgid "OK"
 msgstr "OK"
 
@@ -552,7 +594,7 @@ msgstr "On"
 
 #: src/gui/screen_menu_fw_update.cpp:29
 msgid "On Restart"
-msgstr "In ripresa"
+msgstr "Al riavvio"
 
 #: src/guiapi/include/MItem_tools.hpp:304
 msgid "Once"
@@ -566,11 +608,11 @@ msgstr "Appena la stampante inizia ad estrudere plastica, regola l'altezza ugell
 msgid "Parking"
 msgstr "Parking"
 
-#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:38
+#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:39
 msgid "Pause"
 msgstr "Pausa"
 
-#: src/gui/screen_printing.cpp:39
+#: src/gui/screen_printing.cpp:40
 msgid "Pausing..."
 msgstr "In pausa..."
 
@@ -582,15 +624,25 @@ msgstr "Posiziona un foglio di carta sotto l'ugello durante la calib. dei primi 
 msgid "Please clean the nozzle for calibration. Click NEXT when done."
 msgstr "Pure l'ugello per calibrare. Poi premi su SUCCESSIVO."
 
-#: src/gui/screen_menu_lan_settings.cpp:280
+#: src/gui/screen_menu_lan_settings.cpp:282
 msgid "Please insert a USB drive and try again."
 msgstr "Inserire un drive USB e riprovare."
 
-#: src/gui/guimain.cpp:206
-msgid "Please insert the USB\ndrive that came with\nyour MINI and reset\nthe printer to flash\nthe firmware"
-msgstr "Inserisci il drive USB fornito con la MINI e reimposta la stampante per aggiornare il firmware"
+#: src/gui/guimain.cpp:229
+msgid ""
+"Please insert the USB\n"
+"drive that came with\n"
+"your MINI and reset\n"
+"the printer to flash\n"
+"the firmware"
+msgstr ""
+"Inserisci il drive\n"
+"USB fornito con la\n"
+"tua MINI e riavvia la\n"
+"stampante per effettuare\n"
+"il flash del firmware"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:22
+#: src/gui/dialogs/DialogLoadUnload.cpp:23
 msgid "Please open idler and remove filament manually"
 msgstr "Apri l'idler e rimuovi il filamento manualmente"
 
@@ -606,11 +658,11 @@ msgstr "Rimuovi la lastra d'acciaio dal piano riscaldato."
 msgid "Please wait"
 msgstr "Attendere"
 
-#: src/gui/screen_menu_preheat.cpp:25 src/gui/screen_menu_preheat.cpp:47
+#: src/gui/screen_menu_preheat.cpp:26 src/gui/screen_menu_preheat.cpp:49
 msgid "PREHEAT"
 msgstr "PRERISCALDA"
 
-#: src/gui/screen_home.cpp:34
+#: src/gui/screen_home.cpp:35
 msgid "Preheat"
 msgstr "Preriscalda"
 
@@ -618,19 +670,17 @@ msgstr "Preriscalda"
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:42
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:48
 msgid "PREHEAT ERROR"
-msgstr "ERRORE PREHEAT"
+msgstr "PREHEAT ERROR"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:34
+#: src/gui/dialogs/DialogFactory.cpp:12
 msgid "PREHEAT for LOAD"
 msgstr "PRERIS. per CARICARE"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:54
+#: src/gui/dialogs/DialogFactory.cpp:13
 msgid "PREHEAT for UNLOAD"
 msgstr "PRERISCALDA per SCARICARE"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:26
+#: src/gui/dialogs/DialogSelftestTemp.cpp:27
 msgid "Preparing"
 msgstr "Preparazione"
 
@@ -638,7 +688,7 @@ msgstr "Preparazione"
 msgid "Preparing to ram"
 msgstr "Preparazione al ram"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:23
+#: src/gui/dialogs/DialogLoadUnload.cpp:24
 msgid "Press CONTINUE and push filament into the extruder."
 msgstr "Premi CONTINUA e spingi il filamento nell'estrusore."
 
@@ -646,11 +696,11 @@ msgstr "Premi CONTINUA e spingi il filamento nell'estrusore."
 msgid "Press NEXT to run the Selftest, which checks for potential issues related to the assembly."
 msgstr "Premi SUCCESSIVO per avviare l'autotest, per controllare eventuali problemi legati al montaggio."
 
-#: src/gui/screen_print_preview.cpp:185 src/gui/screen_home.cpp:33
+#: src/gui/screen_print_preview.cpp:64 src/gui/screen_home.cpp:34
 msgid "Print"
 msgstr "Stampa"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:19
+#: src/gui/dialogs/DialogSelftestFans.cpp:20
 #: src/gui/dialogs/DialogSelftestResult.cpp:41
 #: src/guiapi/include/MItem_print.hpp:24
 msgid "Print Fan"
@@ -660,42 +710,46 @@ msgstr "Ventola di stampa"
 msgid "Print fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "La ventola di stampa non gira. Verifica la presenza di eventuali detriti, quindi ispeziona il cablaggio."
 
-#: src/gui/screen_print_preview.cpp:127
+#: src/gui/gcode_description.cpp:36
 msgid "Print Time"
 msgstr "Tempo di stampa"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #. theoretically it can be removed completely in case the string is constant for the whole run of the screen
-#: src/gui/screen_printing.cpp:222
+#: src/gui/screen_printing.cpp:244
 msgid "Print will end"
 msgstr "La stampa terminerà"
 
-#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:360
+#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:370
 msgid "PRINTING"
 msgstr "STAMPA"
 
-#: src/gui/screen_printing.cpp:158
+#: src/gui/screen_printing.cpp:160
 msgid "Printing time"
 msgstr "Tempo di stampa"
 
-#: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
+#: src/gui/dialogs/DialogFactory.cpp:11 src/gui/screen_menu_filament.cpp:87
 msgid "PURGE FILAMENT"
 msgstr "SPURGA FILAMENTO"
 
-#: src/gui/screen_menu_filament.cpp:109
+#: src/gui/screen_menu_filament.cpp:86
 msgid "Purge Filament"
 msgstr "Spurgo filamento"
 
 #. Ok
-#: src/gui/dialogs/dialog_response.cpp:21
+#. PC filament, do not translate
+#. PETG filament, do not translate
+#. PLA filament, do not translate
+#. PP filament, do not translate
+#: src/common/client_response_texts.cpp:31
 msgid "PURGE MORE"
 msgstr "PULISCI DI PIÙ"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:29
+#: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Purging"
 msgstr "Spurgo"
 
-#: src/guiapi/src/window_msgbox.cpp:156
+#: src/guiapi/src/window_msgbox.cpp:157
 msgid "Question"
 msgstr "Domanda"
 
@@ -703,18 +757,18 @@ msgstr "Domanda"
 msgid "Ramming"
 msgstr "Ramming"
 
-#: src/gui/screen_printing_serial.cpp:45
+#: src/gui/screen_printing_serial.cpp:43
 msgid "Really Disconnect?"
 msgstr "Vuoi davvero disconnettere?"
 
 #. Purge_more
-#: src/gui/dialogs/dialog_response.cpp:22
+#: src/common/client_response_texts.cpp:32
 msgid "REHEAT"
 msgstr "RISCALDA"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
-#: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
-#: src/gui/screen_printing.cpp:355
+#: src/gui/screen_printing.cpp:149 src/gui/screen_printing.cpp:248
+#: src/gui/screen_printing.cpp:365
 msgid "Remaining Time"
 msgstr "Tempo Rimanente"
 
@@ -726,7 +780,7 @@ msgstr "RINOMINA"
 msgid "Rename"
 msgstr "Rinomina"
 
-#: src/gui/screen_printing.cpp:44
+#: src/gui/screen_printing.cpp:45
 msgid "Reprint"
 msgstr "Ristampa"
 
@@ -734,23 +788,24 @@ msgstr "Ristampa"
 msgid "Reset"
 msgstr "Reset"
 
-#: src/common/MindaRedscreen.cpp:175 src/gui/guimain.cpp:207
+#: src/common/MindaRedscreen.cpp:175
 msgid "RESET PRINTER"
 msgstr "RESET STAMPANTE"
 
-#: src/gui/screen_printing.cpp:41
+#: src/gui/screen_printing.cpp:42
 msgid "Resume"
 msgstr "Riprendi"
 
-#: src/gui/screen_printing.cpp:42
+#: src/gui/screen_printing.cpp:43
 msgid "Resuming..."
 msgstr "Ripresa..."
 
 #. Reheat
-#: src/gui/dialogs/dialog_response.cpp:23
+#: src/common/client_response_texts.cpp:33
 msgid "RETRY"
 msgstr "RIPROVA"
 
+#: src/gui/dialogs/window_dlg_preheat.hpp:39
 #: src/guiapi/include/WindowMenuItems.hpp:54
 msgid "Return"
 msgstr "Ritorna"
@@ -769,8 +824,12 @@ msgid "Save Settings"
 msgstr "Salva impostazioni"
 
 #: src/gui/wizard/xyzcalib.cpp:180
-msgid "Searching bed\ncalibration points"
-msgstr "Ricerca punti\ndi calibrazione piano"
+msgid ""
+"Searching bed\n"
+"calibration points"
+msgstr ""
+"Ricerca punti\n"
+"di calibrazione piano"
 
 #: src/gui/screen_menu_steel_sheets.cpp:33
 msgid "Select"
@@ -778,9 +837,9 @@ msgstr "Seleziona"
 
 #: src/gui/wizard/firstlay.cpp:71
 msgid "Select Filament Type"
-msgstr "Seleziona tipo filamento"
+msgstr "Seleziona Tipo di Filamento"
 
-#: src/gui/screen_filebrowser.cpp:42
+#: src/gui/screen_filebrowser.cpp:43
 msgid "SELECT FILE"
 msgstr "SELEZIONA FILE"
 
@@ -788,7 +847,7 @@ msgstr "SELEZIONA FILE"
 msgid "SELECT LANGUAGE"
 msgstr "SELEZIONA LINGUA"
 
-#: src/gui/screen_menu_fw_update.cpp:74
+#: src/gui/screen_menu_fw_update.cpp:96
 msgid "Select when you want to automatically flash updated firmware from USB flash disk."
 msgstr "Seleziona quando vuoi aggiornare automaticamente il nuovo firmware da mem. USB."
 
@@ -808,23 +867,24 @@ msgstr "INFO SENSORE"
 msgid "Sensor Info"
 msgstr "Info sensore"
 
-#: src/gui/screen_printing_serial.hpp:13
+#. filament sensor will think printer is in printing state
+#: src/gui/screen_printing_serial.hpp:15
 msgid "SERIAL PRINTING"
 msgstr "STAMPA SERIALE"
 
-#: src/guiapi/include/MItem_menus.hpp:99
+#: src/guiapi/include/MItem_menus.hpp:109
 msgid "Service"
 msgstr "Assistenza"
 
-#: src/gui/screen_home.cpp:37
+#: src/gui/screen_home.cpp:38
 msgid "Settings"
 msgstr "Impost."
 
-#: src/gui/screen_menu_settings.cpp:107
+#: src/gui/screen_menu_settings.cpp:108
 msgid "SETTINGS"
 msgstr "IMPOSTAZIONI"
 
-#: src/gui/screen_menu_lan_settings.cpp:289
+#: src/gui/screen_menu_lan_settings.cpp:291
 msgid "Settings successfully loaded"
 msgstr "Impostazioni caricate correttamente"
 
@@ -852,16 +912,22 @@ msgstr "Modo suono"
 msgid "Sound Volume"
 msgstr "Volume suono"
 
+#. ItemFilament
+#: src/gui/screen_menu_footer_settings.cpp:61
 #: src/guiapi/include/MItem_print.hpp:32
 msgid "Speed"
 msgstr "Velocità"
 
-#: src/gui/screen_menu_lan_settings.cpp:277
+#: src/gui/screen_menu_lan_settings.cpp:279
 msgid "Static IPv4 addresses were not set."
 msgstr "Indirizzo statico IPv4 non impostato."
 
-#: src/guiapi/include/MItem_menus.hpp:49
-msgid "Statistic"
+#: src/gui/screen_menu_odometer.cpp:15
+msgid "STATISTICS"
+msgstr "STATISTICHE"
+
+#: src/guiapi/include/MItem_menus.hpp:29
+msgid "Statistics"
 msgstr "Statistiche"
 
 #: src/gui/screen_menu_steel_sheets.cpp:176 src/gui/screen_menu_hw_setup.cpp:16
@@ -869,11 +935,11 @@ msgid "Steel Sheets"
 msgstr "Piastre d'acciaio"
 
 #. Retry
-#: src/gui/dialogs/dialog_response.cpp:24
+#: src/common/client_response_texts.cpp:34
 msgid "STOP"
 msgstr "STOP"
 
-#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:40
+#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:41
 msgid "Stop"
 msgstr "Stop"
 
@@ -882,11 +948,11 @@ msgstr "Stop"
 msgid "Sun"
 msgstr "Do"
 
-#: src/guiapi/include/MItem_menus.hpp:69
+#: src/guiapi/include/MItem_menus.hpp:79
 msgid "Support"
 msgstr "Supporto"
 
-#: src/guiapi/include/MItem_menus.hpp:39
+#: src/guiapi/include/MItem_menus.hpp:49
 msgid "System Info"
 msgstr "Info di sistema"
 
@@ -894,11 +960,11 @@ msgstr "Info di sistema"
 msgid "TEMPERATURE"
 msgstr "TEMPERATURA"
 
-#: src/guiapi/include/MItem_menus.hpp:79
+#: src/guiapi/include/MItem_menus.hpp:89
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: src/guiapi/include/MItem_menus.hpp:109
+#: src/guiapi/include/MItem_menus.hpp:119
 msgid "Test"
 msgstr "Test"
 
@@ -915,7 +981,7 @@ msgid "Test XYZ-Axis"
 msgstr "Test Assi XYZ"
 
 #. save eeprom flag
-#: src/gui/wizard/firstlay.cpp:184
+#: src/gui/wizard/firstlay.cpp:189
 msgid "The first layer calibration failed to finish. Double-check the printer's wiring, nozzle and axes, then restart the calibration."
 msgstr "Calib. primo layer non riuscita. Ricontrolla il cablaggio, assi e ugello, quindi ripeti la calibrazione."
 
@@ -923,19 +989,31 @@ msgstr "Calib. primo layer non riuscita. Ricontrolla il cablaggio, assi e ugello
 msgid "The selftest failed to finish. Double-check the printer's wiring and axes. Then restart the Selftest."
 msgstr "Autotest non completato. Ricontrolla gli assi e il cablaggio della stampante. Poi riavvia l'Autotest."
 
-#: src/gui/screen_menu_lan_settings.cpp:283
+#: src/gui/screen_menu_lan_settings.cpp:285
 msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
 msgstr "Impostazioni salvate correttamente nel file \"lan_settings.ini\"."
 
 #: src/gui/wizard/screen_wizard.cpp:170
-msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
-msgstr "La barra di stato è in basso. Contiene informazioni su:\n - Temp. Ugello\n - Temp. Piano\n - Vel. di stampa\n - Altezza asse Z\n - Fil. selezionato"
+msgid ""
+"The status bar is at the bottom of the screen. It contains information about:\n"
+"- Nozzle temp.\n"
+"- Heatbed temp.\n"
+"- Printing speed\n"
+"- Z-axis height\n"
+"- Selected filament"
+msgstr ""
+"La barra di stato è in basso. Contiene informazioni su:\n"
+" - Temp. Ugello\n"
+" - Temp. Piano\n"
+" - Vel. di stampa\n"
+" - Altezza asse Z\n"
+" - Fil. selezionato"
 
 #: src/gui/wizard/xyzcalib.cpp:298
 msgid "The XYZ calibration failed to finish. Double-check the printer's wiring and axes, then restart the XYZ calibration."
 msgstr "Calibrazione XYZ non riuscita. Ricontrolla il cablaggio e gli assi, quindi ripeti la calibrazione XYZ."
 
-#: src/gui/screen_menu_lan_settings.cpp:286
+#: src/gui/screen_menu_lan_settings.cpp:288
 msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
 msgstr "Errore nel salvataggio delle impostazioni nel file \"lan_settings.ini\"."
 
@@ -945,7 +1023,7 @@ msgstr "Errore nel salvataggio delle impostazioni nel file \"lan_settings.ini\".
 msgid "THERMAL RUNAWAY"
 msgstr "THERMAL RUNAWAY"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26
 msgid "This G-CODE was set up for another printer type."
 msgstr "Questo G-CODE è stato creato per un altro tipo di stampante."
 
@@ -985,20 +1063,20 @@ msgstr "Ma"
 msgid "TUNE"
 msgstr "REGOLA"
 
-#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:37
+#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:38
 msgid "Tune"
 msgstr "Regola"
 
 #. Stop
-#: src/gui/dialogs/dialog_response.cpp:25
+#: src/common/client_response_texts.cpp:35
 msgid "UNLOAD"
 msgstr "SCARICA"
 
-#: src/gui/dialogs/DialogFactory.cpp:14 src/gui/screen_menu_filament.cpp:72
+#: src/gui/dialogs/DialogFactory.cpp:10 src/gui/screen_menu_filament.cpp:57
 msgid "UNLOAD FILAMENT"
 msgstr "SCARICA FILAMENTO"
 
-#: src/gui/screen_menu_filament.cpp:71
+#: src/gui/screen_menu_filament.cpp:56
 msgid "Unload Filament"
 msgstr "Scarica filamento"
 
@@ -1014,11 +1092,11 @@ msgstr "Unparking"
 msgid "USB drive error, the print is now paused. Reconnect the drive."
 msgstr "Errore unità USB, la stampa è ora in pausa. Ricollegare l'unità."
 
-#: src/gui/screen_print_preview.cpp:129
+#: src/gui/gcode_description.cpp:38
 msgid "Used Filament"
 msgstr "Filamento usato"
 
-#: src/gui/screen_menu_version_info.cpp:31
+#: src/gui/version_info_ST7789V.cpp:27
 msgid "VERSION INFO"
 msgstr "INFO VERSIONE"
 
@@ -1034,7 +1112,7 @@ msgstr "In attesa della temperatura"
 msgid "Warning"
 msgstr "Attenzione"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26 src/gui/screen_print_preview.cpp:113
 msgid "WARNING:"
 msgstr "ATTENZIONE:"
 
@@ -1064,7 +1142,7 @@ msgid "WIZARD - OK"
 msgstr "WIZARD - OK"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:43
-#: src/gui/dialogs/DialogSelftestAxis.cpp:19
+#: src/gui/dialogs/DialogSelftestAxis.cpp:25
 msgid "X-axis"
 msgstr "Asse X"
 
@@ -1073,12 +1151,12 @@ msgid "XYZ CALIBRATION"
 msgstr "CALIBRAZIONE XYZ"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:44
-#: src/gui/dialogs/DialogSelftestAxis.cpp:20
+#: src/gui/dialogs/DialogSelftestAxis.cpp:26
 msgid "Y-axis"
 msgstr "Asse Y"
 
 #. Unload
-#: src/gui/dialogs/dialog_response.cpp:26
+#: src/common/client_response_texts.cpp:36
 msgid "YES"
 msgstr "SI"
 
@@ -1087,6 +1165,6 @@ msgid "Z height:"
 msgstr "Altezza Z:"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:45
-#: src/gui/dialogs/DialogSelftestAxis.cpp:21
+#: src/gui/dialogs/DialogSelftestAxis.cpp:27
 msgid "Z-axis"
 msgstr "Asse Z"

--- a/src/lang/po/pl/Prusa-Firmware-Buddy_pl.po
+++ b/src/lang/po/pl/Prusa-Firmware-Buddy_pl.po
@@ -5,25 +5,39 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n%10 >= 2 && n%10 <=4 && (n%100 < 12 || n%100 > 14)) ? 1 : ((n%10 == 0 || n%10 == 1 || (n%10 >= 5 && n%10 <=9)) || (n%100 >= 12 && n%100 <= 14)) ? 2 : 3);\n"
-"X-Generator: PhraseApp (phraseapp.com)\n"
+"X-Generator: Phrase (phrase.com)\n"
 
 #. c=20 r=4
-#: src/gui/screen_menu_version_info.cpp:82
+#: src/gui/version_info_ST7789V.cpp:102
 #, c-format
-msgid "\nBootloader Version\n%d.%d.%d\n\nBuddy Board\n%d.%d.%d\n%s"
-msgstr "\nWersja Bootloadera\n%d.%d.%d\n\nPłyta Buddy\n%d.%d.%d\n%s"
+msgid ""
+"\n"
+"Bootloader Version\n"
+"%d.%d.%d\n"
+"\n"
+"Buddy Board\n"
+"%d.%d.%d\n"
+"%s"
+msgstr ""
+"\n"
+"Wersja Bootloadera\n"
+"%d.%d.%d\n"
+"\n"
+"Płyta Buddy\n"
+"%d.%d.%d\n"
+"%s"
 
 #: src/guiapi/src/MItem_tools.cpp:200
 msgid "A crash dump report (file dump.bin) has been saved to the USB drive."
 msgstr "Raport zrzutu pamięci (plik dump.bin) został zapisany w pamięci USB."
 
 #. _none
-#: src/gui/dialogs/dialog_response.cpp:11
+#: src/common/client_response_texts.cpp:11
 msgid "ABORT"
 msgstr "PRZERWIJ"
 
 #. / title text
-#: src/gui/dialogs/liveadjust_z.cpp:205
+#: src/gui/dialogs/liveadjust_z.cpp:207
 msgid "Adjust the nozzle height above the heatbed by turning the knob"
 msgstr "Ustaw dyszę w odpowiedniej odległości od stołu obracając pokrętłem."
 
@@ -35,7 +49,7 @@ msgstr "Wszystkie testy ukończono pomyślnie!"
 msgid "Always"
 msgstr "Zawsze"
 
-#: src/gui/screen_printing.cpp:103
+#: src/gui/screen_printing.cpp:104
 msgid "Are you sure to stop this printing?"
 msgstr "Czy na pewno chcesz przerwać wydruk?"
 
@@ -48,15 +62,17 @@ msgid "Auto Home"
 msgstr "Auto bazowanie"
 
 #. Abort
-#: src/gui/dialogs/dialog_response.cpp:12
+#. ABS filament, do not translate
+#. ASA filament, do not translate
+#: src/common/client_response_texts.cpp:14
 msgid "BACK"
 msgstr "WSTECZ"
 
-#: src/gui/screen_print_preview.cpp:189
+#: src/gui/screen_print_preview.cpp:68
 msgid "Back"
 msgstr "Wstecz"
 
-#: src/gui/screen_printing.cpp:205
+#: src/gui/screen_printing.cpp:208
 msgid "Bed leveling failed. Try again?"
 msgstr "Niepowodzenie poziomowania. Spróbować ponownie?"
 
@@ -64,7 +80,7 @@ msgstr "Niepowodzenie poziomowania. Spróbować ponownie?"
 msgid "Calibrating Z"
 msgstr "Kalibuję Z"
 
-#: src/gui/screen_home.cpp:36
+#: src/gui/screen_home.cpp:37
 msgid "Calibration"
 msgstr "Kalibracja"
 
@@ -81,48 +97,48 @@ msgid "Calibration XY"
 msgstr "Kalibracja XY"
 
 #. Back
-#: src/gui/screen_sheet_rename.cpp:18 src/gui/dialogs/dialog_response.cpp:13
+#: src/common/client_response_texts.cpp:15 src/gui/screen_sheet_rename.cpp:18
 msgid "CANCEL"
 msgstr "ANULUJ"
 
-#: src/gui/dialogs/DialogFactory.cpp:12 src/gui/screen_menu_filament.cpp:90
+#: src/gui/dialogs/DialogFactory.cpp:8 src/gui/screen_menu_filament.cpp:72
 msgid "CHANGE FILAMENT"
 msgstr "ZMIANA FILAMENTU"
 
-#: src/gui/screen_menu_filament.cpp:89 src/guiapi/include/MItem_tools.hpp:279
+#: src/gui/screen_menu_filament.cpp:71 src/guiapi/include/MItem_tools.hpp:279
 msgid "Change Filament"
 msgstr "Zmiana filamentu"
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:44
 msgid "Check the heatbed heater & thermistor wiring for possible damage."
-msgstr "Sprawdź czy przewody grzałki i termistora stołu nie są uszkodzone."
+msgstr "Sprawdź okablowanie grzałki i termistora stołu pod kątem uszkodzeń."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:56
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:68
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:80
 msgid "Check the heatbed thermistor wiring for possible damage."
-msgstr "Sprawdź czy przewody termistora stołu nie są uszkodzone."
+msgstr "Sprawdź okablowanie termistora stołu pod kątem uszkodzeń."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:50
 msgid "Check the print head heater & thermistor wiring for possible damage."
-msgstr "Sprawdź czy przewody grzałki i termistora hotendu nie są uszkodzone."
+msgstr "Sprawdź okablowanie grzałki i termistora hotendu pod kątem uszkodzeń."
 
 #. r=5, c=20
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:62
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:74
 #: lib/Prusa-Error-Codes/12_MINI/errors_list.h:86
 msgid "Check the print head thermistor wiring for possible damage."
-msgstr "Sprawdź czy przewody termistora hotendu nie są uszkodzone."
+msgstr "Sprawdź okablowanie termistora hotendu pod kątem uszkodzeń."
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:42
-#: src/gui/dialogs/DialogSelftestAxis.cpp:18
+#: src/gui/dialogs/DialogSelftestAxis.cpp:24
 msgid "Checking axes"
 msgstr "Sprawdzanie osi"
 
-#: src/gui/wizard/firstlay.cpp:168
+#: src/gui/wizard/firstlay.cpp:173
 msgid "Clean steel sheet."
 msgstr "Wyczyść płytę stalową."
 
@@ -130,12 +146,12 @@ msgstr "Wyczyść płytę stalową."
 msgid "Congratulations! XYZ calibration is ok. XY axes are perpendicular."
 msgstr "Gratulacje! Kalibracja XYZ została ukończona. Osie są prostopadłe do siebie."
 
-#. Cancel
-#: src/gui/dialogs/dialog_response.cpp:14
+#. Change
+#: src/common/client_response_texts.cpp:17
 msgid "CONTINUE"
 msgstr "KONTYNUUJ"
 
-#: src/common/filament.cpp:13 src/gui/screen_menu_temperature.cpp:12
+#: src/gui/screen_menu_temperature.cpp:12
 msgid "Cooldown"
 msgstr "Chłodzenie"
 
@@ -143,16 +159,16 @@ msgstr "Chłodzenie"
 msgid "CPU load"
 msgstr "Obciążenie CPU"
 
-#: src/guiapi/include/MItem_menus.hpp:169
+#: src/guiapi/include/MItem_menus.hpp:179
 msgid "Current Profile"
 msgstr "Aktualny profil"
 
-#: src/guiapi/include/MItem_menus.hpp:192
+#: src/guiapi/include/MItem_menus.hpp:202
 msgid "Device hash in QR"
 msgstr "Identyfikator urządzenia w QR"
 
-#. Continue
-#: src/gui/dialogs/dialog_response.cpp:15
+#. Cooldown
+#: src/common/client_response_texts.cpp:19
 msgid "DISABLE SENSOR"
 msgstr "WYŁĄCZ CZUJNIK"
 
@@ -160,25 +176,33 @@ msgstr "WYŁĄCZ CZUJNIK"
 msgid "Disable Steppers"
 msgstr "Wyłącz silniki"
 
-#: src/gui/screen_printing_serial.hpp:10
+#: src/gui/screen_printing_serial.hpp:11
 msgid "Disconnect"
 msgstr "Rozłącz"
 
-#: src/gui/wizard/firstlay.cpp:160
+#: src/gui/wizard/firstlay.cpp:165
 msgid "Do you want to repeat the last step and readjust the distance between the nozzle and heatbed?"
 msgstr "Czy chcesz powtórzyć ostatni krok i poprawić kalibrację odległości dyszy od stołu?"
 
-#. c=20 r=6
-#: src/gui/wizard/firstlay.cpp:112
+#. c=21 r=9
+#: src/gui/wizard/firstlay.cpp:116
 #, c-format
-msgid "Do you want to use the current value?\nCurrent: %0.3f.\nDefault: %0.3f.\nClick NO to use the default value (recommended)"
-msgstr "Czy na pewno chcesz użyć tych wartości:\nObecna: %0.3f.\nDomyślna: %0.3f.\nWciśnij NIE, aby użyć domyślnej (zalecane)"
+msgid ""
+"Do you want to use the current value?\n"
+"Current: %0.3f.\n"
+"Default: %0.3f.\n"
+"Click NO to use the default value (recommended)"
+msgstr ""
+"Czy na pewno chcesz użyć tych wartości:\n"
+"Obecna: %0.3f.\n"
+"Domyślna: %0.3f.\n"
+"Wciśnij NIE, aby użyć domyślnej (zalecane)"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:27
+#: src/gui/dialogs/DialogLoadUnload.cpp:28
 msgid "Ejecting"
 msgstr "Wysuwanie"
 
-#: src/guiapi/src/window_msgbox.cpp:150
+#: src/guiapi/src/window_msgbox.cpp:152
 msgid "Error"
 msgstr "Błąd"
 
@@ -202,11 +226,11 @@ msgstr "Zresetowano do ustawień fabrycznych. System zostanie teraz zrestartowan
 msgid "Factory Reset"
 msgstr "Ustawienia fabryczne"
 
-#: src/guiapi/include/MItem_menus.hpp:59
+#: src/guiapi/include/MItem_menus.hpp:69
 msgid "Fail Stats"
 msgstr "Statystyki błędów"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:17
+#: src/gui/dialogs/DialogSelftestFans.cpp:18
 #: src/gui/dialogs/DialogSelftestResult.cpp:39
 msgid "Fan Test"
 msgstr "Test wentylatorów"
@@ -219,19 +243,22 @@ msgstr "RPM Went. 0"
 msgid "Fan1 RPM"
 msgstr "RPM Went. 1"
 
-#: src/gui/screen_menu_filament.cpp:127
+#: src/gui/screen_menu_filament.cpp:101
 msgid "FILAMENT"
 msgstr "FILAMENT"
 
-#: src/gui/screen_home.cpp:35 src/guiapi/include/MItem_menus.hpp:29
+#. ItemBed
+#: src/gui/screen_menu_odometer.cpp:18
+#: src/gui/screen_menu_footer_settings.cpp:60 src/gui/screen_home.cpp:36
+#: src/guiapi/include/MItem_menus.hpp:39
 msgid "Filament"
 msgstr "Filament"
 
-#: src/gui/screen_menu_filament.cpp:53
+#: src/gui/screen_menu_filament.cpp:41
 msgid "Filament appears to be already loaded, are you sure you want to load it anyway?"
 msgstr "Wygląda na to, że filament jest już załadowany. Na pewno chcesz go załadować?"
 
-#: src/gui/screen_print_preview.cpp:223
+#: src/gui/screen_print_preview.cpp:95
 msgid "Filament not detected. Load filament now? Select NO to cancel, or IGNORE to disable the filament sensor and continue."
 msgstr "Nie wykryto filamentu. Załadować? Wybierz NIE, aby anulować lub IGNORUJ, aby wyłączyć czujnik filamentu i kontynuować."
 
@@ -246,7 +273,7 @@ msgid "Finishing buffered gcodes."
 msgstr "Opróżnianie bufora G-code."
 
 #. r=1 c=20
-#: src/gui/screen_menu_version_info.cpp:60
+#: src/gui/version_info_ST7789V.cpp:80
 msgid "Firmware Version\n"
 msgstr "Wersja Firmware\n"
 
@@ -268,11 +295,11 @@ msgstr "Przepływ"
 msgid "Fri"
 msgstr "Pt"
 
-#: src/gui/screen_menu_fw_update.cpp:70
+#: src/gui/screen_menu_fw_update.cpp:69
 msgid "FW UPDATE"
 msgstr "AKTUALIZACJA FW"
 
-#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:119
+#: src/gui/screen_menu_fw_update.cpp:17 src/guiapi/include/MItem_menus.hpp:129
 msgid "FW Update"
 msgstr "Aktualizacja FW"
 
@@ -281,41 +308,45 @@ msgstr "Aktualizacja FW"
 msgid "Heatbed"
 msgstr "Stół"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:25
+#: src/gui/dialogs/DialogSelftestTemp.cpp:26
 msgid "Heatbed heater check"
 msgstr "Test grzałki stołu"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:27
+#: src/gui/dialogs/DialogSelftestTemp.cpp:28
 msgid "Heater testing"
 msgstr "Test grzałki"
 
-#: src/gui/guimain.cpp:194
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:34
 msgid "Heating disabled due to 30 minutes of inactivity."
 msgstr "Grzanie wyłączone po 30-minutowej bezczynności."
 
-#: src/gui/screen_printing.cpp:43
+#: src/gui/screen_printing.cpp:44
 msgid "Heating..."
 msgstr "Nagrzewanie..."
 
-#: src/gui/guimain.cpp:205
-msgid "Hi, this is your\nOriginal Prusa MINI."
-msgstr "Cześć, jestem Twoją Original Prusa Mini"
+#: src/gui/guimain.cpp:228
+msgid ""
+"Hi, this is your\n"
+"Original Prusa MINI."
+msgstr ""
+"Cześć, tu Twoja\n"
+"Original Prusa MINI."
 
-#: src/gui/screen_home.cpp:68
+#: src/gui/screen_home.cpp:72
 msgid "HOME"
 msgstr "EKRAN GŁÓWNY"
 
 #. special handling for the link back to printing screen - i.e. ".." will be renamed to "Home"
 #. and will get a nice house-like icon
-#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:45
+#: src/gui/window_file_list.cpp:104 src/gui/screen_printing.cpp:46
 msgid "Home"
 msgstr "Ekran główny"
 
-#: src/gui/dialogs/DialogFactory.cpp:40
+#: src/gui/dialogs/DialogFactory.cpp:53
 msgid "HOME TO MAX"
 msgstr "HOME TO MAX"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:18
+#: src/gui/dialogs/DialogSelftestFans.cpp:19
 #: src/gui/dialogs/DialogSelftestResult.cpp:40
 msgid "Hotend Fan"
 msgstr "Wentylator hotendu"
@@ -324,45 +355,48 @@ msgstr "Wentylator hotendu"
 msgid "Hotend fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "Wentylator hotendu nie obraca się. Sprawdź, czy nie jest zablokowany przez zanieczyszczenia, następnie sprawdź przewody."
 
-#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:159
+#: src/gui/screen_menu_hw_setup.cpp:32 src/guiapi/include/MItem_menus.hpp:169
 msgid "HW Setup"
 msgstr "Ustawienia HW"
 
 #. Filament_removed
-#: src/gui/dialogs/dialog_response.cpp:16
+#. FLEX filament, do not translate
+#. HIPS filament, do not translate
+#: src/common/client_response_texts.cpp:22
 msgid "IGNORE"
 msgstr "IGNORUJ"
 
 #. static const char en_text[] = N_("Observe the pattern and turn the knob to adjust the nozzle height in real time. Extruded plastic must stick to the print surface.");
-#: src/gui/wizard/firstlay.cpp:128
+#: src/gui/wizard/firstlay.cpp:132
 msgid "In the next step, use the knob to adjust the nozzle height. Check the pictures in the handbook for reference."
 msgstr "W kolejnym kroku użyj pokrętła, aby ustawić odległość dyszy od stołu. Możesz wspomóc się ilustracjami w Podręczniku."
 
-#: src/gui/screen_menu_info.cpp:20
+#: src/gui/screen_menu_info.cpp:19
+#: src/gui/dialogs/window_dlg_strong_warning.hpp:31
 msgid "INFO"
 msgstr "INFO"
 
-#: src/gui/screen_home.cpp:38
+#: src/gui/screen_home.cpp:39
 msgid "Info"
 msgstr "Info"
 
-#: src/guiapi/src/window_msgbox.cpp:172
+#: src/guiapi/src/window_msgbox.cpp:171
 msgid "Information"
 msgstr "Informacje"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:25
+#: src/gui/dialogs/DialogLoadUnload.cpp:26
 msgid "Inserting"
 msgstr "Wsuwanie"
 
-#: src/gui/screen_menu_lan_settings.cpp:292
+#: src/gui/screen_menu_lan_settings.cpp:294
 msgid "IP addresses or parameters are not valid or the file \"lan_settings.ini\" is not in the root directory of the USB drive."
 msgstr "Adresy IP lub parametry są nieprawidłowe, albo plik \"lan_settings.ini\" nie znajduje się w katalogu głównym pamięci USB."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:30
+#: src/gui/dialogs/DialogLoadUnload.cpp:31
 msgid "Is color correct?"
 msgstr "Kolor prawidłowy?"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:26
+#: src/gui/dialogs/DialogLoadUnload.cpp:27
 msgid "Is filament in extruder gear?"
 msgstr "Czy filament sięga kół radełkowanych?"
 
@@ -370,15 +404,15 @@ msgstr "Czy filament sięga kół radełkowanych?"
 msgid "Is steel sheet on heatbed?"
 msgstr "Czy płyta znajduje się na stole?"
 
-#: src/gui/screen_menu_lan_settings.cpp:221
+#: src/gui/screen_menu_lan_settings.cpp:217
 msgid "LAN SETTINGS"
 msgstr "USTAWIENIA LAN"
 
-#: src/guiapi/include/MItem_menus.hpp:129
+#: src/guiapi/include/MItem_menus.hpp:139
 msgid "Lan Settings"
 msgstr "Ustawienia LAN"
 
-#: src/guiapi/include/MItem_menus.hpp:149
+#: src/guiapi/include/MItem_menus.hpp:159
 msgid "Language"
 msgstr "Języki"
 
@@ -391,15 +425,15 @@ msgid "Live Adjust Z"
 msgstr "Live Adjust Z"
 
 #. Ignore
-#: src/gui/dialogs/dialog_response.cpp:17
+#: src/common/client_response_texts.cpp:23
 msgid "LOAD"
 msgstr "ZAŁADUJ"
 
-#: src/gui/dialogs/DialogFactory.cpp:13 src/gui/screen_menu_filament.cpp:52
+#: src/gui/dialogs/DialogFactory.cpp:9
 msgid "LOAD FILAMENT"
 msgstr "ZAŁADUJ FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:51
+#: src/gui/screen_menu_filament.cpp:40
 msgid "Load Filament"
 msgstr "Załaduj filament"
 
@@ -407,11 +441,11 @@ msgstr "Załaduj filament"
 msgid "Load Settings"
 msgstr "Wczytaj ustawienia"
 
-#: src/gui/screen_splash.cpp:43
+#: src/gui/screen_splash.cpp:38
 msgid "Loading ..."
 msgstr "Wczytywanie ..."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:28
+#: src/gui/dialogs/DialogLoadUnload.cpp:29
 msgid "Loading to nozzle"
 msgstr "Ładowanie do dyszy"
 
@@ -423,11 +457,11 @@ msgstr "Głośno"
 msgid "M.I.N.D.A."
 msgstr "M.I.N.D.A."
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:24
+#: src/gui/dialogs/DialogLoadUnload.cpp:25
 msgid "Make sure the filament is inserted through the sensor."
 msgstr "Upewnij się, że filament przechodzi przez czujnik filamentu."
 
-#: src/gui/screen_print_preview.cpp:128
+#: src/gui/gcode_description.cpp:37
 msgid "Material"
 msgstr "Materiał"
 
@@ -438,8 +472,14 @@ msgid "MAXTEMP ERROR"
 msgstr "BŁĄD MAXTEMP"
 
 #: src/gui/wizard/xyzcalib.cpp:192
-msgid "Measuring reference\nheight of calib.\npoints"
-msgstr "Pomiar wysokości\npunktów\nkalibracyjnych"
+msgid ""
+"Measuring reference\n"
+"height of calib.\n"
+"points"
+msgstr ""
+"Pomiar wysokości\n"
+"punktów\n"
+"kalibracyjnych"
 
 #: src/guiapi/include/MItem_tools.hpp:289
 msgid "Menu Timeout"
@@ -458,7 +498,7 @@ msgstr "POZIOMOWANIE STOŁU"
 msgid "MESSAGES"
 msgstr "KOMUNIKATY"
 
-#: src/guiapi/include/MItem_menus.hpp:139
+#: src/guiapi/include/MItem_menus.hpp:149
 msgid "Messages"
 msgstr "Komunikaty"
 
@@ -473,7 +513,7 @@ msgstr "BŁĄD MINTEMP"
 msgid "Mon"
 msgstr "Pon"
 
-#: src/guiapi/include/MItem_menus.hpp:89
+#: src/guiapi/include/MItem_menus.hpp:99
 msgid "Move Axis"
 msgstr "Ruch osi"
 
@@ -502,12 +542,12 @@ msgid "Name"
 msgstr "Nazwa"
 
 #. Load
-#: src/gui/dialogs/dialog_response.cpp:18
+#: src/common/client_response_texts.cpp:24
 msgid "NEXT"
 msgstr "DALEJ"
 
 #. Next
-#: src/gui/dialogs/dialog_response.cpp:19
+#: src/common/client_response_texts.cpp:25
 msgid "NO"
 msgstr "NIE"
 
@@ -515,14 +555,15 @@ msgstr "NIE"
 msgid "No filament sensor detected. Verify that the sensor is connected and try again."
 msgstr "Nie wykryto czujnika filamentu. Sprawdź, czy jest podłączony i spróbuj ponownie."
 
-#: src/gui/screen_home.cpp:39
+#: src/gui/screen_home.cpp:40
 msgid "No USB"
 msgstr "Brak USB"
 
-#: src/gui/wizard/firstlay.cpp:98
+#: src/gui/wizard/firstlay.cpp:102
 msgid "Now, let's calibrate the distance between the tip of the nozzle and the print sheet."
 msgstr "Teraz ustawimy odległość końcówki dyszy od powierzchni płyty."
 
+#: src/gui/screen_menu_footer_settings.cpp:58
 #: src/gui/dialogs/DialogSelftestResult.cpp:47
 #: src/guiapi/include/MItem_print.hpp:8
 msgid "Nozzle"
@@ -532,17 +573,18 @@ msgstr "Dysza"
 msgid "Nozzle and Heatbed"
 msgstr "Dysza i stół"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:24
+#: src/gui/dialogs/DialogSelftestTemp.cpp:25
 msgid "Nozzle heater check"
 msgstr "Test grzałki hotendu"
 
 #: src/gui/screen_menu_fw_update.cpp:28
 #: src/guiapi/include/WindowMenuItems.hpp:19
+#: src/guiapi/include/WindowMenuSpin.hpp:21
 msgid "Off"
 msgstr "Wył."
 
 #. No
-#: src/gui/screen_sheet_rename.cpp:17 src/gui/dialogs/dialog_response.cpp:20
+#: src/common/client_response_texts.cpp:26 src/gui/screen_sheet_rename.cpp:17
 msgid "OK"
 msgstr "OK"
 
@@ -566,11 +608,11 @@ msgstr "Obracaj pokrętłem, gdy drukarka zacznie wytłaczać plastik, aby zbli�
 msgid "Parking"
 msgstr "Parkowanie"
 
-#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:38
+#: src/gui/ScreenPrintingModel.hpp:16 src/gui/screen_printing.cpp:39
 msgid "Pause"
 msgstr "Pauza"
 
-#: src/gui/screen_printing.cpp:39
+#: src/gui/screen_printing.cpp:40
 msgid "Pausing..."
 msgstr "Pauzowanie"
 
@@ -582,15 +624,25 @@ msgstr "Połóż kartkę papieru pod dyszą podczas kalibracji pierwszych 4 punk
 msgid "Please clean the nozzle for calibration. Click NEXT when done."
 msgstr "Oczyść dyszę do kalibracji i naciśnij DALEJ."
 
-#: src/gui/screen_menu_lan_settings.cpp:280
+#: src/gui/screen_menu_lan_settings.cpp:282
 msgid "Please insert a USB drive and try again."
 msgstr "Podłącz pamięć USB i spróbuj ponownie."
 
-#: src/gui/guimain.cpp:206
-msgid "Please insert the USB\ndrive that came with\nyour MINI and reset\nthe printer to flash\nthe firmware"
-msgstr "Podłącz pamięć USB dostarczoną z Twoją MINI i zresetuj drukarkę, aby wgrać firmware"
+#: src/gui/guimain.cpp:229
+msgid ""
+"Please insert the USB\n"
+"drive that came with\n"
+"your MINI and reset\n"
+"the printer to flash\n"
+"the firmware"
+msgstr ""
+"Podłącz pamięć USB,\n"
+"która była dołączona\n"
+"do MINI i zresetuj\n"
+"drukarkę, aby wgrać\n"
+"firmware"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:22
+#: src/gui/dialogs/DialogLoadUnload.cpp:23
 msgid "Please open idler and remove filament manually"
 msgstr "Otwórz docisk ekstrudera i wyciągnij filament ręcznie"
 
@@ -606,11 +658,11 @@ msgstr "Zdejmij płytę stalową ze stołu."
 msgid "Please wait"
 msgstr "Proszę czekać"
 
-#: src/gui/screen_menu_preheat.cpp:25 src/gui/screen_menu_preheat.cpp:47
+#: src/gui/screen_menu_preheat.cpp:26 src/gui/screen_menu_preheat.cpp:49
 msgid "PREHEAT"
 msgstr "NAGRZEWANIE"
 
-#: src/gui/screen_home.cpp:34
+#: src/gui/screen_home.cpp:35
 msgid "Preheat"
 msgstr "Nagrzewanie"
 
@@ -620,17 +672,15 @@ msgstr "Nagrzewanie"
 msgid "PREHEAT ERROR"
 msgstr "BŁĄD GRZANIA"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:34
+#: src/gui/dialogs/DialogFactory.cpp:12
 msgid "PREHEAT for LOAD"
 msgstr "NAGRZEWANIE do ŁADOWANIA"
 
-#. todo must be called inside _gui_dlg, but nested dialogs are not supported now
-#: src/gui/dialogs/window_dlg_load_unload.cpp:54
+#: src/gui/dialogs/DialogFactory.cpp:13
 msgid "PREHEAT for UNLOAD"
 msgstr "NAGRZEWANIE do ROZŁADOWANIA"
 
-#: src/gui/dialogs/DialogSelftestTemp.cpp:26
+#: src/gui/dialogs/DialogSelftestTemp.cpp:27
 msgid "Preparing"
 msgstr "Przygotowywanie"
 
@@ -638,19 +688,19 @@ msgstr "Przygotowywanie"
 msgid "Preparing to ram"
 msgstr "Przygotowywanie do wyciskania"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:23
+#: src/gui/dialogs/DialogLoadUnload.cpp:24
 msgid "Press CONTINUE and push filament into the extruder."
-msgstr "Naciśnij KONTYNUUJ i wsuń filament do ekstrudera."
+msgstr "Naciśnij KONTYNUUJ i wsuń filament do ekstrudera.    "
 
 #: src/gui/wizard/screen_wizard.cpp:185
 msgid "Press NEXT to run the Selftest, which checks for potential issues related to the assembly."
 msgstr "Wciśnij DALEJ, aby uruchomić Selftest, który sprawdzi ewentualne błędy podczas montażu."
 
-#: src/gui/screen_print_preview.cpp:185 src/gui/screen_home.cpp:33
+#: src/gui/screen_print_preview.cpp:64 src/gui/screen_home.cpp:34
 msgid "Print"
 msgstr "Druk"
 
-#: src/gui/dialogs/DialogSelftestFans.cpp:19
+#: src/gui/dialogs/DialogSelftestFans.cpp:20
 #: src/gui/dialogs/DialogSelftestResult.cpp:41
 #: src/guiapi/include/MItem_print.hpp:24
 msgid "Print Fan"
@@ -660,42 +710,46 @@ msgstr "Went. wydruku"
 msgid "Print fan not spinning. Check it for possible debris, then inspect the wiring."
 msgstr "Wentylator wydruku nie obraca się. Sprawdź, czy nie jest zablokowany przez zanieczyszczenia, następnie sprawdź przewody."
 
-#: src/gui/screen_print_preview.cpp:127
+#: src/gui/gcode_description.cpp:36
 msgid "Print Time"
 msgstr "Czas druku"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
 #. theoretically it can be removed completely in case the string is constant for the whole run of the screen
-#: src/gui/screen_printing.cpp:222
+#: src/gui/screen_printing.cpp:244
 msgid "Print will end"
 msgstr "Druk zakończy się"
 
-#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:360
+#: src/gui/screen_printing.hpp:44 src/gui/screen_printing.cpp:370
 msgid "PRINTING"
 msgstr "DRUKOWANIE"
 
-#: src/gui/screen_printing.cpp:158
+#: src/gui/screen_printing.cpp:160
 msgid "Printing time"
 msgstr "Czas druku"
 
-#: src/gui/dialogs/DialogFactory.cpp:15 src/gui/screen_menu_filament.cpp:110
+#: src/gui/dialogs/DialogFactory.cpp:11 src/gui/screen_menu_filament.cpp:87
 msgid "PURGE FILAMENT"
 msgstr "CZYSZCZENIE"
 
-#: src/gui/screen_menu_filament.cpp:109
+#: src/gui/screen_menu_filament.cpp:86
 msgid "Purge Filament"
 msgstr "Czyszczenie"
 
 #. Ok
-#: src/gui/dialogs/dialog_response.cpp:21
+#. PC filament, do not translate
+#. PETG filament, do not translate
+#. PLA filament, do not translate
+#. PP filament, do not translate
+#: src/common/client_response_texts.cpp:31
 msgid "PURGE MORE"
 msgstr "CZYŚĆ PONOWNIE"
 
-#: src/gui/dialogs/DialogLoadUnload.cpp:29
+#: src/gui/dialogs/DialogLoadUnload.cpp:30
 msgid "Purging"
 msgstr "Czyszczenie"
 
-#: src/guiapi/src/window_msgbox.cpp:156
+#: src/guiapi/src/window_msgbox.cpp:157
 msgid "Question"
 msgstr "Pytanie"
 
@@ -703,18 +757,18 @@ msgstr "Pytanie"
 msgid "Ramming"
 msgstr "Wyciskanie"
 
-#: src/gui/screen_printing_serial.cpp:45
+#: src/gui/screen_printing_serial.cpp:43
 msgid "Really Disconnect?"
 msgstr "Czy na pewno chcesz rozłączyć?"
 
 #. Purge_more
-#: src/gui/dialogs/dialog_response.cpp:22
+#: src/common/client_response_texts.cpp:32
 msgid "REHEAT"
 msgstr "PONOWNE NAGRZEWANIE"
 
 #. store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
-#: src/gui/screen_printing.cpp:147 src/gui/screen_printing.cpp:226
-#: src/gui/screen_printing.cpp:355
+#: src/gui/screen_printing.cpp:149 src/gui/screen_printing.cpp:248
+#: src/gui/screen_printing.cpp:365
 msgid "Remaining Time"
 msgstr "Pozostały czas"
 
@@ -726,7 +780,7 @@ msgstr "ZMIEN NAZWĘ"
 msgid "Rename"
 msgstr "Zmień nazwę"
 
-#: src/gui/screen_printing.cpp:44
+#: src/gui/screen_printing.cpp:45
 msgid "Reprint"
 msgstr "Ponów druk"
 
@@ -734,23 +788,24 @@ msgstr "Ponów druk"
 msgid "Reset"
 msgstr "Reset"
 
-#: src/common/MindaRedscreen.cpp:175 src/gui/guimain.cpp:207
+#: src/common/MindaRedscreen.cpp:175
 msgid "RESET PRINTER"
 msgstr "RESET DRUKARKI"
 
-#: src/gui/screen_printing.cpp:41
+#: src/gui/screen_printing.cpp:42
 msgid "Resume"
 msgstr "Wznów"
 
-#: src/gui/screen_printing.cpp:42
+#: src/gui/screen_printing.cpp:43
 msgid "Resuming..."
 msgstr "Wznawianie..."
 
 #. Reheat
-#: src/gui/dialogs/dialog_response.cpp:23
+#: src/common/client_response_texts.cpp:33
 msgid "RETRY"
 msgstr "PONÓW"
 
+#: src/gui/dialogs/window_dlg_preheat.hpp:39
 #: src/guiapi/include/WindowMenuItems.hpp:54
 msgid "Return"
 msgstr "Powrót"
@@ -769,8 +824,12 @@ msgid "Save Settings"
 msgstr "Zapisz ustawienia"
 
 #: src/gui/wizard/xyzcalib.cpp:180
-msgid "Searching bed\ncalibration points"
-msgstr "Szukam punktów\nkalibracyjnych stołu"
+msgid ""
+"Searching bed\n"
+"calibration points"
+msgstr ""
+"Szukam punktów\n"
+"kalibracyjnych stołu"
 
 #: src/gui/screen_menu_steel_sheets.cpp:33
 msgid "Select"
@@ -778,9 +837,9 @@ msgstr "Wybierz"
 
 #: src/gui/wizard/firstlay.cpp:71
 msgid "Select Filament Type"
-msgstr "Wybierz typ filamentu"
+msgstr "Wybierz rodzaj filamentu"
 
-#: src/gui/screen_filebrowser.cpp:42
+#: src/gui/screen_filebrowser.cpp:43
 msgid "SELECT FILE"
 msgstr "WYBIERZ PLIK"
 
@@ -788,7 +847,7 @@ msgstr "WYBIERZ PLIK"
 msgid "SELECT LANGUAGE"
 msgstr "WYBIERZ JĘZYK"
 
-#: src/gui/screen_menu_fw_update.cpp:74
+#: src/gui/screen_menu_fw_update.cpp:96
 msgid "Select when you want to automatically flash updated firmware from USB flash disk."
 msgstr "Wybierz, jeśli chcesz automatycznie wgrać zaktualizowane firmware z pamięci USB."
 
@@ -808,23 +867,24 @@ msgstr "INFO O SENSORACH"
 msgid "Sensor Info"
 msgstr "Info o sensorach"
 
-#: src/gui/screen_printing_serial.hpp:13
+#. filament sensor will think printer is in printing state
+#: src/gui/screen_printing_serial.hpp:15
 msgid "SERIAL PRINTING"
 msgstr "DRUK SZEREGOWY"
 
-#: src/guiapi/include/MItem_menus.hpp:99
+#: src/guiapi/include/MItem_menus.hpp:109
 msgid "Service"
 msgstr "Serwis"
 
-#: src/gui/screen_home.cpp:37
+#: src/gui/screen_home.cpp:38
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: src/gui/screen_menu_settings.cpp:107
+#: src/gui/screen_menu_settings.cpp:108
 msgid "SETTINGS"
 msgstr "USTAWIENIA"
 
-#: src/gui/screen_menu_lan_settings.cpp:289
+#: src/gui/screen_menu_lan_settings.cpp:291
 msgid "Settings successfully loaded"
 msgstr "Ustawienia wczytane pomyślnie"
 
@@ -852,16 +912,22 @@ msgstr "Tryb dźwięku"
 msgid "Sound Volume"
 msgstr "Głośność dźwięku"
 
+#. ItemFilament
+#: src/gui/screen_menu_footer_settings.cpp:61
 #: src/guiapi/include/MItem_print.hpp:32
 msgid "Speed"
 msgstr "Prędkość"
 
-#: src/gui/screen_menu_lan_settings.cpp:277
+#: src/gui/screen_menu_lan_settings.cpp:279
 msgid "Static IPv4 addresses were not set."
 msgstr "Nie ustawiono statycznych adresów IPv4."
 
-#: src/guiapi/include/MItem_menus.hpp:49
-msgid "Statistic"
+#: src/gui/screen_menu_odometer.cpp:15
+msgid "STATISTICS"
+msgstr "STATYSTYKI"
+
+#: src/guiapi/include/MItem_menus.hpp:29
+msgid "Statistics"
 msgstr "Statystyki"
 
 #: src/gui/screen_menu_steel_sheets.cpp:176 src/gui/screen_menu_hw_setup.cpp:16
@@ -869,11 +935,11 @@ msgid "Steel Sheets"
 msgstr "Płyty stalowe"
 
 #. Retry
-#: src/gui/dialogs/dialog_response.cpp:24
+#: src/common/client_response_texts.cpp:34
 msgid "STOP"
 msgstr "STOP"
 
-#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:40
+#: src/gui/ScreenPrintingModel.hpp:17 src/gui/screen_printing.cpp:41
 msgid "Stop"
 msgstr "Stop"
 
@@ -882,11 +948,11 @@ msgstr "Stop"
 msgid "Sun"
 msgstr "Ndz"
 
-#: src/guiapi/include/MItem_menus.hpp:69
+#: src/guiapi/include/MItem_menus.hpp:79
 msgid "Support"
 msgstr "Pomoc"
 
-#: src/guiapi/include/MItem_menus.hpp:39
+#: src/guiapi/include/MItem_menus.hpp:49
 msgid "System Info"
 msgstr "Info systemowe"
 
@@ -894,11 +960,11 @@ msgstr "Info systemowe"
 msgid "TEMPERATURE"
 msgstr "TEMPERATURA"
 
-#: src/guiapi/include/MItem_menus.hpp:79
+#: src/guiapi/include/MItem_menus.hpp:89
 msgid "Temperature"
 msgstr "Temperatura"
 
-#: src/guiapi/include/MItem_menus.hpp:109
+#: src/guiapi/include/MItem_menus.hpp:119
 msgid "Test"
 msgstr "Test"
 
@@ -915,7 +981,7 @@ msgid "Test XYZ-Axis"
 msgstr "Test osi XYZ"
 
 #. save eeprom flag
-#: src/gui/wizard/firstlay.cpp:184
+#: src/gui/wizard/firstlay.cpp:189
 msgid "The first layer calibration failed to finish. Double-check the printer's wiring, nozzle and axes, then restart the calibration."
 msgstr "Kalibracja pierwszej warstwy zakończona niepowodzeniem. Sprawdź okablowanie, dyszę oraz osie drukarki, następnie ponów kalibrację."
 
@@ -923,19 +989,31 @@ msgstr "Kalibracja pierwszej warstwy zakończona niepowodzeniem. Sprawdź okablo
 msgid "The selftest failed to finish. Double-check the printer's wiring and axes. Then restart the Selftest."
 msgstr "Selftest zakończony niepowodzeniem. Sprawdź okablowanie drukarki oraz osie, następnie zrestartuj Selftest."
 
-#: src/gui/screen_menu_lan_settings.cpp:283
+#: src/gui/screen_menu_lan_settings.cpp:285
 msgid "The settings have been saved successfully in the \"lan_settings.ini\" file."
 msgstr "Ustawienia zostały pomyślnie zapisane w pliku \"lan_settings.ini\"."
 
 #: src/gui/wizard/screen_wizard.cpp:170
-msgid "The status bar is at the bottom of the screen. It contains information about:\n- Nozzle temp.\n- Heatbed temp.\n- Printing speed\n- Z-axis height\n- Selected filament"
-msgstr "Pasek stanu znajduje się na spodzie ekranu. Zawiera informacje:\n- Temperatura dyszy\n- Temperatura stołu\n- Prędkość druku\n- Pozycja osi Z\n- Wybrany filament"
+msgid ""
+"The status bar is at the bottom of the screen. It contains information about:\n"
+"- Nozzle temp.\n"
+"- Heatbed temp.\n"
+"- Printing speed\n"
+"- Z-axis height\n"
+"- Selected filament"
+msgstr ""
+"Pasek stanu znajduje się na spodzie ekranu. Zawiera informacje:\n"
+"- Temperatura dyszy\n"
+"- Temperatura stołu\n"
+"- Prędkość druku\n"
+"- Pozycja osi Z\n"
+"- Wybrany filament"
 
 #: src/gui/wizard/xyzcalib.cpp:298
 msgid "The XYZ calibration failed to finish. Double-check the printer's wiring and axes, then restart the XYZ calibration."
 msgstr "Kalibracja XYZ zakończona niepowodzeniem. Sprawdź okablowanie oraz osie drukarki, następnie uruchom kalibrację ponownie."
 
-#: src/gui/screen_menu_lan_settings.cpp:286
+#: src/gui/screen_menu_lan_settings.cpp:288
 msgid "There was an error saving the settings in the \"lan_settings.ini\" file."
 msgstr "Wystąpił błąd podczas zapisywania ustawień w pliku \"lan_settings.ini\"."
 
@@ -945,7 +1023,7 @@ msgstr "Wystąpił błąd podczas zapisywania ustawień w pliku \"lan_settings.i
 msgid "THERMAL RUNAWAY"
 msgstr "THERMAL RUNAWAY"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26
 msgid "This G-CODE was set up for another printer type."
 msgstr "Ten G-code jest przygotowany dla innej drukarki."
 
@@ -985,20 +1063,20 @@ msgstr "Wt"
 msgid "TUNE"
 msgstr "PARAMETRY"
 
-#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:37
+#: src/gui/ScreenPrintingModel.hpp:15 src/gui/screen_printing.cpp:38
 msgid "Tune"
 msgstr "Parametry"
 
 #. Stop
-#: src/gui/dialogs/dialog_response.cpp:25
+#: src/common/client_response_texts.cpp:35
 msgid "UNLOAD"
 msgstr "ROZŁADUJ"
 
-#: src/gui/dialogs/DialogFactory.cpp:14 src/gui/screen_menu_filament.cpp:72
+#: src/gui/dialogs/DialogFactory.cpp:10 src/gui/screen_menu_filament.cpp:57
 msgid "UNLOAD FILAMENT"
 msgstr "ROZŁADUJ FILAMENT"
 
-#: src/gui/screen_menu_filament.cpp:71
+#: src/gui/screen_menu_filament.cpp:56
 msgid "Unload Filament"
 msgstr "Rozładuj filament"
 
@@ -1014,11 +1092,11 @@ msgstr "Odparkowanie"
 msgid "USB drive error, the print is now paused. Reconnect the drive."
 msgstr "Błąd nośnika USB. Drukowanie zostało wstrzymane. Odłącz i ponownie podłącz nośnik."
 
-#: src/gui/screen_print_preview.cpp:129
+#: src/gui/gcode_description.cpp:38
 msgid "Used Filament"
 msgstr "Użyty filament"
 
-#: src/gui/screen_menu_version_info.cpp:31
+#: src/gui/version_info_ST7789V.cpp:27
 msgid "VERSION INFO"
 msgstr "WERSJA"
 
@@ -1034,7 +1112,7 @@ msgstr "Czekam na temp."
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
-#: src/gui/screen_print_preview.cpp:149
+#: src/gui/screen_print_preview.cpp:26 src/gui/screen_print_preview.cpp:113
 msgid "WARNING:"
 msgstr "UWAGA:"
 
@@ -1064,7 +1142,7 @@ msgid "WIZARD - OK"
 msgstr "ASYSTENT - OK"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:43
-#: src/gui/dialogs/DialogSelftestAxis.cpp:19
+#: src/gui/dialogs/DialogSelftestAxis.cpp:25
 msgid "X-axis"
 msgstr "Oś X"
 
@@ -1073,12 +1151,12 @@ msgid "XYZ CALIBRATION"
 msgstr "KALIBRACJA XYZ"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:44
-#: src/gui/dialogs/DialogSelftestAxis.cpp:20
+#: src/gui/dialogs/DialogSelftestAxis.cpp:26
 msgid "Y-axis"
 msgstr "Oś Y"
 
 #. Unload
-#: src/gui/dialogs/dialog_response.cpp:26
+#: src/common/client_response_texts.cpp:36
 msgid "YES"
 msgstr "TAK"
 
@@ -1087,6 +1165,6 @@ msgid "Z height:"
 msgstr "Wysokość Z:"
 
 #: src/gui/dialogs/DialogSelftestResult.cpp:45
-#: src/gui/dialogs/DialogSelftestAxis.cpp:21
+#: src/gui/dialogs/DialogSelftestAxis.cpp:27
 msgid "Z-axis"
 msgstr "Oś Z"

--- a/src/lang/translation_provider_CPUFLASH.hpp
+++ b/src/lang/translation_provider_CPUFLASH.hpp
@@ -53,7 +53,7 @@ public:
     }
 
     // 2020-08-18 updated to 340 buckets with more texts coming in. With previous 256 buckets, collisions occured already (we have 240+ texts)
-    using SHashTable = string_hash_table<hash_djb2, buckets_count, 256>; ///< beware of low numbers of buckets - collisions may occur unexpectedly
+    using SHashTable = string_hash_table<hash_djb2, buckets_count, 310>; ///< beware of low numbers of buckets - collisions may occur unexpectedly
 #ifndef TRANSLATIONS_UNITTEST
 protected:
 #endif

--- a/src/lang/translation_provider_CPUFLASH.hpp
+++ b/src/lang/translation_provider_CPUFLASH.hpp
@@ -52,7 +52,8 @@ public:
         return string_view_utf8::MakeCPUFLASH(utf8raw);
     }
 
-    // 2020-08-18 updated to 340 buckets with more texts coming in. With previous 256 buckets, collisions occured already (we have 240+ texts)
+    // bucket_count is being computed at compile time (lang.py is searching for the lowest possible number of buckets where collisions do not occur)
+    // 310 is the maximum total number of strings the translator array can hold. To be increased in the future as new strings come into the FW
     using SHashTable = string_hash_table<hash_djb2, buckets_count, 310>; ///< beware of low numbers of buckets - collisions may occur unexpectedly
 #ifndef TRANSLATIONS_UNITTEST
 protected:

--- a/tests/unit/lang/translator/hash.cpp
+++ b/tests/unit/lang/translator/hash.cpp
@@ -184,20 +184,22 @@ bool CheckHashClass() {
     return true;
 }
 
+using TPBSH = CPUFLASHTranslationProviderBase::SHashTable;
+
 TEST_CASE("string_hash_table::make_hash_table_256_buckets", "[translator]") {
-    REQUIRE(CheckHashClass<hash_djb2, 256, 256>());
+    REQUIRE(CheckHashClass<hash_djb2, 256, TPBSH::MaxStrings()>());
 }
 TEST_CASE("string_hash_table::make_hash_table_128_buckets", "[translator]") {
-    REQUIRE(CheckHashClass<hash_djb2, 128, 256>());
+    REQUIRE(CheckHashClass<hash_djb2, 128, TPBSH::MaxStrings()>());
 }
 TEST_CASE("string_hash_table::make_hash_table_100_buckets", "[translator]") {
-    REQUIRE(CheckHashClass<hash_djb2, 100, 256>());
+    REQUIRE(CheckHashClass<hash_djb2, 100, TPBSH::MaxStrings()>());
 }
 TEST_CASE("string_hash_table::make_hash_table_96_buckets", "[translator]") {
-    REQUIRE(CheckHashClass<hash_djb2, 96, 256>());
+    REQUIRE(CheckHashClass<hash_djb2, 96, TPBSH::MaxStrings()>());
 }
 TEST_CASE("string_hash_table::make_hash_table_64_buckets", "[translator]") {
-    REQUIRE(CheckHashClass<hash_djb2, 64, 256>());
+    REQUIRE(CheckHashClass<hash_djb2, 64, TPBSH::MaxStrings()>());
 }
 
 // intentional creation of hash collision and handling it

--- a/tests/unit/lang/translator/providerCPUFLASH.cpp
+++ b/tests/unit/lang/translator/providerCPUFLASH.cpp
@@ -33,7 +33,7 @@ const TPBSH::BucketRange hash_table_ForComparison[TPBSH::Buckets()] =
     const TPBSH::BucketItem stringRecArrayForComparison[TPBSH::MaxStrings()] =
 #include "hash_table_string_indices.ipp"
 
-        constexpr size_t maxStringBegins = 256;
+        constexpr size_t maxStringBegins = TPBSH::MaxStrings();
 constexpr size_t maxUtf8Raw = 16384;
 
 /// just like the StringTableCS, but without const data - to be able to fill them during testing at runtime


### PR DESCRIPTION
- Odometer -> Statistics
- unify Print time -> Print Time (we already had that text in the FW)
- X|Y|Z axis -> X|Y|Z-axis (we already had those text in the FW)
- update POT file accordingly
- remove translation marks from experimental menu completely (approved by Content+Testing)