### PR TITLE
BFW-2295: Silence runtime warning about unknown ESP event.

### DIFF
--- a/lib/WUI/netdev.c
+++ b/lib/WUI/netdev.c
@@ -158,6 +158,10 @@ esp_callback_func(esp_evt_t *evt) {
         _dbg("ESP_EVT_RESET");
         break;
     }
+    case ESP_EVT_RESTORE: {
+        _dbg("ESP_EVT_RESTORE");
+        break;
+    }
     case ESP_EVT_RESET_DETECTED: {
         esp_reconfigure_uart(ESP_CFG_AT_PORT_BAUDRATE);
         _dbg("ESP_EVT_RESET_DETECTED");


### PR DESCRIPTION
PR #1729 made the FW to restore ESP configuration to the factory defaults using "AT+RESTORE" command. The command triggers ESP_EVT_RESTORE which in turn triggers scary debug warning about unknown/unhadled event. This adds a dummy handler to silence the warning.