### PR TITLE
Rename confusing raster operation

### DIFF
--- a/src/guiapi/include/IWindowMenuItem.hpp
+++ b/src/guiapi/include/IWindowMenuItem.hpp
@@ -76,7 +76,7 @@ public:
     virtual ~IWindowMenuItem() = default;
     void Enable() { enabled = is_enabled_t::yes; }
     void Disable() { enabled = is_enabled_t::no; }
-    bool IsEnabled() const { return enabled == is_enabled_t::yes; }
+    bool IsEnabled() const { return enabled == is_enabled_t::yes; } // This translates to 'shadow' in window_t's derived classes (remains focusable but cant be executed)
     bool IsSelected() const { return selected == is_selected_t::yes; }
     void Hide() { hidden = (uint8_t)is_hidden_t::yes; }
     void Show() { hidden = (uint8_t)is_hidden_t::no; }

--- a/src/guiapi/include/raster_opfn.hpp
+++ b/src/guiapi/include/raster_opfn.hpp
@@ -23,7 +23,7 @@ enum class has_swapped_bw : bool {
     yes
 };
 
-enum class is_disabled : bool {
+enum class is_shadowed : bool {
     no,
     yes
 };
@@ -31,11 +31,11 @@ enum class is_disabled : bool {
 struct ropfn {
     is_inverted invert : 1;
     has_swapped_bw swap_bw : 1;
-    is_disabled disable : 1;
-    constexpr ropfn(is_inverted invert = is_inverted::no, has_swapped_bw swap_bw = has_swapped_bw::no, is_disabled disable = is_disabled::no)
+    is_shadowed shadow : 1;
+    constexpr ropfn(is_inverted invert = is_inverted::no, has_swapped_bw swap_bw = has_swapped_bw::no, is_shadowed shadow = is_shadowed::no)
         : invert(invert)
         , swap_bw(swap_bw)
-        , disable(disable) {}
+        , shadow(shadow) {}
 
     constexpr uint8_t ConvertToC() const {
         uint8_t ret = 0;
@@ -43,8 +43,8 @@ struct ropfn {
             ret |= ROPFN_INVERT;
         if (swap_bw == has_swapped_bw::yes)
             ret |= ROPFN_SWAPBW;
-        if (disable == is_disabled::yes)
-            ret |= ROPFN_DISABLE;
+        if (shadow == is_shadowed::yes)
+            ret |= ROPFN_SHADOW;
         return ret;
     }
 };
@@ -58,5 +58,5 @@ struct icon_flags {
 
     constexpr bool IsInverted() { return raster_flags.invert == is_inverted::yes; }
     constexpr bool HasSwappedBW() { return raster_flags.swap_bw == has_swapped_bw::yes; }
-    constexpr bool IsDisabled() { return raster_flags.disable == is_disabled::yes; }
+    constexpr bool IsShadowed() { return raster_flags.shadow == is_shadowed::yes; }
 };

--- a/src/guiapi/include/raster_opfn_c.h
+++ b/src/guiapi/include/raster_opfn_c.h
@@ -8,8 +8,8 @@
 
 //raster operation function constants
 enum {
-    ROPFN_COPY = 0x00,    //copy (no operation)
-    ROPFN_INVERT = 0x01,  //invert
-    ROPFN_SWAPBW = 0x02,  //swap black-white
-    ROPFN_DISABLE = 0x04, //disables (darker colors)
+    ROPFN_COPY = 0x00,   //copy (no operation)
+    ROPFN_INVERT = 0x01, //invert
+    ROPFN_SWAPBW = 0x02, //swap black-white
+    ROPFN_SHADOW = 0x04, //darker colors
 };

--- a/src/guiapi/include/window_types.hpp
+++ b/src/guiapi/include/window_types.hpp
@@ -59,7 +59,7 @@ union WindowFlags {
         bool hidden_behind_dialog : 1;             // 09 - there is an dialog over this window
         is_closed_on_timeout_t timeout_close : 1;  // 0A - menu timeout flag - it's meant to be used in window_frame_t
         is_closed_on_serial_t serial_close : 1;    // 0B - serial printing screen open close
-        bool shadow : 1;                           // 0C - darker colors
+        bool shadow : 1;                           // 0C - executable (causes darker colors)
         bool enforce_capture_when_not_visible : 1; // 0D - normally invisible / hidden_behind_dialog windows does not get capture
         bool has_relative_subwins : 1;             // 0E - X Y coords of all children are relative to this, screen cannot have this flag because 1st level windows can be dialogs and they must not have relative coords
         bool multiline : 1;                        // 0F - multiline text affect window_text_t anf its children

--- a/src/guiapi/src/IWindowMenuItem.cpp
+++ b/src/guiapi/src/IWindowMenuItem.cpp
@@ -51,7 +51,7 @@ Rect16 IWindowMenuItem::getExtensionRect(Rect16 rect) const {
 
 void IWindowMenuItem::Print(Rect16 rect) const {
     ropfn raster_op;
-    raster_op.disable = IsEnabled() ? is_disabled::no : is_disabled::yes;
+    raster_op.shadow = IsEnabled() ? is_shadowed::no : is_shadowed::yes;
     raster_op.swap_bw = IsFocused() ? has_swapped_bw::yes : has_swapped_bw::no;
 
     color_t mi_color_back = GetBackColor();

--- a/src/guiapi/src/st7789v.cpp
+++ b/src/guiapi/src/st7789v.cpp
@@ -594,7 +594,7 @@ void st7789v_draw_png_ex(uint16_t point_x, uint16_t point_y, FILE *pf, uint32_t 
                         uint8_t *ppx888 = (uint8_t *)(st7789v_buff + j * pixsize);
 
                         switch (rop) {
-                        case ROPFN_SWAPBW | ROPFN_DISABLE:
+                        case ROPFN_SWAPBW | ROPFN_SHADOW:
                             // TODO
                             break;
                         case ROPFN_INVERT:
@@ -603,7 +603,7 @@ void st7789v_draw_png_ex(uint16_t point_x, uint16_t point_y, FILE *pf, uint32_t 
                         case ROPFN_SWAPBW:
                             rop_rgb888_swapbw(ppx888);
                             break;
-                        case ROPFN_DISABLE:
+                        case ROPFN_SHADOW:
                             rop_rgb888_disabled(ppx888);
                             break;
                         }

--- a/src/guiapi/src/window_icon.cpp
+++ b/src/guiapi/src/window_icon.cpp
@@ -37,7 +37,7 @@ window_icon_t::window_icon_t(window_t *parent, uint16_t id_res, point_i16_t pt, 
 
 void window_icon_t::unconditionalDraw() {
     ropfn raster_op;
-    raster_op.disable = IsEnabled() ? is_disabled::no : is_disabled::yes;
+    raster_op.shadow = IsShadowed() ? is_shadowed::yes : is_shadowed::no;
     raster_op.swap_bw = IsFocused() ? has_swapped_bw::yes : has_swapped_bw::no;
 
     super::unconditionalDraw();


### PR DESCRIPTION
Rename raster operation 'disable' to 'shadow' to avoid confusion in code.