### PR TITLE
Fix getting current IP address

### DIFF
--- a/lib/WUI/netdev.h
+++ b/lib/WUI/netdev.h
@@ -127,7 +127,7 @@ uint32_t netdev_get_active_id();
  * \param [out] dest - an 4-element array to put the IP into, in network order.
  * \return If any address was filled in (false in case it failed).
  */
-bool get_current_ipv4(uint8_t *dest);
+bool netdev_get_current_ipv4(uint8_t *dest);
 
 ////////////////////////////////////////////////////////////////////////////
 /// @brief Set network device for communication

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -165,7 +165,7 @@ void stringify_eth_for_screen(lan_descp_str_t *dest, ETH_config_t *config);
 *
 * \param [in] config - structure that stores currnet ethernet configurations
 *****************************************************************************/
-void get_eth_address(uint32_t, ETH_config_t *);
+void netdev_get_eth_address(uint32_t, ETH_config_t *);
 
 /*!*********************************************************************************************************************
 * \brief Parses time from device's time storage to seconds. MONTHS are from 0 and YEARS are from 1900

--- a/src/gui/screen_menu_lan_settings.cpp
+++ b/src/gui/screen_menu_lan_settings.cpp
@@ -115,7 +115,7 @@ ScreenMenuLanSettings::ScreenMenuLanSettings()
 void ScreenMenuLanSettings::refresh_addresses() {
     if (netdev_get_status(netdev_get_active_id()) == NETDEV_NETIF_UP) {
         ETH_config_t ethconfig = {};
-        get_eth_address(netdev_get_active_id(), &ethconfig);
+        netdev_get_eth_address(netdev_get_active_id(), &ethconfig);
         stringify_eth_for_screen(&plan_str, &ethconfig);
     } else {
         snprintf(plan_str, LAN_DESCP_SIZE, "NO CONNECTION\n");


### PR DESCRIPTION
* Use the relevant function to get it from the driver instead of relying
  on a variable.
* Fix the comment describing the said variable, to make it clear it is
  not actually the active state of the interface.

Follow-up of BFW-2240.