### PR TITLE
Fix --generate-bbf flag not being properly propagated to IDEs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     - id: generate-cmake-presets
       name: generate-cmake-presets
       description: This hook generates CMakePresets.json file based on utils/presets/presets.json
-      entry: python utils/build.py --generate-cmake-presets
+      entry: python utils/build.py --generate-cmake-presets --generate-bbf
       files: (.*.json)
       pass_filenames: false
       language: python

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,8 +32,8 @@
                     "value": "YES"
                 },
                 "GENERATE_BBF": {
-                    "type": "STRING",
-                    "value": "FALSE"
+                    "type": "BOOL",
+                    "value": "TRUE"
                 },
                 "GENERATE_DFU": {
                     "type": "BOOL",
@@ -87,7 +87,7 @@
                     "value": "NO"
                 },
                 "GENERATE_BBF": {
-                    "type": "STRING",
+                    "type": "BOOL",
                     "value": "FALSE"
                 },
                 "GENERATE_DFU": {
@@ -142,8 +142,8 @@
                     "value": "YES"
                 },
                 "GENERATE_BBF": {
-                    "type": "STRING",
-                    "value": "FALSE"
+                    "type": "BOOL",
+                    "value": "TRUE"
                 },
                 "GENERATE_DFU": {
                     "type": "BOOL",
@@ -197,7 +197,7 @@
                     "value": "NO"
                 },
                 "GENERATE_BBF": {
-                    "type": "STRING",
+                    "type": "BOOL",
                     "value": "FALSE"
                 },
                 "GENERATE_DFU": {

--- a/utils/build.py
+++ b/utils/build.py
@@ -149,7 +149,7 @@ class FirmwareBuildConfiguration(BuildConfiguration):
             __file__).resolve().parent.parent / 'cmake/GccArmNoneEabi.cmake'
 
     def get_cmake_cache_entries(self):
-        if self.generate_bbf and self.bootloader == Bootloader.EMPTY:
+        if self.generate_bbf and self.bootloader != Bootloader.NO:
             generate_bbf = True
             signing_key_flg = self.signing_key.resolve(
             ) if self.signing_key else ''
@@ -177,7 +177,7 @@ class FirmwareBuildConfiguration(BuildConfiguration):
         # set general entries
         entries.extend([
             ('BOOTLOADER', 'STRING', self.bootloader.value.upper()),
-            ('GENERATE_BBF', 'STRING', str(generate_bbf).upper()),
+            ('GENERATE_BBF', 'BOOL', str(generate_bbf).upper()),
             ('GENERATE_DFU', 'BOOL', 'ON' if self.generate_dfu else 'OFF'),
             ('SIGNING_KEY', 'FILEPATH', str(signing_key_flg)),
             ('CMAKE_TOOLCHAIN_FILE', 'FILEPATH', str(self.toolchain)),


### PR DESCRIPTION
Fixes an issue where *boot* configurations built from an IDE did not generate BBF files.