### PR TITLE
BFW-2175: Extract only whole X-Api-Key header

### DIFF
--- a/lib/WUI/http/httpd.c
+++ b/lib/WUI/http/httpd.c
@@ -2598,7 +2598,7 @@ static void wui_api_files(struct fs_file *file) {
 }
 
 bool authorize_request(const struct pbuf *req) {
-    const char *api_key_tag = "X-Api-Key:";
+    const char *api_key_tag = CRLF "X-Api-Key:";
     uint32_t api_key_tag_length = strlen(api_key_tag);
     uint32_t index = pbuf_strstr(req, api_key_tag);
 


### PR DESCRIPTION
This'll now accept only the `X-Api-Key` header, not eg.
`Not-An-X-Api-Key` header, nor it'll accept the text somewhere in a
content of something.

Tested manually (unit tests of this area of code is going to be a whole
separate chapter, it seems :-|).

This is still not perfect ‒ the header should be parsed in case
insensitive manner, arbitrary amount of arbitrary whitespace can precede
the value... but this seems to be a general problem of the whole web
server implementation and we shall decide what to do with it in some
larger scale.