### PR TITLE
cleanup: enum type safety in eeprom

### DIFF
--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -304,8 +304,8 @@ static inline void eeprom_unlock(void) {
 
 // forward declarations of private functions
 
-static uint16_t eeprom_var_size(uint8_t id);
-static uint16_t eeprom_var_addr(uint8_t id);
+static uint16_t eeprom_var_size(enum eevar_id id);
+static uint16_t eeprom_var_addr(enum eevar_id id);
 //static void eeprom_print_vars(void);
 static int eeprom_convert_from_v2(void);
 static int eeprom_convert_from(uint16_t version, uint16_t features);
@@ -371,7 +371,7 @@ static eeprom_vars_t &eeprom_startup_vars() {
     return ret;
 }
 
-variant8_t eeprom_get_var(uint8_t id) {
+variant8_t eeprom_get_var(enum eevar_id id) {
     uint16_t addr;
     uint16_t size;
     uint16_t data_size;
@@ -395,7 +395,7 @@ variant8_t eeprom_get_var(uint8_t id) {
     return var;
 }
 
-void eeprom_set_var(uint8_t id, variant8_t var) {
+void eeprom_set_var(enum eevar_id id, variant8_t var) {
     uint16_t addr;
     uint16_t size;
     uint16_t data_size;
@@ -405,7 +405,7 @@ void eeprom_set_var(uint8_t id, variant8_t var) {
         if (id == EEVAR_ZOFFSET && variant8_get_type(var) == VARIANT8_FLT) {
             variant8_t recent_sheet = eeprom_get_var(EEVAR_ACTIVE_SHEET);
             uint8_t index = variant8_get_ui8(recent_sheet);
-            uint16_t profile_address = eeprom_var_addr(EEVAR_SHEET_PROFILE0 + index);
+            uint16_t profile_address = eeprom_var_addr(static_cast<enum eevar_id>(EEVAR_SHEET_PROFILE0 + index));
             float z_offset = variant8_get_flt(var);
             st25dv64k_user_write_bytes(profile_address + MAX_SHEET_NAME_LENGTH, &z_offset, sizeof(float));
         }
@@ -433,13 +433,13 @@ uint8_t eeprom_get_var_count(void) {
     return EEPROM_VARCOUNT;
 }
 
-const char *eeprom_get_var_name(uint8_t id) {
+const char *eeprom_get_var_name(enum eevar_id id) {
     if (id < EEPROM_VARCOUNT)
         return eeprom_map[id].name;
     return "???";
 }
 
-int eeprom_var_format(char *str, unsigned int size, uint8_t id, variant8_t var) {
+int eeprom_var_format(char *str, unsigned int size, enum eevar_id id, variant8_t var) {
     int n = 0;
     switch (id) {
     // ip addresses
@@ -472,16 +472,17 @@ void eeprom_clear(void) {
 
 // private functions
 
-static uint16_t eeprom_var_size(uint8_t id) {
+static uint16_t eeprom_var_size(enum eevar_id id) {
     if (id < EEPROM_VARCOUNT)
         return variant8_type_size(eeprom_map[id].type & ~VARIANT8_PTR) * eeprom_map[id].count;
     return 0;
 }
 
-static uint16_t eeprom_var_addr(uint8_t id) {
+static uint16_t eeprom_var_addr(enum eevar_id id) {
     uint16_t addr = EEPROM_ADDRESS;
-    while (id)
-        addr += eeprom_var_size(--id);
+    uint8_t id_idx = id;
+    while (id_idx > 0)
+        addr += eeprom_var_size(static_cast<enum eevar_id>(--id_idx));
     return addr;
 }
 
@@ -512,7 +513,7 @@ static void eeprom_save_upgraded(eeprom_vars_t &vars) {
     st25dv64k_user_write_bytes(EEPROM_ADDRESS, (void *)&vars, EEPROM_DATASIZE);
 }
 
-static void eeprom_import_block(uint8_t begin, uint8_t end, void *dst) {
+static void eeprom_import_block(enum eevar_id begin, enum eevar_id end, void *dst) {
     // start addres of imported data block
     uint16_t addr_start = eeprom_var_addr(begin);
     // end addres of imported data - end means the next first eeprom var we do NOT want to copy
@@ -737,7 +738,7 @@ uint32_t sheet_next_calibrated() {
 
 bool sheet_is_calibrated(uint32_t index) {
 #if (EEPROM_FEATURES & EEPROM_FEATURE_SHEETS)
-    uint16_t profile_address = eeprom_var_addr(EEVAR_SHEET_PROFILE0 + index);
+    uint16_t profile_address = eeprom_var_addr(static_cast<enum eevar_id>(EEVAR_SHEET_PROFILE0 + index));
     float z_offset = FLT_MAX;
     st25dv64k_user_read_bytes(profile_address + MAX_SHEET_NAME_LENGTH,
         &z_offset, sizeof(float));
@@ -752,7 +753,7 @@ bool sheet_select(uint32_t index) {
     if (index >= MAX_SHEETS || !sheet_is_calibrated(index))
         return false;
     uint16_t active_sheet_address = eeprom_var_addr(EEVAR_ACTIVE_SHEET);
-    uint16_t profile_address = eeprom_var_addr(EEVAR_SHEET_PROFILE0 + index);
+    uint16_t profile_address = eeprom_var_addr(static_cast<enum eevar_id>(EEVAR_SHEET_PROFILE0 + index));
     uint16_t z_offset_address = eeprom_var_addr(EEVAR_ZOFFSET);
     float z_offset = FLT_MAX;
     st25dv64k_user_read_bytes(profile_address + MAX_SHEET_NAME_LENGTH,
@@ -785,7 +786,7 @@ bool sheet_reset(uint32_t index) {
     if (index >= MAX_SHEETS)
         return false;
     uint8_t active = variant8_get_ui8(eeprom_get_var(EEVAR_ACTIVE_SHEET));
-    uint16_t profile_address = eeprom_var_addr(EEVAR_SHEET_PROFILE0 + index);
+    uint16_t profile_address = eeprom_var_addr(static_cast<enum eevar_id>(EEVAR_SHEET_PROFILE0 + index));
     float z_offset = FLT_MAX;
 
     st25dv64k_user_write_bytes(profile_address + MAX_SHEET_NAME_LENGTH,
@@ -828,7 +829,7 @@ uint32_t sheet_name(uint32_t index, char *buffer, uint32_t length) {
     if (index >= MAX_SHEETS || !buffer || !length)
         return 0;
 #if (EEPROM_FEATURES & EEPROM_FEATURE_SHEETS)
-    uint16_t profile_address = eeprom_var_addr(EEVAR_SHEET_PROFILE0 + index);
+    uint16_t profile_address = eeprom_var_addr(static_cast<enum eevar_id>(EEVAR_SHEET_PROFILE0 + index));
     uint32_t l = length < MAX_SHEET_NAME_LENGTH - 1
         ? length
         : MAX_SHEET_NAME_LENGTH - 1;
@@ -849,7 +850,7 @@ uint32_t sheet_rename(uint32_t index, char const *name, uint32_t length) {
     if (index >= MAX_SHEETS || !name || !length)
         return false;
     char eeprom_name[MAX_SHEET_NAME_LENGTH];
-    uint16_t profile_address = eeprom_var_addr(EEVAR_SHEET_PROFILE0 + index);
+    uint16_t profile_address = eeprom_var_addr(static_cast<enum eevar_id>(EEVAR_SHEET_PROFILE0 + index));
     uint32_t l = length < MAX_SHEET_NAME_LENGTH - 1
         ? length
         : MAX_SHEET_NAME_LENGTH - 1;
@@ -956,12 +957,12 @@ extern "C" uint16_t get_steps_per_unit_e_rounded() {
 }
 
 //by write functions, cannot read startup variables, must read current value from eeprom
-template <int ENUM>
+template <enum eevar_id ENUM>
 bool is_current_axis_value_inverted() {
     return std::signbit(variant8_get_flt(eeprom_get_var(ENUM)));
 }
 
-template <int ENUM>
+template <enum eevar_id ENUM>
 void set_steps_per_unit(float steps) {
     if (steps > 0) {
         bool negative_direction = is_current_axis_value_inverted<ENUM>();
@@ -983,12 +984,12 @@ extern "C" void set_steps_per_unit_e(float steps) {
 }
 
 //by write functions, cannot read startup variables, must read current value from eeprom
-template <int ENUM>
+template <enum eevar_id ENUM>
 float get_current_steps_per_unit() {
     return std::abs(variant8_get_flt(eeprom_get_var(ENUM)));
 }
 
-template <int ENUM>
+template <enum eevar_id ENUM>
 void set_axis_positive_direction() {
     float steps = get_current_steps_per_unit<ENUM>();
     eeprom_set_var(ENUM, variant8_flt(steps));
@@ -1007,7 +1008,7 @@ extern "C" void set_positive_direction_e() {
     set_axis_positive_direction<AXIS_STEPS_PER_UNIT_E0>();
 }
 
-template <int ENUM>
+template <enum eevar_id ENUM>
 void set_axis_negative_direction() {
     float steps = get_current_steps_per_unit<ENUM>();
     eeprom_set_var(ENUM, variant8_flt(-steps));
@@ -1087,7 +1088,7 @@ extern "C" uint16_t get_microsteps_e() {
     return is_microstep_value_valid(ret) ? ret : E0_MICROSTEPS;
 }
 
-template <int ENUM>
+template <enum eevar_id ENUM>
 void set_microsteps(uint16_t microsteps) {
     if (is_microstep_value_valid(microsteps)) {
         eeprom_set_var(ENUM, variant8_ui16(microsteps));
@@ -1127,7 +1128,7 @@ extern "C" uint16_t get_rms_current_ma_e() {
     return (ret > 0) ? ret : E0_CURRENT;
 }
 
-template <int ENUM>
+template <enum eevar_id ENUM>
 void set_rms_current_ma(uint16_t current) {
     if (current > 0) {
         eeprom_set_var(ENUM, variant8_ui16(current));

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -21,7 +21,7 @@ enum {
     MAX_SHEET_NAME_LENGTH = 8,
 };
 
-enum {
+enum eevar_id {
     // basic variables
     EEVAR_VERSION = 0x00,         // uint16_t eeprom version
     EEVAR_FEATURES = 0x01,        // uint16_t feature mask
@@ -168,19 +168,19 @@ extern eeprom_init_status_t eeprom_init(void);
 extern void eeprom_defaults(void);
 
 // get variable value as variant8
-extern variant8_t eeprom_get_var(uint8_t id);
+extern variant8_t eeprom_get_var(enum eevar_id id);
 
 // set variable value as variant8
-extern void eeprom_set_var(uint8_t id, variant8_t var);
+extern void eeprom_set_var(enum eevar_id id, variant8_t var);
 
 // get number of variables
 extern uint8_t eeprom_get_var_count(void);
 
 // get variable name
-extern const char *eeprom_get_var_name(uint8_t id);
+extern const char *eeprom_get_var_name(enum eevar_id id);
 
 // format variable value to string (some variables can have specific formating)
-extern int eeprom_var_format(char *str, unsigned int size, uint8_t id, variant8_t var);
+extern int eeprom_var_format(char *str, unsigned int size, enum eevar_id id, variant8_t var);
 
 // fill range 0x0000..0x0800 with 0xff
 extern void eeprom_clear(void);

--- a/src/common/odometer.cpp
+++ b/src/common/odometer.cpp
@@ -7,7 +7,7 @@
 #include "eeprom.h"
 
 // translation table to get eevar from axis index
-static constexpr int eevars[] = {
+static constexpr enum eevar_id eevars[] = {
     EEVAR_ODOMETER_X,
     EEVAR_ODOMETER_Y,
     EEVAR_ODOMETER_Z,


### PR DESCRIPTION
Pass the eeprom variable ID as the actual enum. This helps a bit against
passing the wrong thing by accident, in IDEs' completions and such. Far
from the "if it compiles, it's correct" ideal, but we need to start
somewhere to get there.

Previously mentioned in Slack. Should I go the next step of not numbering it and have it auto-numbered?