### PR TITLE
One click upload

### DIFF
--- a/lib/WUI/wui_api.c
+++ b/lib/WUI/wui_api.c
@@ -22,6 +22,7 @@
 #include <time.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdatomic.h>
 
 #define USB_MOUNT_POINT        "/usb/"
 #define USB_MOUNT_POINT_LENGTH 5
@@ -35,6 +36,7 @@ static FILE *upload_file = NULL;
 static char tmp_filename[FILE_NAME_MAX_LEN];
 static bool sntp_time_init = false;
 static char wui_media_LFN[FILE_NAME_MAX_LEN + 1]; // static buffer for gcode file name
+static atomic_int_least32_t uploaded_gcodes;
 
 void wui_marlin_client_init(void) {
     marlin_vars_t *vars = marlin_client_init(); // init the client
@@ -404,6 +406,9 @@ uint32_t wui_upload_finish(const char *old_filename, const char *new_filename, u
         goto clean_temp_file;
     }
 
+    // We have it in place, success!
+    uploaded_gcodes++;
+
     if (marlin_vars()->sd_printing && start) {
         error_code = 409;
         goto return_error_code;
@@ -420,4 +425,8 @@ clean_temp_file:
     remove(tmp_filename);
 return_error_code:
     return error_code;
+}
+
+uint32_t wui_gcodes_uploaded() {
+    return uploaded_gcodes;
 }

--- a/lib/WUI/wui_api.c
+++ b/lib/WUI/wui_api.c
@@ -370,6 +370,15 @@ uint32_t wui_upload_data(const char *data, uint32_t length) {
 }
 
 uint32_t wui_upload_finish(const char *old_filename, const char *new_filename, uint32_t start) {
+    /*
+     * TODO: Starting print of the just-uploaded file is temporarily disabled.
+     *
+     * See https://dev.prusa3d.com/browse/BFW-2300.
+     *
+     * Once we have time to deal with all the corner-cases, race conditions and
+     * collisions caused by that possibility, we will re-enable.
+     */
+    start = 0;
     uint32_t fname_length = strlen(new_filename);
     uint32_t error_code = 200;
     int result = 0;

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -205,6 +205,15 @@ uint32_t wui_upload_data(const char *, uint32_t);
 uint32_t wui_upload_finish(const char *, const char *, uint32_t);
 
 ////////////////////////////////////////////////////////////////////////////
+/// @brief Return the number of gcodes uploaded since boot.
+///
+/// May be used to check if a file was uploaded since last check.
+/// Guaranteed to start at 0, but may wrap around (unlikely).
+///
+/// Thread safe.
+uint32_t wui_gcodes_uploaded();
+
+////////////////////////////////////////////////////////////////////////////
 /// @brief initialize marlin client for tcpip thread
 ///
 void wui_marlin_client_init(void);

--- a/src/gui/screen_home.hpp
+++ b/src/gui/screen_home.hpp
@@ -7,6 +7,7 @@
 
 struct screen_home_data_t : public AddSuperWindow<screen_t> {
     static bool usbWasAlreadyInserted; // usb inserted at least once
+    static uint32_t lastUploadCount;
     bool usbInserted;
 
     window_header_t header;
@@ -29,4 +30,5 @@ private:
 
     void printBtnEna();
     void printBtnDis();
+    bool moreGcodesUploaded();
 };


### PR DESCRIPTION
Disabling the start-after-upload feature temporarily, replacing by showing a one-click-print dialog (the latter is not temporary), as agreed.

The dialog appears, but usually shows the wrong file. This is caused by not setting the date/time of the new file correctly. I've tried @dragomirecky 's patch for teaching fatfs to set it correctly, but it doesn't seem to work for me:

* Only one of the three times (ctime, mtime, atime) is set, the rest is still at 1.1. 1980.
* The one that _is_ set is set to 1.1.2098.

Which doesn't actually fix the right-file-to-show problem anyway. I'm leaving investigation of that part for another task.

BFW-2300

