### PR TITLE
Refactor httpd ‒ split to content & http parts

### DIFF
--- a/lib/WUI/CMakeLists.txt
+++ b/lib/WUI/CMakeLists.txt
@@ -8,6 +8,8 @@ target_sources(
             alsockets.c
             wui_api.c
             http/fs.c
+            http/handler.c
+            http/handler_defaults.c
             http/httpd.c
             http/httpd_post.c
             http/multipart_parser.c

--- a/lib/WUI/CMakeLists.txt
+++ b/lib/WUI/CMakeLists.txt
@@ -9,7 +9,7 @@ target_sources(
             wui_api.c
             http/fs.c
             http/handler.c
-            http/handler_defaults.c
+            http_handler_default.c
             http/httpd.c
             http/httpd_post.c
             http/multipart_parser.c

--- a/lib/WUI/http/handler.c
+++ b/lib/WUI/http/handler.c
@@ -1,0 +1,19 @@
+#include "handler.h"
+
+#include <string.h>
+
+const struct GetDescriptor *http_handlers_find_get(const struct HttpHandlers *self, const char *uri) {
+    for (const struct GetDescriptor *h = self->gets; h->uri != NULL; h++) {
+        if (h->prefix) {
+            if (strncmp(uri, h->uri, strlen(h->uri)) == 0) {
+                return h;
+            }
+        } else {
+            if (strcmp(uri, h->uri) == 0) {
+                return h;
+            }
+        }
+    }
+
+    return NULL;
+}

--- a/lib/WUI/http/handler.h
+++ b/lib/WUI/http/handler.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+/*
+ * The http handlers.
+ *
+ * These are the functions that provide the dynamic content. They are not
+ * supposed to have any knowledge of the actual HTTP or its implementation as
+ * far as possible.
+ *
+ * They are passed to the HTTP server to serve the content. This also allows to
+ * plugging some mocks to do the server part.
+ *
+ * The server is initialized with a pointer to the HttpHandlers structure. The
+ * ownership is _not_ passed to the server, and it is required the structure
+ * lives at least as long as the server.
+ *
+ * All the handlers get the structure as their first parameter. This can be
+ * used to pass additional data using the "C-style inheritance" pattern (well,
+ * C++ inheritance would work  too). Note that the requests share the structure
+ * and therefore this is not the right place for per-request scratch pad.
+ *
+ * The real application can use the `default_http_handlers` for the server.
+ */
+
+struct HttpHandlers;
+
+/**
+ * Function to handle a get request.
+ *
+ * For now we assume there are no parameters to the get requests and the
+ * response depends only on the state of the printer.
+ *
+ * Furthermore, we assume the buffer will be large enough to encompass the
+ * response; if not, the data shall be truncated. This is wrong, and we need
+ * some way to stream large data without putting it all into RAM, but that's
+ * going to happen in the future.
+ */
+typedef void get_handler(struct HttpHandlers *self, char *buffer, size_t buffer_size);
+
+/**
+ * Function to return current API key.
+ *
+ * In case it returns NULL, no authentication is possible and all access is denied.
+ */
+typedef const char *get_api_key();
+
+/**
+ * Descriptor of single GET endpoint.
+ */
+struct GetDescriptor {
+    /// The URI this handles, eg. `/api/whatever`.
+    const char *uri;
+    /// The function to call.
+    get_handler *handler;
+    /// If set to true, authentication won't be checked for this request.
+    bool anonymous : 1;
+    /**
+     * Do prefix match on the passed-in uri, not exact match.
+     *
+     * If set to true, the handler will also match URLs that have some suffix.
+     * Eg. the `/api/whatever` handler will also handle `/api/whateverelse` or
+     * `/api/whatever/something`.
+     */
+    bool prefix : 1;
+};
+
+struct HttpHandlers {
+    /**
+     * An array of GET handlers.
+     *
+     * Terminated by a sentinel ‒ single element with uri & handler set to NULL.
+     *
+     * The first one matching will be used. Therefore, it is possible to do
+     * more exact matches first and than fall back to more generic things.
+     */
+    const struct GetDescriptor *gets;
+
+    get_api_key *api_key;
+};
+
+/**
+ * The default handlers that can be used for the real application.
+ *
+ * Tests may use their own mock set. Also note that the implementation lives in
+ * a different file (handler_defaults.c).
+ */
+extern struct HttpHandlers default_http_handlers;
+
+// TODO: Eventually turn this thing into C++, so they live "inside" the HttpHandlers.
+
+/**
+ * Look up the corresponding GET handler.
+ *
+ * Returns NULL in case it's not available.
+ */
+const struct GetDescriptor *http_handlers_find_get(const struct HttpHandlers *self, const char *uri);

--- a/lib/WUI/http/handler.h
+++ b/lib/WUI/http/handler.h
@@ -116,14 +116,6 @@ struct HttpHandlers {
     gcode_handler_finish *gcode_finish;
 };
 
-/**
- * The default handlers that can be used for the real application.
- *
- * Tests may use their own mock set. Also note that the implementation lives in
- * a different file (handler_defaults.c).
- */
-extern struct HttpHandlers default_http_handlers;
-
 // TODO: Eventually turn this thing into C++, so they live "inside" the HttpHandlers.
 
 /**

--- a/lib/WUI/http/handler.h
+++ b/lib/WUI/http/handler.h
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include <lwip/altcp.h>
+
 /*
  * The http handlers.
  *
@@ -79,6 +81,15 @@ struct HttpHandlers {
     const struct GetDescriptor *gets;
 
     get_api_key *api_key;
+
+    /**
+     * Allocator used for getting the listening socket.
+     *
+     * This ties us into specific server implementation for now. This hopefully
+     * will go away once we have proper socket abstraction and a proper HTTP
+     * server.
+     */
+    altcp_allocator_t listener_alloc;
 };
 
 /**

--- a/lib/WUI/http/handler_defaults.c
+++ b/lib/WUI/http/handler_defaults.c
@@ -1,0 +1,44 @@
+#include "handler.h"
+
+#include "../wui_REST_api.h"
+#include "../wui_api.h"
+
+// The get_* functions we use do exactly what we need, except they take fewer
+// params. Generate the wrappers to throw them out without too much
+// copy-pasting.
+#define GET_WRAPPER(NAME)                                                                       \
+    static void handler_##NAME(struct HttpHandlers *unused, char *buffer, size_t buffer_size) { \
+        (void)unused;                                                                           \
+        NAME(buffer, buffer_size);                                                              \
+    }
+GET_WRAPPER(get_printer);
+GET_WRAPPER(get_version);
+GET_WRAPPER(get_job);
+GET_WRAPPER(get_files);
+#undef GET_WRAPPER
+
+static const struct GetDescriptor get_handlers[] = {
+    {
+        .uri = "/api/printer",
+        .handler = handler_get_printer,
+    },
+    {
+        .uri = "/api/version",
+        .handler = handler_get_version,
+    },
+    {
+        .uri = "/api/job",
+        .handler = handler_get_job,
+    },
+    {
+        .uri = "/api/files",
+        .handler = handler_get_files,
+        .prefix = true, // Any uri starting with /api/files is fine (for now).
+    },
+    {}, // Sentinel
+};
+
+struct HttpHandlers default_http_handlers = {
+    .gets = get_handlers,
+    .api_key = wui_get_api_key,
+};

--- a/lib/WUI/http/handler_defaults.c
+++ b/lib/WUI/http/handler_defaults.c
@@ -4,9 +4,6 @@
 #include "../wui_api.h"
 #include "../wui.h"
 
-// The get_* functions we use do exactly what we need, except they take fewer
-// params. Generate the wrappers to throw them out without too much
-// copy-pasting.
 #define GET_WRAPPER(NAME)                                                                       \
     static void handler_##NAME(struct HttpHandlers *unused, char *buffer, size_t buffer_size) { \
         (void)unused;                                                                           \
@@ -17,6 +14,18 @@ GET_WRAPPER(get_version);
 GET_WRAPPER(get_job);
 GET_WRAPPER(get_files);
 #undef GET_WRAPPER
+
+static uint32_t post_start(struct HttpHandlers *unused, const char *filename) {
+    return wui_upload_begin(filename);
+}
+
+static uint32_t post_data(struct HttpHandlers *unused, const char *data, size_t len) {
+    return wui_upload_data(data, len);
+}
+
+static uint32_t post_finish(struct HttpHandlers *unused, const char *tmp_filename, const char *final_filename, bool start) {
+    return wui_upload_finish(tmp_filename, final_filename, start);
+}
 
 static const struct GetDescriptor get_handlers[] = {
     {
@@ -44,5 +53,8 @@ struct HttpHandlers default_http_handlers = {
     .api_key = wui_get_api_key,
     .listener_alloc = {
         .alloc = prusa_alloc,
-    }
+    },
+    .gcode_start = post_start,
+    .gcode_data = post_data,
+    .gcode_finish = post_finish,
 };

--- a/lib/WUI/http/handler_defaults.c
+++ b/lib/WUI/http/handler_defaults.c
@@ -2,6 +2,7 @@
 
 #include "../wui_REST_api.h"
 #include "../wui_api.h"
+#include "../wui.h"
 
 // The get_* functions we use do exactly what we need, except they take fewer
 // params. Generate the wrappers to throw them out without too much
@@ -41,4 +42,7 @@ static const struct GetDescriptor get_handlers[] = {
 struct HttpHandlers default_http_handlers = {
     .gets = get_handlers,
     .api_key = wui_get_api_key,
+    .listener_alloc = {
+        .alloc = prusa_alloc,
+    }
 };

--- a/lib/WUI/http/httpd.c
+++ b/lib/WUI/http/httpd.c
@@ -2712,4 +2712,9 @@ process_file:
     return http_init_file(hs, file, is_09, uri, 0, NULL);
 }
 
+struct HttpHandlers *extract_http_handlers(void *connection) {
+    struct http_state *state = connection;
+    return state->handlers;
+}
+
 #endif /* LWIP_TCP && LWIP_CALLBACK_API */

--- a/lib/WUI/http/httpd.h
+++ b/lib/WUI/http/httpd.h
@@ -42,9 +42,11 @@
 #define LWIP_HDR_APPS_HTTPD_H
 
 #include "httpd_opts.h"
-#include "lwip/err.h"
-#include "lwip/pbuf.h"
-#include "stdbool.h"
+#include "handler.h"
+
+#include <lwip/err.h>
+#include <lwip/pbuf.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -283,7 +285,7 @@ void httpd_post_data_recved(void *connection, u16_t recved_len);
  *
  * For further re-binds/re-initializations, see @c httpd_reinit.
  */
-void httpd_init(void);
+void httpd_init(struct HttpHandlers *handlers);
 /**
  * Re-create the httpd listening socket, with current network settings.
  *
@@ -294,7 +296,7 @@ void httpd_init(void);
  *
  * Thread safe.
  */
-void httpd_reinit(void);
+void httpd_reinit(struct HttpHandlers *handlers);
 
 /**
  * Stop listening with the httpd server.
@@ -315,10 +317,11 @@ void httpd_inits(struct altcp_tls_config *conf);
  *
  * Currently it checks if the HTTP request contains the right X-Api-Key header.
  *
+ * @param handlers The http handlers defining the content (and how to get the API key in this case).
  * @param req The request, in form of the pbuf.
  * @return If it is allowed to proceed.
  */
-bool authorize_request(const struct pbuf *req);
+bool authorize_request(const struct HttpHandlers *handlers, const struct pbuf *req);
 
 #ifdef __cplusplus
 }

--- a/lib/WUI/http/httpd.h
+++ b/lib/WUI/http/httpd.h
@@ -323,6 +323,18 @@ void httpd_inits(struct altcp_tls_config *conf);
  */
 bool authorize_request(const struct HttpHandlers *handlers, const struct pbuf *req);
 
+/**
+ * Extract the relevant handlers out of a POST connection.
+ *
+ * The connection parameter passed to the post "callbacks" is opaque. We don't
+ * want to share the internals, but we provide this function to extract the
+ * associated HttpHandlers structure.
+ *
+ * This may be used only inside the `httpd_post_*` callbacks, on the provided
+ * connection parameter.
+ */
+struct HttpHandlers *extract_http_handlers(void *connection);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/WUI/http/httpd_post.c
+++ b/lib/WUI/http/httpd_post.c
@@ -206,7 +206,8 @@ static bool authenticate_post(const char *http_request, uint16_t http_request_le
         .len = http_request_len,
         .tot_len = http_request_len,
     };
-    return authorize_request(&buf);
+    // XXX: Pass this through
+    return authorize_request(&default_http_handlers, &buf);
     // No need to free anything related to the buf.
 }
 

--- a/lib/WUI/http_handler_default.c
+++ b/lib/WUI/http_handler_default.c
@@ -1,8 +1,7 @@
-#include "handler.h"
-
-#include "../wui_REST_api.h"
-#include "../wui_api.h"
-#include "../wui.h"
+#include "http_handler_default.h"
+#include "wui_REST_api.h"
+#include "wui_api.h"
+#include "wui.h"
 
 #define GET_WRAPPER(NAME)                                                                       \
     static void handler_##NAME(struct HttpHandlers *unused, char *buffer, size_t buffer_size) { \

--- a/lib/WUI/http_handler_default.h
+++ b/lib/WUI/http_handler_default.h
@@ -1,0 +1,8 @@
+#include "http/handler.h"
+
+/**
+ * The default handlers that can be used for the real application.
+ *
+ * Tests may use their own mock set.
+ */
+extern struct HttpHandlers default_http_handlers;

--- a/lib/WUI/wui.c
+++ b/lib/WUI/wui.c
@@ -84,7 +84,7 @@ void StartWebServerTask(void const *argument) {
     }
 
     if (variant8_get_ui8(eeprom_get_var(EEVAR_PL_RUN)) == 1) {
-        httpd_init();
+        httpd_init(&default_http_handlers);
     }
 
     for (;;) {

--- a/lib/WUI/wui.c
+++ b/lib/WUI/wui.c
@@ -22,7 +22,8 @@
 #include <lwip/tcp.h>
 #include <lwip/altcp_tcp.h>
 #include "esp_tcp.h"
-#include "httpd.h"
+#include "http/httpd.h"
+#include "http_handler_default.h"
 #include "main.h"
 
 #include "netdev.h"

--- a/src/gui/screen_menu_esp_update.cpp
+++ b/src/gui/screen_menu_esp_update.cpp
@@ -214,7 +214,7 @@ void ScreenMenuESPUpdate::windowEvent(EventLock /*has private ctor*/, window_t *
             esp_loader_flash_finish(true);
             esp_set_operating_mode(ESP_RUNNING_MODE);
             netdev_init_esp();
-            httpd_reinit();
+            httpd_reinit(&default_http_handlers);
             progress_state = esp_upload_action::Initial;
             current_file = firmware_set.begin();
             readCount = 0;

--- a/src/gui/screen_menu_esp_update.cpp
+++ b/src/gui/screen_menu_esp_update.cpp
@@ -13,11 +13,12 @@ extern "C" {
 #include "dbg.h"
 #include "ff.h"
 
-#include "stm32_port.h"
-#include "esp_loader.h"
-#include "lwesp_ll_buddy.h"
-#include "netdev.h"
-#include "httpd.h"
+#include <stm32_port.h>
+#include <esp_loader.h>
+#include <lwesp_ll_buddy.h>
+#include <netdev.h>
+#include <http/httpd.h>
+#include <http_handler_default.h>
 
 #ifdef __cplusplus
 }

--- a/src/gui/screen_menu_lan_settings.cpp
+++ b/src/gui/screen_menu_lan_settings.cpp
@@ -13,7 +13,8 @@
 #include "RAII.hpp"
 #include "i18n.h"
 #include "ScreenHandler.hpp"
-#include <httpd.h>
+#include <http/httpd.h>
+#include <http_handler_default.h>
 
 /*****************************************************************************/
 class MI_NET_INTERFACE_t : public WI_SWITCH_t<3> {

--- a/src/gui/screen_menu_lan_settings.cpp
+++ b/src/gui/screen_menu_lan_settings.cpp
@@ -169,7 +169,7 @@ void ScreenMenuLanSettings::windowEvent(EventLock /*has private ctor*/, window_t
             netdev_set_down(netdev_get_active_id());
             netdev_set_active_id(action);
             netdev_set_up(action);
-            httpd_reinit();
+            httpd_reinit(&default_http_handlers);
             break;
         case MI_NET_IP_t::EventMask::value:
             httpd_close();
@@ -178,7 +178,7 @@ void ScreenMenuLanSettings::windowEvent(EventLock /*has private ctor*/, window_t
             } else {
                 netdev_set_dhcp(netdev_get_active_id());
             }
-            httpd_reinit();
+            httpd_reinit(&default_http_handlers);
             break;
         default:
             break;


### PR DESCRIPTION
This splits the httpd related handling into the http parts and content related parts.

The primary intention is to unblock unit & fuzz tests on the http part (which is exposed to the outside without authentication). It also draws the boundary between parts in somewhat thicker line and will make our life a little bit easier once we start replacing the HTTP server itself… but the boundary is probably in a suboptimal place and will eventually move ‒ this is what the code was doing now and I didn't want to introduce big or functional changes. In other words, this is supposed to be gradual improvement but is far from the ideal.