### PR TITLE
Optimalize ESP uart writes, 4.6M baudrate

### DIFF
--- a/lib/ESP/prusa/src/system/lwesp_ll_buddy.c
+++ b/lib/ESP/prusa/src/system/lwesp_ll_buddy.c
@@ -120,9 +120,8 @@ esp_transmit_data(const void *data, size_t len) {
         return 0;
     }
 
-    for (size_t i = 0; i < len; ++i) {
-        HAL_UART_Transmit(&huart6, (uint8_t *)(data + i), 1, 10);
-    }
+    HAL_UART_Transmit(&huart6, (uint8_t *)data, len, 10 * len);
+
     return len;
 }
 

--- a/lib/WUI/netdev.c
+++ b/lib/WUI/netdev.c
@@ -31,7 +31,7 @@
 #include "alsockets.h"
 #include "lwesp_ll_buddy.h"
 
-static const uint32_t esp_target_baudrate = 500000;
+static const uint32_t esp_target_baudrate = 4600000;
 static netdev_status_t esp_state = NETDEV_NETIF_DOWN;
 static uint32_t active_netdev_id = NETDEV_NODEV_ID;
 static ETH_config_t wui_netdev_config[NETDEV_COUNT]; // the active WUI configuration for ethernet, connect and server


### PR DESCRIPTION
- Avoid sending data to ESP byte by byte. This allows to talk much
  faster to ESP. Does this simplifies data processing on ESP?
- Set ESP UART baudrate to 4.6M