### PR TITLE
bsod: Include FreeRTOS to get configCHECK_FOR_STACK_OVERFLOW

### DIFF
--- a/src/common/bsod_nogui.cpp
+++ b/src/common/bsod_nogui.cpp
@@ -1,6 +1,7 @@
 // bsod_nogui.cpp - blue screen of death
 #include "bsod.h"
 #include "safe_state.h"
+#include "FreeRTOS.h"
 
 void _bsod(const char *fmt, const char *file_name, int line_number, ...) {
     hwio_safe_state();
@@ -27,7 +28,6 @@ void ScreenHardFault(void) {
 }
 
 #ifdef configCHECK_FOR_STACK_OVERFLOW
-    #include "FreeRTOS.h"
     #include "task.h"
 
 extern "C" void vApplicationStackOverflowHook(TaskHandle_t xTask, signed char *pcTaskName) {


### PR DESCRIPTION
We can skip the value of configCHECK_FOR_STACK_OVERFLOW otherwise.