### PR TITLE
Remove redundant includes

### DIFF
--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -12,8 +12,6 @@
 #include "version.h"
 #include "wdt.h"
 #include "../Marlin/src/module/temperature.h"
-#include "../include/marlin/Configuration.h"
-#include "../include/marlin/Configuration_adv.h"
 #include "cmath_ext.h"
 #include "footer_eeprom.hpp"
 #include <bitset>

--- a/src/marlin_stubs/G162.cpp
+++ b/src/marlin_stubs/G162.cpp
@@ -1,4 +1,3 @@
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
 #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
 #include "../../../lib/Marlin/Marlin/src/module/motion.h"
 

--- a/src/marlin_stubs/G26.cpp
+++ b/src/marlin_stubs/G26.cpp
@@ -1,12 +1,6 @@
 #include <algorithm>
 
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
-#include "../../lib/Marlin/Marlin/src/feature/host_actions.h"
-#include "../../lib/Marlin/Marlin/src/feature/safety_timer.h"
-#include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
-#include "../../lib/Marlin/Marlin/src/module/motion.h"
 #include "../../lib/Marlin/Marlin/src/module/temperature.h"
-#include "../../lib/Marlin/Marlin/src/Marlin.h"
 #include "marlin_server.hpp"
 #include "client_fsm_types.h"
 #include "PrusaGcodeSuite.hpp"

--- a/src/marlin_stubs/M330.cpp
+++ b/src/marlin_stubs/M330.cpp
@@ -1,4 +1,3 @@
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
 #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
 
 #include "M330.h"

--- a/src/marlin_stubs/M50.cpp
+++ b/src/marlin_stubs/M50.cpp
@@ -1,5 +1,4 @@
 //selftest
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
 #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
 #include "../../../lib/Marlin/Marlin/src/module/motion.h"
 

--- a/src/marlin_stubs/M876.cpp
+++ b/src/marlin_stubs/M876.cpp
@@ -26,7 +26,6 @@
     #include "../../lib/Marlin/Marlin/src/feature/host_actions.h"
     #include "safety_timer_stubbed.hpp"
     #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
-    #include "../../lib/Marlin/Marlin/src/Marlin.h"
     #include "marlin_server.hpp"
     #include "client_fsm_types.h"
 

--- a/src/marlin_stubs/M997.cpp
+++ b/src/marlin_stubs/M997.cpp
@@ -1,4 +1,3 @@
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
 #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
 #include "../../lib/Marlin/Marlin/src/gcode/queue.h"
 #include "PrusaGcodeSuite.hpp"

--- a/src/marlin_stubs/M999.cpp
+++ b/src/marlin_stubs/M999.cpp
@@ -1,4 +1,3 @@
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
 #include "../../lib/Marlin/Marlin/src/gcode/queue.h"
 #include "PrusaGcodeSuite.hpp"
 

--- a/src/marlin_stubs/gcode.cpp
+++ b/src/marlin_stubs/gcode.cpp
@@ -1,4 +1,3 @@
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
 #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
 
 #include "PrusaGcodeSuite.hpp"

--- a/src/marlin_stubs/pause/pause.cpp
+++ b/src/marlin_stubs/pause/pause.cpp
@@ -6,8 +6,6 @@
  * @date 2020-12-18
  */
 
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfigPre.h"
-
 #include "../../lib/Marlin/Marlin/src/Marlin.h"
 #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
 #include "../../lib/Marlin/Marlin/src/module/motion.h"


### PR DESCRIPTION
These are useless and/or redundant and get included indirectly by the more specific (remaining) lines.