### PR TITLE
Introduce InterruptPin, switch hw::zMin to it

### DIFF
--- a/src/common/Pin.hpp
+++ b/src/common/Pin.hpp
@@ -164,6 +164,21 @@ protected:
     Pull m_pull;
 };
 
+/**
+ * InterruptPin exposes hal pin/IRQ numbers necessary for interrupt configuration and efficient
+ * dispatch. It doesn't attempt to do any interrupt configuration by itself (yet).
+ */
+class InterruptPin : public InputPin {
+public:
+    constexpr InterruptPin(IoPort ioPort, IoPin ioPin, IMode iMode, Pull pull, IRQn_Type IRQn)
+        : InputPin(ioPort, ioPin, iMode, pull)
+        , m_halIRQn(IRQn) {}
+
+public:
+    using InputPin::m_halPin;
+    const IRQn_Type m_halIRQn;
+};
+
 enum class OMode : uint8_t {
     pushPull = GPIO_MODE_OUTPUT_PP,
     openDrain = GPIO_MODE_OUTPUT_OD,

--- a/src/common/Pin.hpp
+++ b/src/common/Pin.hpp
@@ -159,7 +159,7 @@ public:
 private:
     void configure(Pull pull) const;
 
-public:
+protected:
     IMode m_mode;
     Pull m_pull;
 };

--- a/src/common/hwio_pindef.h
+++ b/src/common/hwio_pindef.h
@@ -150,7 +150,7 @@
 
     #if BOARD_IS_BUDDY
         #define PIN_TABLE_BOARD_SPECIFIC(MACRO_FUNCTION)                                                                                                                     \
-            MACRO_FUNCTION(buddy::hw::InputPin, zMin, BUDDY_PIN(Z_MIN), IMode::IT_falling COMMA Pull::up)                                                                    \
+            MACRO_FUNCTION(buddy::hw::InterruptPin, zMin, BUDDY_PIN(Z_MIN), IMode::IT_falling COMMA Pull::up COMMA EXTI9_5_IRQn)                                             \
             MACRO_FUNCTION(buddy::hw::OutputPin, yEnable, BUDDY_PIN(Y_ENA), Pin::State::high COMMA OMode::pushPull COMMA OSpeed::low)                                        \
             MACRO_FUNCTION(buddy::hw::OutputPin, displayCs, buddy::hw::IoPort::C COMMA buddy::hw::IoPin::p9, Pin::State::high COMMA OMode::pushPull COMMA OSpeed::high)      \
             MACRO_FUNCTION(buddy::hw::OutputPin, displayRs, buddy::hw::IoPort::D COMMA buddy::hw::IoPin::p11, Pin::State::high COMMA OMode::pushPull COMMA OSpeed::high)     \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,10 +87,6 @@
 #define FAN1_TACH_Pin       GPIO_PIN_14
 #define FAN1_TACH_GPIO_Port GPIOE
 #define FAN1_TACH_EXTI_IRQn EXTI15_10_IRQn
-#if (PRINTER_TYPE == PRINTER_PRUSA_MINI)
-    #define Z_MIN_Pin       GPIO_PIN_8
-    #define Z_MIN_EXTI_IRQn EXTI9_5_IRQn
-#endif
 #define SWDIO_Pin           GPIO_PIN_13
 #define SWDIO_GPIO_Port     GPIOA
 #define SWCLK_Pin           GPIO_PIN_14
@@ -1024,7 +1020,7 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
 
 void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
     switch (GPIO_Pin) {
-    case Z_MIN_Pin:
+    case buddy::hw::zMin.m_halPin:
         ++minda_falling_edges;
         break;
     }


### PR DESCRIPTION
InterruptPin is derived from InputPut, but exposes hal pin/irq numbers
necessary for pin configuration and efficient interrupt dispatch.

These need to be const public expressions in order to work within a
switch statement.

We can think of using this class to setup the interrupt configuration in
the future as well. This is not currently done, as most interrupts need
to be configured per-group, and doing so per-pin would be incorrect.

Change/deduplicate code around zMin.