### PR TITLE
BFW-2302: Stubs to make the PrusaLink "work"

### DIFF
--- a/lib/WUI/http/handler.h
+++ b/lib/WUI/http/handler.h
@@ -39,8 +39,10 @@ struct HttpHandlers;
  * response; if not, the data shall be truncated. This is wrong, and we need
  * some way to stream large data without putting it all into RAM, but that's
  * going to happen in the future.
+ *
+ * @return Numeric HTTP status code (eg. 200).
  */
-typedef void get_handler(struct HttpHandlers *self, char *buffer, size_t buffer_size);
+typedef uint16_t get_handler(struct HttpHandlers *self, char *buffer, size_t buffer_size);
 
 /**
  * Handlers of the GCODE upload.

--- a/lib/WUI/http/httpd_structs.h
+++ b/lib/WUI/http/httpd_structs.h
@@ -33,7 +33,8 @@ static const char *const g_psHTTPHeaderStrings[] = {
     "HTTP/1.0 304 Not Modified\r\n",
     "HTTP/1.0 409 Conflict\r\n",
     "HTTP/1.0 415 Unsupported Media Type\r\n",
-    "HTTP/1.0 503 Service Temporarily Unavailable\r\n"
+    "HTTP/1.0 503 Service Temporarily Unavailable\r\n",
+    "HTTP/1.0 204 No Content\r\n"
     #if LWIP_HTTPD_SUPPORT_11_KEEPALIVE
     ,
     "Connection: keep-alive\r\nContent-Length: 77\r\n\r\n<html><body><h2>404: The requested file cannot be found.</h2></body></html>\r\n"
@@ -62,8 +63,9 @@ static const char *const g_psHTTPHeaderStrings[] = {
     #define HTTP_HDR_409            17 /* 409 Conflict */
     #define HTTP_HDR_415            18 /* 415 Unsupported Media Type */
     #define HTTP_HDR_503            19 /* 503 Service Temporarily Unavailable */
+    #define HTTP_HDR_NO_CONTENT     20 /* 204 No Content */
     #if LWIP_HTTPD_SUPPORT_11_KEEPALIVE
-        #define DEFAULT_404_HTML_PERSISTENT 20 /* default 404 body, but including Connection: keep-alive */
+        #define DEFAULT_404_HTML_PERSISTENT 21 /* default 404 body, but including Connection: keep-alive */
     #endif
 
     #define HTTP_CONTENT_TYPE(contenttype)                    "Content-Type: " contenttype "\r\n\r\n"

--- a/lib/WUI/wui_REST_api.c
+++ b/lib/WUI/wui_REST_api.c
@@ -80,22 +80,21 @@ void get_printer(char *data, const uint32_t buf_len) {
     snprintf(data, buf_len,
         "{"
         "\"telemetry\": {"
+        "\"temp-bed\": %.1f,"
+        "\"temp-nozzle\": %.1f,"
+        "\"print-speed\": %d,"
+        "\"z-height\": %.1f,"
         "\"material\": \"%s\""
         "},"
         "\"temperature\": {"
         "\"tool0\": {"
-        "\"actual\": %d.%.1d,"
-        "\"target\": 0,"
+        "\"actual\": %.1f,"
+        "\"target\": %.1f,"
         "\"offset\": 0"
         "},"
         "\"bed\": {"
-        "\"actual\": %d.%.1d,"
-        "\"target\": 0,"
-        "\"offset\": 0"
-        "},"
-        "\"chamber\": {"
-        "\"actual\": 0,"
-        "\"target\": 0,"
+        "\"actual\": %.1f,"
+        "\"target\": %.1f,"
         "\"offset\": 0"
         "}"
         "},"
@@ -118,9 +117,19 @@ void get_printer(char *data, const uint32_t buf_len) {
         "}"
         "}"
         "}",
+        (double)vars->temp_bed,
+        (double)vars->temp_nozzle,
+        (int)vars->print_speed,
+        (double)vars->pos[2], // XYZE, mm
         filament_material,
-        (int)vars->temp_nozzle, (int)(vars->temp_nozzle * 10) % 10,
-        (int)vars->temp_bed, (int)(vars->temp_bed * 10) % 10,
+        (double)vars->temp_nozzle,
+        // Sometimes, the GUI lies about the target temperature (eg. when
+        // preheating). Let's keep the company and lie too..
+        (double)vars->display_nozzle,
+        (double)vars->temp_bed,
+        (double)vars->target_bed,
+
+        // TODO: Format as bools to be according to the spec
         operational, paused, printing, cancelling, pausing, sd_ready,
         error, ready, closed_on_error, busy);
 }
@@ -178,14 +187,25 @@ void get_job(char *data, const uint32_t buf_len) {
 
 void get_files(char *data, const uint32_t buf_len) {
 
+    /*
+     * Warning: This is a hack/stub.
+     *
+     * * This is being used both to answer /api/files _and_ as the content of the post GCODE.
+     * * We don't have a way to stream the body (eg. generate on the fly as we
+     *   are iterating through the files on the flash drive).
+     * * This is missing a lot of fields in the files.
+     *
+     * This probably depends on first getting an actual HTTP server.
+     */
+
     snprintf(data, buf_len,
         "{"
-        "\"files\": {"
+        "\"files\": [{"
         "\"local\": {"
         "\"name\": \"%s\","
-        "\"origin\": \"local\","
+        "\"origin\": \"local\""
         "}"
-        "},"
+        "}],"
         "\"done\": %d"
         "}",
         filename, (int)!start_print);


### PR DESCRIPTION
The current PrusaLink page is asking about bunch of stuff. To avoid
getting all the "404 Not Found" pop-ups, add few stub API
implementations for now.

Also, some more related cleanups of the API implementation, fixes of JSON to be actually JSON or to correspond to the spec… this is not exhaustive.

This is related to #1722.

I did get a promise from Ilka Kartašov to tweak the web page as we need, but I've tried to go and see what can be done on our side. This brings the new PrusaLink implementation into much more usable state.

But I'm not sure how many "stubs" do we have here.