### PR TITLE
Introduce "config_features.h"

### DIFF
--- a/lib/Marlin/Marlin/src/core/drivers.h
+++ b/lib/Marlin/Marlin/src/core/drivers.h
@@ -21,8 +21,6 @@
  */
 #pragma once
 
-#include "../inc/MarlinConfigPre.h"
-
 #define _A4988              0x001
 #define _A5984              0x002
 #define _DRV8825            0x003

--- a/src/common/config_features.h
+++ b/src/common/config_features.h
@@ -1,0 +1,15 @@
+// Define available printer features
+#pragma once
+
+/**
+ * Printer features configured (in order) via:
+ *   include/printers.h
+ *   src/common/config.h
+ *   include/marlin/Configuration.h
+ *   include/marlin/Configuration_MODEL.h
+ *   include/marlin/Configuration_MODEL_adv.h
+ */
+#include "../../lib/Marlin/Marlin/src/core/macros.h"
+#include "../include/marlin/Configuration.h"
+#include "../../lib/Marlin/Marlin/src/core/drivers.h"
+#include "../include/marlin/Configuration_adv.h"

--- a/src/common/selftest/selftest_fan.cpp
+++ b/src/common/selftest/selftest_fan.cpp
@@ -3,8 +3,8 @@
 #include "selftest_fan.h"
 #include "wizard_config.hpp"
 #include "fanctl.h"
-#include "../../../lib/Marlin/Marlin/src/inc/MarlinConfigPre.h" //EXTRUDER_AUTO_FAN_TEMPERATURE
-#include "marlin_server.h"                                      //marlin_server_get_temp_nozzle()
+#include "config_features.h" //EXTRUDER_AUTO_FAN_TEMPERATURE
+#include "marlin_server.h"   //marlin_server_get_temp_nozzle()
 
 #define FANTEST_STOP_DELAY    2000
 #define FANTEST_WAIT_DELAY    2500


### PR DESCRIPTION
Getting configured printer features is currently tricky, as it needs to
be done by including the appropriate local and Marlin configuration,
without including any other Marlin global or header.

Create a new "config_features.h" file which exposes this info by including
the minimal set of appropriate files.