### PR TITLE
cleanup: Reduce Marlin include pollution

### DIFF
--- a/src/gui/dialogs/liveadjust_z.cpp
+++ b/src/gui/dialogs/liveadjust_z.cpp
@@ -10,10 +10,9 @@
 #include "eeprom.h"
 #include "display_helper.h"
 
-#include "../Marlin/src/inc/MarlinConfig.h"
+#include "config_features.h"
 #if (PRINTER_TYPE == PRINTER_PRUSA_MINI)
     #include "gui_config_mini.h"
-    #include "Configuration_MINI_adv.h"
 #else
     #error "Unknown PRINTER_TYPE."
 #endif

--- a/src/gui/menu_vars.cpp
+++ b/src/gui/menu_vars.cpp
@@ -2,12 +2,10 @@
 #include "config.h"
 #include "int_to_cstr.h"
 
-#include "../Marlin/src/inc/MarlinConfig.h"
 #include "../Marlin/src/module/temperature.h"
 
 #if (PRINTER_TYPE == PRINTER_PRUSA_MINI)
     #include "gui_config_mini.h"
-    #include "Configuration_MINI_adv.h"
 #else
     #error "Unknown PRINTER_TYPE."
 #endif

--- a/src/marlin_stubs/M876.cpp
+++ b/src/marlin_stubs/M876.cpp
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
+#include "config_features.h"
 
 #if ENABLED(HOST_PROMPT_SUPPORT) && DISABLED(EMERGENCY_PARSER)
 

--- a/src/marlin_stubs/host/M115.cpp
+++ b/src/marlin_stubs/host/M115.cpp
@@ -21,7 +21,6 @@
  */
 
 #include "../gcode.h"
-#include "../../inc/MarlinConfig.h"
 
 #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
 static void cap_line(PGM_P const name, bool ena = false) {

--- a/src/marlin_stubs/pause/G27.cpp
+++ b/src/marlin_stubs/pause/G27.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include "../../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
+#include "config_features.h"
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
 

--- a/src/marlin_stubs/pause/M125.cpp
+++ b/src/marlin_stubs/pause/M125.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include "../../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
+#include "config_features.h"
 
 #if ENABLED(PARK_HEAD_ON_PAUSE)
 

--- a/src/marlin_stubs/pause/M600.cpp
+++ b/src/marlin_stubs/pause/M600.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include "../../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
+#include "config_features.h"
 
 // clang-format off
 #if (!ENABLED(ADVANCED_PAUSE_FEATURE)) || \

--- a/src/marlin_stubs/pause/M601_M602.cpp
+++ b/src/marlin_stubs/pause/M601_M602.cpp
@@ -1,4 +1,3 @@
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
 #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
 #include "marlin_server.h"
 

--- a/src/marlin_stubs/pause/M603.cpp
+++ b/src/marlin_stubs/pause/M603.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include "../../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
+#include "config_features.h"
 
 #if ENABLED(ADVANCED_PAUSE_FEATURE)
 

--- a/src/marlin_stubs/pause/M701_M702.cpp
+++ b/src/marlin_stubs/pause/M701_M702.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include "../../../lib/Marlin/Marlin/src/inc/MarlinConfigPre.h"
+#include "config_features.h"
 
 // clang-format off
 #if (!ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)) || \

--- a/src/marlin_stubs/sdcard/M20-M30_M32-M34.cpp
+++ b/src/marlin_stubs/sdcard/M20-M30_M32-M34.cpp
@@ -1,6 +1,5 @@
 #include <dirent.h>
 
-#include "../../lib/Marlin/Marlin/src/inc/MarlinConfig.h"
 #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
 #include "marlin_server.h"
 #include "media.h"


### PR DESCRIPTION
Use the most-specific header possible when checking for configuration
options and avoid including Marlin headers entirely if possible.