### PR TITLE
Use symbolic names for interrupt priorities

### DIFF
--- a/lib/WUI/ethernetif.c
+++ b/lib/WUI/ethernetif.c
@@ -157,7 +157,7 @@ void HAL_ETH_MspInit(ETH_HandleTypeDef *ethHandle) {
         HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
         /* Peripheral interrupt init */
-        HAL_NVIC_SetPriority(ETH_IRQn, 5, 0);
+        HAL_NVIC_SetPriority(ETH_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
         HAL_NVIC_EnableIRQ(ETH_IRQn);
         /* USER CODE BEGIN ETH_MspInit 1 */
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -909,19 +909,19 @@ static void MX_DMA_Init(void) {
 
     /* DMA interrupt init */
     /* DMA1_Stream4_IRQn interrupt configuration */
-    HAL_NVIC_SetPriority(DMA1_Stream4_IRQn, 5, 0);
+    HAL_NVIC_SetPriority(DMA1_Stream4_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
     HAL_NVIC_EnableIRQ(DMA1_Stream4_IRQn);
     /* DMA1_Stream5_IRQn interrupt configuration */
-    HAL_NVIC_SetPriority(DMA1_Stream5_IRQn, 5, 0);
+    HAL_NVIC_SetPriority(DMA1_Stream5_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
     HAL_NVIC_EnableIRQ(DMA1_Stream5_IRQn);
     /* DMA2_Stream1_IRQn interrupt configuration */
-    HAL_NVIC_SetPriority(DMA2_Stream1_IRQn, 5, 0);
+    HAL_NVIC_SetPriority(DMA2_Stream1_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
     HAL_NVIC_EnableIRQ(DMA2_Stream1_IRQn);
     /* DMA2_Stream2_IRQn interrupt configuration */
-    HAL_NVIC_SetPriority(DMA2_Stream2_IRQn, 5, 0);
+    HAL_NVIC_SetPriority(DMA2_Stream2_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
     HAL_NVIC_EnableIRQ(DMA2_Stream2_IRQn);
     /* DMA2_Stream0_IRQn interrupt configuration */
-    HAL_NVIC_SetPriority(DMA2_Stream0_IRQn, 5, 0);
+    HAL_NVIC_SetPriority(DMA2_Stream0_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
     HAL_NVIC_EnableIRQ(DMA2_Stream0_IRQn);
 }
 
@@ -991,7 +991,7 @@ static void MX_GPIO_Init(void) {
     HAL_NVIC_SetPriority(EXTI9_5_IRQn, 0, 0);
     HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
 
-    HAL_NVIC_SetPriority(EXTI15_10_IRQn, 5, 0);
+    HAL_NVIC_SetPriority(EXTI15_10_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
     HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
 }
 

--- a/src/stm32f4xx_hal_msp.c
+++ b/src/stm32f4xx_hal_msp.c
@@ -104,7 +104,7 @@ void HAL_MspInit(void) {
 
     /* System interrupt init*/
     /* PendSV_IRQn interrupt configuration */
-    HAL_NVIC_SetPriority(PendSV_IRQn, 15, 0);
+    HAL_NVIC_SetPriority(PendSV_IRQn, configLIBRARY_LOWEST_INTERRUPT_PRIORITY, 0);
 
     /* USER CODE BEGIN MspInit 1 */
 
@@ -499,7 +499,7 @@ void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim_base) {
         /* Peripheral clock enable */
         __HAL_RCC_TIM14_CLK_ENABLE();
         /* TIM14 interrupt Init */
-        HAL_NVIC_SetPriority(TIM8_TRG_COM_TIM14_IRQn, 5, 0);
+        HAL_NVIC_SetPriority(TIM8_TRG_COM_TIM14_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
         HAL_NVIC_EnableIRQ(TIM8_TRG_COM_TIM14_IRQn);
         /* USER CODE BEGIN TIM14_MspInit 1 */
 
@@ -695,7 +695,7 @@ void HAL_UART_MspInit(UART_HandleTypeDef *huart) {
         __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
 
         // Enable the ISR
-        HAL_NVIC_SetPriority(USART2_IRQn, 5, 0);
+        HAL_NVIC_SetPriority(USART2_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
         HAL_NVIC_EnableIRQ(USART2_IRQn);
 
     } else if (huart->Instance == USART6) {
@@ -744,7 +744,7 @@ void HAL_UART_MspInit(UART_HandleTypeDef *huart) {
         __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
 
         // Enable the ISR
-        HAL_NVIC_SetPriority(USART6_IRQn, 5, 0);
+        HAL_NVIC_SetPriority(USART6_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
         HAL_NVIC_EnableIRQ(USART6_IRQn);
     }
 }

--- a/src/usbd_conf.c
+++ b/src/usbd_conf.c
@@ -114,7 +114,7 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *pcdHandle) {
         __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
 
         /* Peripheral interrupt init */
-        HAL_NVIC_SetPriority(OTG_FS_IRQn, 5, 0);
+        HAL_NVIC_SetPriority(OTG_FS_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
         HAL_NVIC_EnableIRQ(OTG_FS_IRQn);
         /* USER CODE BEGIN USB_OTG_FS_MspInit 1 */
 

--- a/src/usbh_conf.c
+++ b/src/usbh_conf.c
@@ -110,7 +110,7 @@ void HAL_HCD_MspInit(HCD_HandleTypeDef *hcdHandle) {
         __HAL_RCC_USB_OTG_HS_CLK_ENABLE();
 
         /* Peripheral interrupt init */
-        HAL_NVIC_SetPriority(OTG_HS_IRQn, 5, 0);
+        HAL_NVIC_SetPriority(OTG_HS_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY, 0);
         HAL_NVIC_EnableIRQ(OTG_HS_IRQn);
         /* USER CODE BEGIN USB_OTG_HS_MspInit 1 */
 


### PR DESCRIPTION
When setting interrupt priorities, two special values pop up:

5: configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY
15: configLIBRARY_LOWEST_INTERRUPT_PRIORITY

These are for 5) interrupts that need to call back into FreeRTOS code,
and 15) the lowest priority.

Do not hardcode such values. Use symbolic names, which makes the
priority meaningful.