### PR TITLE
Add support for AUTO.GCO

### DIFF
--- a/src/common/appmain.cpp
+++ b/src/common/appmain.cpp
@@ -12,6 +12,7 @@
 #include "hwio.h"
 #include "sys.h"
 #include "gpio.h"
+#include "print_utils.hpp"
 #include "sound.hpp"
 #include "language_eeprom.hpp"
 #include "usbd_cdc_if.h"
@@ -87,6 +88,7 @@ void app_idle(void) {
     Buddy::Metrics::RecordMarlinVariables();
     Buddy::Metrics::RecordRuntimeStats();
     Buddy::Metrics::RecordPrintFilename();
+    print_utils_loop();
     osDelay(0); // switch to other threads - without this is UI slow during printing
 }
 

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -448,6 +448,13 @@ void marlin_server_test_abort(void) {
     }
 }
 
+bool marlin_server_printer_idle() {
+    return marlin_server.print_state == mpsIdle
+        || marlin_server.print_state == mpsPaused
+        || marlin_server.print_state == mpsAborted
+        || marlin_server.print_state == mpsFinished;
+}
+
 void marlin_server_print_start(const char *filename) {
     if (Selftest.IsInProgress())
         return;

--- a/src/common/marlin_server.h
+++ b/src/common/marlin_server.h
@@ -70,6 +70,9 @@ extern void marlin_server_manage_heater(void);
 // direct call of planner.quick_stop()
 extern void marlin_server_quick_stop(void);
 
+// direct print file with SFM format
+void marlin_server_print_start(const char *filename);
+
 //
 extern uint32_t marlin_server_get_command(void);
 
@@ -96,6 +99,9 @@ extern void marlin_server_print_reheat_start(void);
 
 //
 extern int marlin_server_print_reheat_ready(void);
+
+// return true if the printer is not moving (idle, paused, aborted or finished)
+extern bool marlin_server_printer_idle();
 
 //
 extern void marlin_server_park_head(void);

--- a/src/common/print_utils.cpp
+++ b/src/common/print_utils.cpp
@@ -1,9 +1,45 @@
 #include "print_utils.hpp"
 #include <stdint.h>
 #include "../Marlin/src/gcode/lcd/M73_PE.h"
+#include "../lib/Marlin/Marlin/src/module/temperature.h"
 #include "marlin_client.h"
+#include "media.h"
 #include "timing.h"
+#include "marlin_server.hpp"
 #include "guiconfig.h" // GUI_WINDOW_SUPPORT
+#include "unistd.h"
+
+#if AUTOSTART_GCODE
+static const char *autostart_filename = "/usb/AUTO.GCO";
+#endif
+static bool run_once_done = false;
+static uint32_t current_time = 0;
+static uint32_t rescan_delay = 1500;
+static uint32_t max_rescan_time = 10000;
+
+void run_once_after_boot() {
+    // g-code autostart
+#if AUTOSTART_GCODE
+    if (access(autostart_filename, F_OK) == 0) {
+        //call directly marlin server start print. This function is not safe
+        marlin_server_print_start(autostart_filename);
+        oProgressData.mInit();
+    }
+#endif
+}
+
+void print_utils_loop() {
+    if (run_once_done == false && HAL_GetTick() >= current_time + rescan_delay) {
+        current_time += rescan_delay;
+        if (media_get_state() == media_state_INSERTED) {
+            run_once_done = true;
+            run_once_after_boot();
+        } else if (current_time > max_rescan_time || !marlin_server_printer_idle()) {
+            // no longer attempt to run the autostart sequence
+            run_once_done = true;
+        }
+    }
+}
 
 #ifdef GUI_WINDOW_SUPPORT
     #include "ScreenHandler.hpp"

--- a/src/common/print_utils.hpp
+++ b/src/common/print_utils.hpp
@@ -9,6 +9,8 @@ extern "C" {
 /// Opens print screen (and closes all others) if GUI_WINDOW_SUPPORT is defined
 void print_begin(const char *filename);
 
+// Called once after each marlin server loop
+void print_utils_loop();
 #ifdef __cplusplus
 }
 #endif // __cplusplus


### PR DESCRIPTION
Disabled by default. Can be enabled using `-DAUTOSTART_GCODE=1`.