### PR TITLE
hal: Switch back to NVIC_PRIORITYGROUP_4

### DIFF
--- a/include/freertos/FreeRTOSConfig.h
+++ b/include/freertos/FreeRTOSConfig.h
@@ -149,7 +149,7 @@ to exclude the API function. */
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
 function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY 7
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY 15
 
 /* The highest interrupt priority that can be used by any interrupt service
 routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL

--- a/lib/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.c
+++ b/lib/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.c
@@ -170,7 +170,7 @@ HAL_StatusTypeDef HAL_Init(void)
 #endif /* PREFETCH_ENABLE */
 
   /* Set Interrupt Group Priority */
-  HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_3);
+  HAL_NVIC_SetPriorityGrouping(NVIC_PRIORITYGROUP_4);
 
   /* Use systick as time base source and configure 1ms tick (default clock after Reset is HSI) */
   HAL_InitTick(TICK_INT_PRIORITY);

--- a/lib/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c
+++ b/lib/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c
@@ -773,9 +773,7 @@ static void vPortEnableVFP( void )
 		scheduler.  Note however that some vendor specific peripheral libraries
 		assume a non-zero priority group setting, in which cases using a value
 		of zero will result in unpredicable behaviour. */
-
-		// Buddy FW is using NVIC_PRIORITYGROUP_3 (3:1) - disable this check
-		//configASSERT( ( portAIRCR_REG & portPRIORITY_GROUP_MASK ) <= ulMaxPRIGROUPValue );
+		configASSERT( ( portAIRCR_REG & portPRIORITY_GROUP_MASK ) <= ulMaxPRIGROUPValue );
 	}
 
 #endif /* configASSERT_DEFINED */


### PR DESCRIPTION
Turns out subpriorities might not be needed.

Partially revert 915eb487cffe998bf0ff39faf02d070ce1f79c0e which is the
"normal" configuration but keep all the new checks.