### PR TITLE
BFW-2171: More accurate HTTP response headers

### DIFF
--- a/lib/WUI/http/httpd.c
+++ b/lib/WUI/http/httpd.c
@@ -2729,6 +2729,8 @@ static err_t http_find_file(struct http_state *hs, const char *uri, int is_09) {
         if (authorize_request(hs->req)) {
             handler(&api_file);
             file = &api_file;
+            static const char name[] = "response.json";
+            uri = &name[0];
         } else {
             uri = "401";
         }


### PR DESCRIPTION
Provide an internal URL with an extension, to hint the automagic
routines in the http server to more accurate/descriptive headers.

(Yes, I'm aware there'll be a collision around #1682, but the solution is obvious)