### PR TITLE
bsod: Mark _bsod as noreturn

### DIFF
--- a/src/common/bsod.h
+++ b/src/common/bsod.h
@@ -27,7 +27,7 @@ extern "C" {
 //no file name, no line number
 #define bsod_nofn_noln(fmt, ...) _bsod(fmt, 0, -1, ##__VA_ARGS__)
 
-void _bsod(const char *fmt, const char *fine_name, int line_number, ...); //with file name and line number
+__attribute__((noreturn)) void _bsod(const char *fmt, const char *fine_name, int line_number, ...); //with file name and line number
 
 void general_error(const char *error, const char *module);
 


### PR DESCRIPTION
This helps (among others) to avoid warnings when using bsod as the end
of a non-void function.