### PR TITLE
BFW-2375: PrusaLink: Consume chained packets

### DIFF
--- a/lib/WUI/http/httpd_post.c
+++ b/lib/WUI/http/httpd_post.c
@@ -321,9 +321,15 @@ err_t httpd_post_receive_data(void *connection, struct pbuf *p) {
     char *data;
     err_t ret_val = ERR_ARG;
 
-    if (connection != NULL && p != NULL) {
-        data = p->payload;
+    struct pbuf *current = p;
+
+    while (connection != NULL && current != NULL) {
+        data = current->payload;
         ret_val = http_parse_post(data, p->len);
+        current = current->next;
+        if (ret_val != ERR_OK) {
+            break;
+        }
     }
 
     if (p != NULL) {


### PR DESCRIPTION
Note: Verified manually. Before this fix, the upload was corrupted 9 times out of 10, after it it is correct 5 times out of 5.

In the code to upload data to PrusaLink, consume the whole chain of
pbufs, not just the first one.

Pbufs can be chained into a linked list. This is used very rarely, but
can happen in certain cornercases ‒ like when packets of TCP connection
come out of order, when the missing is finally acquired, the whole
accumulated bunch is submitted to user code at once as a single linked
list.

Previously, if this happened, the "tail" of the linked list would be
lost, corrupting the uploaded GCODE (in a way that's possible to go
unnoticed).