### PR TITLE
Remove shell scripts

### DIFF
--- a/utils/openocd_flash.sh
+++ b/utils/openocd_flash.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-openocd --file utils/cproject/Buddy-Debug-OpenOCD.cfg --command "program build/mini_debug_noboot/firmware verify reset"

--- a/utils/openocd_swo.sh
+++ b/utils/openocd_swo.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-openocd --file utils/cproject/A3ides-SWO-OpenOCD.cfg -c "tpiu config internal /dev/stdout uart off 168000000 1680000; init"


### PR DESCRIPTION
Don't know why those scripts appeared here, but I don't think there is a reason to keep them around.

We don't want any shell scripts. Shell would be a new dependency introduced to the project. All our scripts are intentionally written in Python.