### PR TITLE
GUI: QR header adjustment

### DIFF
--- a/src/guiapi/include/window_qr.hpp
+++ b/src/guiapi/include/window_qr.hpp
@@ -6,8 +6,11 @@
 
 class window_qr_t : public AddSuperWindow<window_t> {
 public:
-    window_qr_t(window_t *parent, Rect16 rect, uint16_t err_num);
+    window_qr_t(window_t *parent, Rect16 rect, uint16_t error_num);
+    window_qr_t(window_t *parent, Rect16 rect);
+
     static constexpr uint16_t MAX_LEN_4QR = 256;
+    void SetQRHeader(uint16_t err_num);
 
 private:
     /// Defines maximal size of QR code and buffers needed for generating. Keep it low.

--- a/src/guiapi/src/window_qr.cpp
+++ b/src/guiapi/src/window_qr.cpp
@@ -11,6 +11,11 @@
 
 /// QR Window
 window_qr_t::window_qr_t(window_t *parent, Rect16 rect, uint16_t err_num)
+    : window_qr_t(parent, rect) {
+    SetQRHeader(err_num);
+}
+
+window_qr_t::window_qr_t(window_t *parent, Rect16 rect)
     : AddSuperWindow<window_t>(parent, rect)
     // , version(9)
     // , ecc_level(qrcodegen_Ecc_HIGH)
@@ -19,7 +24,9 @@ window_qr_t::window_qr_t(window_t *parent, Rect16 rect, uint16_t err_num)
     , px_per_module(2)
     , align(Align_t::Center())
     , scale(true) {
+}
 
+void window_qr_t::SetQRHeader(uint16_t err_num) {
     bool devhash_in_qr = variant8_get_ui8(eeprom_get_var(EEVAR_DEVHASH_IN_QR));
     if (devhash_in_qr) {
         error_url_long(text, sizeof(text), err_num);


### PR DESCRIPTION
Move setting of the QR header out of constructor to support static screens with QR.