### PR TITLE
Fix non-existing endpoint

### DIFF
--- a/lib/WUI/http/httpd.c
+++ b/lib/WUI/http/httpd.c
@@ -2736,6 +2736,8 @@ static err_t http_find_file(struct http_state *hs, const char *uri, int is_09) {
     } else if (!strncmp(uri, "/api/files", 10)) {
         wui_api_files(&api_file);
         file = &api_file;
+    } else {
+        uri = "404";
     }
 
 process_file:


### PR DESCRIPTION
In case of request non-existing endpoint the web server returns status code 404

BFW-2172