### PR TITLE
Fix Z_probe_interrupt_handler calls itself.

### DIFF
--- a/src/common/Z_probe.cpp
+++ b/src/common/Z_probe.cpp
@@ -4,7 +4,6 @@
  * @author Marek Bel
  */
 #include "Z_probe.hpp"
-#include "../lib/Marlin/Marlin/src/module/endstops.h"
 #include "hwio_pindef.h"
 
 static volatile uint32_t minda_falling_edges = 0;
@@ -23,6 +22,4 @@ void buddy::hw::Z_probe_interrupt_handler() {
     }
 
     previousState = currentState;
-
-    endstops.poll();
 }


### PR DESCRIPTION
Z_probe_interrupt_handler is called from endstops.update()
so it can not call endstops.poll() which calls endstops.update().
This would lead to infinite loop and stack overflow.