### PR TITLE
Increase build nr one higher to distinguish 4.3.4-final from RC

### DIFF
--- a/src/common/appmain.cpp
+++ b/src/common/appmain.cpp
@@ -95,6 +95,7 @@ void app_idle(void) {
     Buddy::Metrics::RecordPrintFilename();
     osDelay(0); // switch to other threads - without this is UI slow during printing
 }
+// a dummy comment just to bump the build nr. one higher to avoid user confusion
 
 void app_run(void) {
     DBG("app_run");


### PR DESCRIPTION
This is just a dummy PR to avoid user confusion if 4.3.4 final and RC had the same build number (has happened before with 4.3.2 and some of the users were really confused).