### PR TITLE
BFW-2295: Restore ESP factory defaults at startup

### DIFF
--- a/include/esp/esp_config.h
+++ b/include/esp/esp_config.h
@@ -93,7 +93,7 @@
 
 #define ESP_CFG_INPUT_USE_PROCESS       1
 #define ESP_CFG_RESET_ON_INIT           1
-#define ESP_CFG_RESTORE_ON_INIT         0
+#define ESP_CFG_RESTORE_ON_INIT         1
 #define ESP_CFG_MAX_SSID_LENGTH         32
 #define ESP_CFG_NETCONN                 1
 #define ESP_ALTCP                       1


### PR DESCRIPTION
This prevents ESP from retaining potentially stale network configuration between restarts and power cycles.