### PR TITLE
hal: Switch to NVIC_PRIORITYGROUP_3 (1 bit of IRQ subpriority)

### DIFF
--- a/include/freertos/FreeRTOSConfig.h
+++ b/include/freertos/FreeRTOSConfig.h
@@ -149,7 +149,7 @@ to exclude the API function. */
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
 function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY 15
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY 7
 
 /* The highest interrupt priority that can be used by any interrupt service
 routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL

--- a/lib/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.c
+++ b/lib/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.c
@@ -170,7 +170,7 @@ HAL_StatusTypeDef HAL_Init(void)
 #endif /* PREFETCH_ENABLE */
 
   /* Set Interrupt Group Priority */
-  HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
+  HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_3);
 
   /* Use systick as time base source and configure 1ms tick (default clock after Reset is HSI) */
   HAL_InitTick(TICK_INT_PRIORITY);


### PR DESCRIPTION
NVIC_PRIORITYGROUP_3 allows IRQ priority subgroups: interrupts in the
same class won't preempt each-other.

Change symbolic IRQ priorities to match.

Include additional configASSERT checks from FreeRTOS v1.26.2 and
disable the no-subpriority sanity check.