### PR TITLE
Upload state

### DIFF
--- a/lib/WUI/CMakeLists.txt
+++ b/lib/WUI/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
             http/httpd.c
             http/httpd_post.c
             http/multipart_parser.c
+            http/upload_state.cpp
             ethernetif.c
             sntp/sntp_client.c
             sntp/sntp.c

--- a/lib/WUI/http/handler.h
+++ b/lib/WUI/http/handler.h
@@ -56,13 +56,15 @@ typedef uint16_t get_handler(struct HttpHandlers *self, char *buffer, size_t buf
  *   replacement of the HTTP server implementation.
  * * The API does _not_ currently support multiple parallel uploads. The HTTP
  *   server currently refuses attempts to do so.
- * * The return values are a bit unclear. Current code's implementation and
- *   documentation doesn't match. Research or replacement is needed.
+ * * Return HTTP error codes for error and 0 for success.
+ * * The finish may be called without a filename (final_filename = NULL) as an
+ *   indication of an aborted upload. The data did not finish and shall not be
+ *   stored.
  */
-typedef uint32_t gcode_handler_start(struct HttpHandlers *self, const char *filename);
+typedef uint16_t gcode_handler_start(struct HttpHandlers *self, const char *filename);
 // FIXME: const char *data is probably wrong, it should be const uint8_t * as arbitrary data; but everything around rigth now uses char :-(
-typedef uint32_t gcode_handler_data(struct HttpHandlers *self, const char *data, size_t len);
-typedef uint32_t gcode_handler_finish(struct HttpHandlers *self, const char *tmp_filename, const char *final_filename, bool start_print);
+typedef uint16_t gcode_handler_data(struct HttpHandlers *self, const char *data, size_t len);
+typedef uint16_t gcode_handler_finish(struct HttpHandlers *self, const char *tmp_filename, const char *final_filename, bool start_print);
 
 /**
  * Function to return current API key.

--- a/lib/WUI/http/handler.h
+++ b/lib/WUI/http/handler.h
@@ -74,6 +74,17 @@ typedef uint16_t gcode_handler_finish(struct HttpHandlers *self, const char *tmp
 typedef const char *get_api_key();
 
 /**
+ * Function to look up a corresponding file/uri/handler page for given error
+ * code.
+ *
+ * This is a hack, as the current http server has very weird handling of error
+ * codes.
+ *
+ * The result needs to point to static memory (not get deallocated).
+ */
+typedef const char *code_to_uri(struct HttpHandlers *self, uint16_t code);
+
+/**
  * Descriptor of single GET endpoint.
  */
 struct GetDescriptor {
@@ -118,6 +129,8 @@ struct HttpHandlers {
     gcode_handler_start *gcode_start;
     gcode_handler_data *gcode_data;
     gcode_handler_finish *gcode_finish;
+
+    code_to_uri *code_lookup;
 };
 
 // TODO: Eventually turn this thing into C++, so they live "inside" the HttpHandlers.

--- a/lib/WUI/http/httpd.h
+++ b/lib/WUI/http/httpd.h
@@ -265,13 +265,6 @@ void httpd_post_finished(void *connection, char *response_uri, u16_t response_ur
  */
 const char *find_boundary(const char *content_type);
 
-/** Find the key name in the header of a form value.
- * Looking for name=
- *
- * @param header Header string that contains the name.
- */
-const char *find_header_name(const char *header);
-
     #if LWIP_HTTPD_POST_MANUAL_WND
 void httpd_post_data_recved(void *connection, u16_t recved_len);
     #endif /* LWIP_HTTPD_POST_MANUAL_WND */

--- a/lib/WUI/http/httpd_structs.h
+++ b/lib/WUI/http/httpd_structs.h
@@ -34,7 +34,11 @@ static const char *const g_psHTTPHeaderStrings[] = {
     "HTTP/1.0 409 Conflict\r\n",
     "HTTP/1.0 415 Unsupported Media Type\r\n",
     "HTTP/1.0 503 Service Temporarily Unavailable\r\n",
-    "HTTP/1.0 204 No Content\r\n"
+    "HTTP/1.0 204 No Content\r\n",
+    "HTTP/1.0 418 I'm a Teapot Printer\r\n",
+    "HTTP/1.0 422 Unprocessable Entity\r\n",
+    "HTTP/1.0 431 Request Header Fields Too Large\r\n",
+    "HTTP/1.0 507 Insufficient Storage\r\n"
     #if LWIP_HTTPD_SUPPORT_11_KEEPALIVE
     ,
     "Connection: keep-alive\r\nContent-Length: 77\r\n\r\n<html><body><h2>404: The requested file cannot be found.</h2></body></html>\r\n"
@@ -64,8 +68,12 @@ static const char *const g_psHTTPHeaderStrings[] = {
     #define HTTP_HDR_415            18 /* 415 Unsupported Media Type */
     #define HTTP_HDR_503            19 /* 503 Service Temporarily Unavailable */
     #define HTTP_HDR_NO_CONTENT     20 /* 204 No Content */
+    #define HTTP_HDR_418            21 /* 418 I'm a Teapot */
+    #define HTTP_HDR_422            22 /* 422 Unprocessable Entity */
+    #define HTTP_HDR_431            23 /* 431 Request Header Fields Too Large */
+    #define HTTP_HDR_507            24 /* 431 Request Header Fields Too Large */
     #if LWIP_HTTPD_SUPPORT_11_KEEPALIVE
-        #define DEFAULT_404_HTML_PERSISTENT 21 /* default 404 body, but including Connection: keep-alive */
+        #define DEFAULT_404_HTML_PERSISTENT 25 /* default 404 body, but including Connection: keep-alive */
     #endif
 
     #define HTTP_CONTENT_TYPE(contenttype)                    "Content-Type: " contenttype "\r\n\r\n"

--- a/lib/WUI/http/multipart_parser.c
+++ b/lib/WUI/http/multipart_parser.c
@@ -174,6 +174,16 @@ size_t multipart_parser_execute(multipart_parser *p, const char *buf, size_t len
             }
 
             cl = tolower(c);
+            /*
+             * FIXME: This one is probably wrong. The multipart/form-data
+             * derives from multipart/ * content types from RFC1341. That one
+             * derives the individual bodies from the email RFC822 where in the
+             * 3.2 section the definition of header name is:
+             *
+             * field-name  =  1*<any CHAR, excluding CTLs, SPACE, and ":">
+             *
+             * But ignoring it for now...
+             */
             if ((c != '-') && (cl < 'a' || cl > 'z')) {
                 multipart_log("invalid character in header name");
                 return i;

--- a/lib/WUI/http/upload_state.cpp
+++ b/lib/WUI/http/upload_state.cpp
@@ -1,0 +1,445 @@
+#include "upload_state.h"
+#include "multipart_parser.h"
+
+#include <file_list_defs.h>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cctype>
+#include <cstring>
+#include <memory>
+#include <string_view>
+
+using std::array;
+using std::string_view;
+using std::unique_ptr;
+
+namespace {
+
+constexpr const char *const CDISP = "content-disposition:";
+constexpr const char *const HEADER_SEP = "=\"";
+constexpr const char *const NAME = "name";
+constexpr const char *const FILENAME = "filename";
+constexpr const char *const FILE = "file";
+constexpr const char *const PRINT = "print";
+// FIXME: Have a separate one for parallel uploads
+constexpr const char *const DEFAULT_UPLOAD_FILENAME = "tmp.gcode";
+
+const constexpr size_t MAX_SUBTOKEN = 19;
+
+class Accumulator {
+private:
+    size_t len = 0;
+    string_view looking_for;
+    bool sensitive = true;
+    array<char, MAX_SUBTOKEN> buffer;
+
+public:
+    Accumulator() {
+        // Initialize to avoid UB due to reading/moving uninit values.
+        memset(buffer.begin(), 0, buffer.size());
+    }
+    enum class Lookup {
+        Found,
+        NotYet,
+        Overflow,
+    };
+    void start(const char *looking_for, bool sensitive) {
+        const size_t len = strlen(looking_for);
+        assert(len <= buffer.size());
+        this->looking_for = string_view(looking_for, len);
+        this->sensitive = sensitive;
+        this->len = 0;
+    }
+    Lookup feed(char c) {
+        memmove(buffer.begin() + 1, buffer.begin(), buffer.size() - 1);
+        if (!sensitive) {
+            c = tolower(c);
+        }
+        buffer[buffer.size() - 1] = c;
+        const bool was_full = (len == buffer.size());
+        if (!was_full) {
+            len += 1;
+        }
+
+        const size_t suffix_len = std::min(len, looking_for.size());
+        string_view suffix(buffer.end() - suffix_len, suffix_len);
+
+        if (suffix == looking_for) {
+            return Lookup::Found;
+        } else if (was_full) {
+            return Lookup::Overflow;
+        } else {
+            return Lookup::NotYet;
+        }
+    }
+    bool empty() const {
+        return len == 0;
+    }
+    string_view prefix() const {
+        assert(len >= looking_for.size());
+        return string_view(buffer.end() - len, len - looking_for.size());
+    }
+    array<char, MAX_SUBTOKEN> &borrow_buf() {
+        return buffer;
+    }
+};
+
+class UploadState {
+private:
+    enum class TokenType {
+        NoToken,
+        HeaderField,
+        HeaderValue,
+    };
+
+    enum class State {
+        NoState,
+        CheckHeaderIsCDisp,
+        IgnoredHeader,
+        CDispHeader,
+        ReadString,
+        ReadPartName,
+        Data,
+    };
+
+    enum class Part {
+        Unknown,
+        Print,
+        File,
+        // Possibly others in the future
+    };
+
+    // TODO: Compact them a bit
+    TokenType type = TokenType::NoToken;
+    State state = State::NoState;
+    Part part = Part::Unknown;
+    Accumulator accumulator;
+    char *string_dst_pos = nullptr;
+    const char *string_dst_end = nullptr;
+    array<char, FILE_NAME_BUFFER_LEN> filename;
+    bool have_valid_filename = false;
+    bool init_done = false;
+    bool start_print = false;
+
+    HttpHandlers *handlers;
+
+    unique_ptr<multipart_parser, void (*)(multipart_parser *)> multiparter;
+
+    int header_field(const string_view &payload) {
+        if (type != TokenType::HeaderField) { // Start this token
+            type = TokenType::HeaderField;
+            state = State::CheckHeaderIsCDisp;
+            part = Part::Unknown;
+            accumulator.start(CDISP, false);
+        }
+
+        for (const char c : payload) {
+            if (state == State::CheckHeaderIsCDisp) {
+                if (!isspace(c)) {
+                    switch (accumulator.feed(c)) {
+                    case Accumulator::Lookup::Found:
+                        state = State::CDispHeader;
+                        break;
+                    case Accumulator::Lookup::Overflow:
+                        state = State::IgnoredHeader;
+                        break;
+                    case Accumulator::Lookup::NotYet:
+                        break;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+
+        return 0;
+    }
+
+    void handle_disp_field() {
+        /*
+         * The accumulator contains the name of the field before the separator.
+         * Decide what to do with it.
+         *
+         * The accumulator can overflow (dropping previous characters in the
+         * process). That's OK, because we abuse the fact its buffer is longer
+         * than whatever we look for here and it would still not match.
+         */
+        const auto &prefix = accumulator.prefix();
+        // Unless it's something special, simply throw it away.
+        state = State::ReadString;
+        string_dst_end = string_dst_pos = nullptr;
+
+        if (prefix == NAME) {
+            state = State::ReadPartName;
+            // Let's reuse the accumulator buffer for the name of the part.
+            // It's not being used right now.
+            auto &buffer = accumulator.borrow_buf();
+            string_dst_pos = buffer.begin();
+            string_dst_end = buffer.end();
+        } else if (prefix == FILENAME && !have_valid_filename) {
+            /*
+             * This one is a bit tricky. We want the filename of the file part.
+             * But we are not guaranteed the name of the part comes first and
+             * we don't know there won't be some other part with a file name in
+             * it. So we need to accumulate filename even before knowing the
+             * name, but only if we don't have one yet. And then when the part
+             * ends, we check if it indeed is the right one.
+             */
+            string_dst_pos = filename.begin();
+            // Leave space for \0 in this case - we need to talk with C there.
+            string_dst_end = filename.end() - 1;
+        }
+    }
+
+    int header_value(const string_view &payload) {
+        // In case we just came from the header_field, it may have unfinished bussiness here.
+        if (state == State::CheckHeaderIsCDisp) {
+            state = State::IgnoredHeader;
+        }
+
+        if (state == State::IgnoredHeader) { // Finish previous token
+            return 0;
+        }
+
+        if (type != TokenType::HeaderValue) { // Start this token
+            type = TokenType::HeaderValue;
+            accumulator.start(HEADER_SEP, true);
+        }
+
+        for (const char c : payload) {
+            switch (state) {
+            case State::CDispHeader:
+                if (c == ';') {
+                    /*
+                         * End of the field without = in it, something we don't
+                         * care about (or leftover from the previous one). Just
+                         * reset the buffer and start fresh.
+                         */
+                    accumulator.start(HEADER_SEP, true);
+                }
+                if (!isspace(c)) {
+                    if (accumulator.feed(c) == Accumulator::Lookup::Found) {
+                        handle_disp_field();
+                    }
+                }
+                break;
+            case State::ReadString:
+            case State::ReadPartName:
+                /*
+                     * FIXME: In reality, this is a bit more involved and
+                     * complex. It can be escaped/otherwise encoded, since the
+                     * string also can contain special characters...
+                     *
+                     * For now we just assume trivial case here.
+                     */
+                if (c == '"') {
+                    if (state == State::ReadPartName) {
+                        const char *start = accumulator.borrow_buf().begin();
+                        const size_t length = string_dst_pos - start;
+                        assert(length <= accumulator.borrow_buf().size());
+                        const string_view name(start, length);
+                        if (name == PRINT) {
+                            part = Part::Print;
+                        } else if (name == FILE) {
+                            part = Part::File;
+                        } else {
+                            part = Part::Unknown;
+                        }
+                    }
+                    state = State::CDispHeader;
+                    string_dst_end = string_dst_pos = nullptr;
+                } else if (string_dst_pos < string_dst_end) {
+                    *(string_dst_pos++) = c;
+                }
+                /*
+                     * else:
+                     * If both are null, then we just throw the string away.
+                     * Otherwise we have filled the string to the brim. What
+                     * do we do with it now? Should we use the shorter one or
+                     * error?
+                     */
+                break;
+            case State::NoState:
+            case State::CheckHeaderIsCDisp:
+            case State::IgnoredHeader:
+            case State::Data:
+                assert(0); // Unreachable
+                break;
+            }
+        }
+
+        return 0;
+    }
+
+    int headers_complete() {
+        if (part == Part::File) {
+            if (filename[0] != '\0') {
+                // Make sure this is not overwritten next time.
+                have_valid_filename = true;
+            } else {
+                // TODO: Error. We have a file part without a filename.
+            }
+        } else {
+            /*
+             * In case something else than the file part tries to give us a
+             * file name, throw it away. We are not interested.
+             *
+             * But preserve the one from previous file part, of course.
+             */
+            if (!have_valid_filename) {
+                memset(filename.begin(), 0, filename.size());
+            }
+        }
+        state = State::Data;
+
+        return 0;
+    }
+
+    int part_data_begin() {
+        switch (part) {
+        case Part::File:
+            if (!init_done) {
+                init_done = true;
+                // TODO: Handle return code
+                handlers->gcode_start(handlers, DEFAULT_UPLOAD_FILENAME);
+            }
+            break;
+        case Part::Print:
+            // Prepare a storage for the true/false
+            accumulator.start("true", true);
+            break;
+        case Part::Unknown:
+            // Nothing to do with unknown parts. Simply skip.
+            break;
+        }
+
+        return 0;
+    }
+
+    int file_part(const string_view &payload) {
+        // TODO: Handle return code
+        handlers->gcode_data(handlers, payload.begin(), payload.size());
+        return 0;
+    }
+
+    int print_part(const string_view &payload) {
+        for (const char c : payload) {
+            if (accumulator.feed(c) == Accumulator::Lookup::Found) {
+                start_print = true;
+            }
+        }
+
+        return 0;
+    }
+
+    int part_data(const string_view &payload) {
+        switch (part) {
+        case Part::File:
+            return file_part(payload);
+        case Part::Print:
+            return print_part(payload);
+        case Part::Unknown:
+            // Unknown parts are simply ignored.
+            return 0;
+        }
+        assert(0);
+        return 0;
+    }
+
+    int body_end() {
+        if (init_done) {
+            // TODO: Handle return code
+            handlers->gcode_finish(handlers, DEFAULT_UPLOAD_FILENAME, filename.begin(), start_print);
+            init_done = false;
+        }
+        return 0;
+    }
+
+#define DATA(NAME)                                                              \
+    static int NAME##_raw(multipart_parser *p, const char *at, size_t length) { \
+        auto me = static_cast<UploadState *>(multipart_parser_get_data(p));     \
+        return me->NAME(string_view(at, length));                               \
+    }
+    DATA(header_field);
+    DATA(header_value);
+    DATA(part_data);
+#undef DATA
+#define NOTIF(NAME)                                                         \
+    static int NAME##_raw(multipart_parser *p) {                            \
+        auto me = static_cast<UploadState *>(multipart_parser_get_data(p)); \
+        return me->NAME();                                                  \
+    }
+    NOTIF(headers_complete);
+    NOTIF(part_data_begin);
+    NOTIF(body_end);
+
+    static const constexpr struct multipart_parser_settings parser_settings = {
+        header_field_raw,
+        header_value_raw,
+        part_data_raw,
+        part_data_begin_raw,
+        headers_complete_raw,
+        nullptr, // part_data_end
+        body_end_raw,
+    };
+
+public:
+    UploadState(const char *boundary, HttpHandlers *handlers)
+        : handlers(handlers)
+        , multiparter(multipart_parser_init(boundary, &parser_settings), multipart_parser_free) {
+        memset(filename.begin(), 0, filename.size());
+        multipart_parser_set_data(multiparter.get(), this);
+    }
+    ~UploadState() {
+        if (init_done) {
+            // TODO: Call some kind of abort thing on the upload
+        }
+    }
+    // A good reason why we don't want these is because this is a
+    // self-referential type (pointers leading to self) with raw pointers and
+    // it's probably not easy to deal with (in case of the multipart parser
+    // anyway).
+    UploadState(const UploadState &other) = delete;
+    UploadState(UploadState &&other) = delete;
+    UploadState &operator=(const UploadState &other) = delete;
+    UploadState &operator=(UploadState &&other) = delete;
+
+    void feed(const string_view &data) {
+        // TODO: Error handling
+        multipart_parser_execute(multiparter.get(), data.begin(), data.size());
+    }
+};
+
+}
+
+extern "C" {
+
+struct Uploader {
+    UploadState state;
+    Uploader(const char *boundary, HttpHandlers *handlers)
+        : state(boundary, handlers) {}
+};
+
+struct Uploader *uploader_init(const char *boundary, HttpHandlers *handlers) {
+    return new Uploader(boundary, handlers);
+}
+
+void uploader_feed(struct Uploader *uploader, const char *data, size_t len) {
+    uploader->state.feed(string_view(data, len));
+}
+
+void uploader_finish(struct Uploader *uploader) {
+    delete uploader;
+}
+}
+
+/*
+ * TODO: Missing parts:
+ * * Handle allocation failures. Or even better, figure out a way to get rid of
+ *   allocations.
+ * * Format/request error handling.
+ * * Propagating errors from the handler callbacks.
+ * * Make sure there may be multiple instances (create new file name for each?).
+ */

--- a/lib/WUI/http/upload_state.h
+++ b/lib/WUI/http/upload_state.h
@@ -9,9 +9,9 @@ extern "C" {
 struct Uploader;
 
 struct Uploader *uploader_init(const char *boundary, HttpHandlers *handlers);
-// TODO: Error handling?
 void uploader_feed(struct Uploader *uploader, const char *data, size_t len);
 void uploader_finish(struct Uploader *uploader);
+uint16_t uploader_error(struct Uploader *uploader);
 
 #ifdef __cplusplus
 }

--- a/lib/WUI/http/upload_state.h
+++ b/lib/WUI/http/upload_state.h
@@ -10,7 +10,7 @@ struct Uploader;
 
 struct Uploader *uploader_init(const char *boundary, HttpHandlers *handlers);
 // TODO: Error handling?
-void upleader_feed(struct Uploader *uploader, const char *data, size_t len);
+void uploader_feed(struct Uploader *uploader, const char *data, size_t len);
 void uploader_finish(struct Uploader *uploader);
 
 #ifdef __cplusplus

--- a/lib/WUI/http/upload_state.h
+++ b/lib/WUI/http/upload_state.h
@@ -1,16 +1,95 @@
 #pragma once
 
+/**
+ * \file
+ * \brief Tracking the state of gcode upload and parsing whatever needed.
+ *
+ * This integrates into the post handling in our http server (yes, that's kind
+ * of wrong as abstractions go, and this'll need to change eventually, probably
+ * as we replace the http server). It is also kind of single-purpose parser,
+ * since we want to have only a single POST endpoint handling
+ * multipart/form-data (the others will be JSON, which'll be some other kind of
+ * beast anyway).
+ *
+ * Each new upload creates an instance, feeds it with data and checks if
+ * everything goes fine (the errors can happen anytime and it is up to the
+ * caller to either check after each feeding or at the end).
+ *
+ * Internally, it calls the callbacks from the http handlers. If it calls the
+ * start handler, it guarantees it'll either see an error returned from one of
+ * the callbacks (in which case it is assumed the callbacks clean up their
+ * state) or will eventually call the finish callback (even if the upload is
+ * interrupted, reaches invalid state, etc).
+ *
+ * The data fed to it may be split arbitrarily.
+ */
+
 #include "handler.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/// A handle to the upload state.
 struct Uploader;
 
+/**
+ * \brief Creates a fresh new instance of the tracker.
+ *
+ * \param boundary C-style string specifying the boundary between parts. From
+ *   the Content-Type header. Can be freed after the call to this function.
+ * \param handlers Structure with callbacks to pass the parsed data to. Needs
+ *   to stay alive until the call of uploader_finish, but the uploader doesn't
+ *   take ownership.
+ * \return
+ *   - A fresh instance of the tracker. Note that even this one might already
+ *     be in an error state and it might be worth checking for errors.
+ *   - NULL in case of allocation errors.
+ */
 struct Uploader *uploader_init(const char *boundary, struct HttpHandlers *handlers);
+
+/**
+ * \brief Inserts more data into the tracker.
+ *
+ * This assumes the data is the next chunk of valid multipart/form-data with
+ * the upload "form". Internally it might call some of the callbacks.
+ *
+ * \param uploader An instance of the uploader.
+ * \param data, len The data to process (and their length). The uploader does
+ *   not take ownership and the data may be disposed of right after the call
+ *   terminates (they are not kept around).
+ */
 void uploader_feed(struct Uploader *uploader, const char *data, size_t len);
+
+/**
+ * \brief Finishes processing and releases resources.
+ *
+ * This finishes any needed processing and calling of callbacks. Then it frees
+ * internal resources. After this call, the uploader is no longer valid.
+ *
+ * It is recommended to check for errors before calling this.
+ *
+ * \param uploader The uploader to free.
+ * \return Boolean specifying if an end of the data has been seen. Result of
+ *   false either means the form didn't contain all the needed parts or that the
+ *   upload was aborted/interrupted and the "tail" is missing.
+ */
 bool uploader_finish(struct Uploader *uploader);
+
+/**
+ * \brief Checks for error state of the uploader.
+ *
+ * Returns if there was an error in processing the upload (and which one). Once
+ * the uploader reaches an error state, there's no way to reset it - errors are
+ * not recoverable.
+ *
+ * It is possible to check repeatedly/after each feeding or at the end. Feeding
+ * data to an uploader in error state is possible, but has no effect.
+ *
+ * \return
+ *   - 0 if there was no error so far.
+ *   - Anything else: http status corresponding to the error.
+ */
 uint16_t uploader_error(const struct Uploader *uploader);
 
 #ifdef __cplusplus

--- a/lib/WUI/http/upload_state.h
+++ b/lib/WUI/http/upload_state.h
@@ -8,10 +8,10 @@ extern "C" {
 
 struct Uploader;
 
-struct Uploader *uploader_init(const char *boundary, HttpHandlers *handlers);
+struct Uploader *uploader_init(const char *boundary, struct HttpHandlers *handlers);
 void uploader_feed(struct Uploader *uploader, const char *data, size_t len);
-void uploader_finish(struct Uploader *uploader);
-uint16_t uploader_error(struct Uploader *uploader);
+bool uploader_finish(struct Uploader *uploader);
+uint16_t uploader_error(const struct Uploader *uploader);
 
 #ifdef __cplusplus
 }

--- a/lib/WUI/http/upload_state.h
+++ b/lib/WUI/http/upload_state.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "handler.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct Uploader;
+
+struct Uploader *uploader_init(const char *boundary, HttpHandlers *handlers);
+// TODO: Error handling?
+void upleader_feed(struct Uploader *uploader, const char *data, size_t len);
+void uploader_finish(struct Uploader *uploader);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/WUI/http_handler_default.c
+++ b/lib/WUI/http_handler_default.c
@@ -27,15 +27,15 @@ static uint16_t settings_stub(struct HttpHandlers *unused, char *buffer, size_t 
     return 200;
 }
 
-static uint32_t post_start(struct HttpHandlers *unused, const char *filename) {
+static uint16_t post_start(struct HttpHandlers *unused, const char *filename) {
     return wui_upload_begin(filename);
 }
 
-static uint32_t post_data(struct HttpHandlers *unused, const char *data, size_t len) {
+static uint16_t post_data(struct HttpHandlers *unused, const char *data, size_t len) {
     return wui_upload_data(data, len);
 }
 
-static uint32_t post_finish(struct HttpHandlers *unused, const char *tmp_filename, const char *final_filename, bool start) {
+static uint16_t post_finish(struct HttpHandlers *unused, const char *tmp_filename, const char *final_filename, bool start) {
     return wui_upload_finish(tmp_filename, final_filename, start);
 }
 

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -181,28 +181,31 @@ void wui_store_api_key(char *, uint32_t);
 /// @brief Prepare file descriptor to upload the file
 ///
 /// @param[in] filename Name of the file to start uploading
-/// @return Return 0 if success otherwise the error code
-uint32_t wui_upload_begin(const char *);
+/// @return
+///   - 0 For success
+///   - Otherwise a http error code to use.
+uint16_t wui_upload_begin(const char *);
 
 ////////////////////////////////////////////////////////////////////////////
 /// @brief Writting received data on already prepared file descriptor
 ///
 /// @param[in] buffer Received file data
 /// @param[in] length Size of the buffer
-/// @return Return 0 if success otherwise the error code
-uint32_t wui_upload_data(const char *, uint32_t);
+/// @return
+///    - 0 for success
+///    - http error code to use.
+uint16_t wui_upload_data(const char *, uint32_t);
 
 ////////////////////////////////////////////////////////////////////////////
 /// @brief Finalize upload of the file
 ///
 /// @param[in] oldFilename Temporary file name
 /// @param[in] newFilename Regular file name
-/// @param[in] startPrint 1 if print should start after upload, 0 otherwise
-/// @return Return status code for http response
-///                 200 OK
-///                 409 Conflict
-///                 415 Unsupported Media Type
-uint32_t wui_upload_finish(const char *, const char *, uint32_t);
+/// @param[in] startPrint true if print shall start after upload
+/// @return
+///     - 0 for success
+///     - http error code to use
+uint16_t wui_upload_finish(const char *, const char *, bool);
 
 ////////////////////////////////////////////////////////////////////////////
 /// @brief Return the number of gcodes uploaded since boot.

--- a/tests/integration/test_prusa_link.py
+++ b/tests/integration/test_prusa_link.py
@@ -86,12 +86,10 @@ async def test_upload(printer: Printer, wui_client: aiohttp.ClientSession):
     # TODO: Turn off printer and see that the file appeared on the flash drive.
 
 
-# Known issue: Returns 404 instead of 401
-@pytest.mark.skip()
 async def test_upload_notauth(printer: Printer,
                               wui_client: aiohttp.ClientSession):
     await screen.wait_for_text(printer, 'HOME')
     data = aiohttp.FormData()
     data.add_field('file', b'', filename='empty.gcode')
     response = await wui_client.post('/api/files/sdcard', data=data)
-    assert response == 401
+    assert response.status == 401

--- a/tests/unit/lib/WUI/http/CMakeLists.txt
+++ b/tests/unit/lib/WUI/http/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(
   http_tests
   # Test files
   ${CMAKE_CURRENT_SOURCE_DIR}/http_tests.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/multipart_upload.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/missing_functions.c
   # Tested files
   ${CMAKE_SOURCE_DIR}/lib/WUI/http/handler.c
@@ -9,6 +10,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/lib/WUI/http/httpd_post.c
   ${CMAKE_SOURCE_DIR}/lib/WUI/http/fs.c
   ${CMAKE_SOURCE_DIR}/lib/WUI/http/multipart_parser.c
+  ${CMAKE_SOURCE_DIR}/lib/WUI/http/upload_state.cpp
   # Dependencies.
   # It seems it's not possible to just link the damn LwIP library:
   # * Somehow, the target_link_libraries directive poisons include

--- a/tests/unit/lib/WUI/http/multipart_upload.cpp
+++ b/tests/unit/lib/WUI/http/multipart_upload.cpp
@@ -1,0 +1,256 @@
+#include <upload_state.h>
+
+#include <catch2/catch.hpp>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <optional>
+#include <vector>
+
+using std::nullopt;
+using std::optional;
+using std::string;
+using std::string_view;
+using std::unique_ptr;
+using std::vector;
+
+namespace {
+
+#define BOUNDARY    "bOUndAry"
+#define CRLF        "\r\n"
+#define GCODE_LINE1 "G1 X0 Y0 Z0 E0 F0"
+
+struct Start {
+    string filename;
+};
+
+struct Finish {
+    string tmp_filename;
+    string final_filename;
+    bool print;
+};
+
+struct Log {
+    optional<Start> start = nullopt;
+    optional<Finish> finish = nullopt;
+    vector<string> data;
+
+    void gcode_start(const char *filename) {
+        REQUIRE_FALSE(start.has_value());
+        REQUIRE_FALSE(finish.has_value());
+        start = Start { string(filename) };
+    }
+
+    void gcode_data(const char *data, size_t len) {
+        REQUIRE(start.has_value());
+        REQUIRE_FALSE(finish.has_value());
+        this->data.push_back(string(data, len));
+    }
+
+    void gcode_finish(const char *tmp_filename, const char *final_filename, bool print) {
+        REQUIRE(start.has_value());
+        REQUIRE_FALSE(finish.has_value());
+        finish = Finish {
+            string(tmp_filename),
+            string(final_filename),
+            print
+        };
+    }
+};
+
+class FakeHandlers : public HttpHandlers {
+private:
+    static uint32_t start(struct HttpHandlers *self, const char *filename) {
+        static_cast<FakeHandlers *>(self)->log.gcode_start(filename);
+        return 0;
+    }
+    static uint32_t data(struct HttpHandlers *self, const char *data, size_t len) {
+        static_cast<FakeHandlers *>(self)->log.gcode_data(data, len);
+        return 0;
+    }
+    static uint32_t finish(struct HttpHandlers *self, const char *tmp_filename, const char *final_filename, bool print) {
+        static_cast<FakeHandlers *>(self)->log.gcode_finish(tmp_filename, final_filename, print);
+        return 0;
+    }
+
+public:
+    Log log;
+    FakeHandlers() {
+        // Initialize/zero the C-originating parent
+        HttpHandlers *handlers = this;
+        memset(handlers, 0, sizeof(*handlers));
+        gcode_start = start;
+        gcode_data = data;
+        gcode_finish = finish;
+    }
+};
+
+class Test {
+public:
+    FakeHandlers handlers;
+    unique_ptr<Uploader, void (*)(Uploader *)> uploader;
+    Test()
+        : uploader(uploader_init(BOUNDARY, &handlers), uploader_finish) {}
+    void finish() {
+        uploader.reset();
+    }
+
+    const Log &log() const {
+        return handlers.log;
+    }
+
+    void feed(const string_view &data) {
+        uploader_feed(uploader.get(), data.begin(), data.size());
+    }
+};
+
+}
+
+// This simply creates and destroyes the parsers and checks that nothing "happens"
+TEST_CASE("Unused") {
+    Test test;
+    test.finish();
+    REQUIRE_FALSE(test.log().start.has_value());
+    REQUIRE_FALSE(test.log().finish.has_value());
+    REQUIRE(test.log().data.empty());
+}
+
+/*
+ * I know there's a reason to have uniformly formatted code, but these string
+ * constants are formatted in blocks that actually correspond to the lines that
+ * are sent over the wire. Trying to indent them (in somewhat confused way too)
+ * doesn't really help a single bit.
+ */
+// clang-format off
+constexpr const char *const OK_FORM =
+"--" BOUNDARY CRLF
+"Content-Disposition: form-data; name=\"file\"; filename=\"test.gcode\"" CRLF
+CRLF
+GCODE_LINE1 CRLF
+"--" BOUNDARY "--" CRLF
+;
+
+constexpr const char *const DO_PRINT =
+"--" BOUNDARY CRLF
+"Content-Disposition: form-data; name=\"file\"; filename=\"test.gcode\"" CRLF
+CRLF
+GCODE_LINE1 CRLF
+"--" BOUNDARY CRLF
+"Content-Disposition: form-data; name=\"print\"" CRLF
+CRLF
+"true" CRLF
+"--" BOUNDARY "--" CRLF;
+
+constexpr const char *const DO_PRINT_EXTRA_PARTS =
+"--" BOUNDARY CRLF
+"Content-Disposition: form-data; name=\"extra-file\"; filename=\"not-really\"" CRLF
+"Content-Disposition-Trap: name=\"file\"; filename=\"whatever-else\"" CRLF
+CRLF
+CRLF
+"--" BOUNDARY CRLF
+"Content-Disposition-Trap: name=\"file\"; filename=\"whatever-else\"" CRLF
+"Content-Disposition: form-data; filename=\"test.gcode\"; whatever=\"else\"; name=\"file\"" CRLF
+"Content-Disposition-Another-Trap: name=\"file\"; filename=\"whatever-else\"" CRLF
+"Disposition: name=\"file\"; filename=\"whatever-else\"" CRLF
+CRLF
+GCODE_LINE1 CRLF
+"--" BOUNDARY CRLF
+"Content-Disposition: form-data; name=\"print\"" CRLF
+CRLF
+"true" CRLF
+"--" BOUNDARY "--" CRLF;
+
+constexpr const char *const DONT_PRINT =
+"--" BOUNDARY CRLF
+"Content-Disposition: form-data; name=\"file\"; filename=\"test.gcode\"" CRLF
+CRLF
+GCODE_LINE1 CRLF
+"--" BOUNDARY CRLF
+"Content-Disposition: form-data; name=\"print\"" CRLF
+CRLF
+"false" CRLF
+"--" BOUNDARY "--" CRLF;
+// clang-format on
+
+TEST_CASE("One Big Chunk") {
+    Test test;
+    test.feed(OK_FORM);
+
+    SECTION("With close") {
+        test.finish();
+    }
+
+    SECTION("Without close") {}
+
+    const auto &log = test.log();
+    REQUIRE(log.start.has_value());
+    REQUIRE(log.start->filename == "tmp.gcode");
+    REQUIRE(log.data.size() == 1);
+    REQUIRE(log.data[0] == GCODE_LINE1);
+    REQUIRE(log.finish.has_value());
+    REQUIRE(log.finish->tmp_filename == "tmp.gcode");
+    REQUIRE(log.finish->final_filename == "test.gcode");
+    REQUIRE_FALSE(log.finish->print);
+}
+
+TEST_CASE("Handling multiple parts") {
+    Test test;
+
+    bool expect_start = false;
+
+    SECTION("Do print") {
+        expect_start = true;
+        test.feed(DO_PRINT);
+    }
+
+    SECTION("Ignoring extra stuff") {
+        expect_start = true;
+        test.feed(DO_PRINT_EXTRA_PARTS);
+    }
+
+    SECTION("Don't print") {
+        test.feed(DONT_PRINT);
+    }
+
+    const auto &log = test.log();
+    REQUIRE(log.start.has_value());
+    REQUIRE(log.start->filename == "tmp.gcode");
+    REQUIRE(log.data.size() == 1);
+    REQUIRE(log.data[0] == GCODE_LINE1);
+    REQUIRE(log.finish.has_value());
+    REQUIRE(log.finish->tmp_filename == "tmp.gcode");
+    REQUIRE(log.finish->final_filename == "test.gcode");
+    REQUIRE(log.finish->print == expect_start);
+}
+
+// Chunk it into small parts. Go as far as single characters to go to the
+// extreme and make sure that anything and everything breaks into parts.
+TEST_CASE("Chunked") {
+    Test test;
+
+    const auto data = string_view(DO_PRINT);
+    for (const char *c = data.begin(); c != data.end(); c++) {
+        test.feed(string_view(c, 1));
+    }
+
+    const auto &log = test.log();
+    REQUIRE(log.start.has_value());
+    REQUIRE(log.start->filename == "tmp.gcode");
+    string result;
+    for (const auto &chunk : log.data) {
+        result += chunk;
+    }
+    REQUIRE(result == GCODE_LINE1);
+    REQUIRE(log.finish.has_value());
+    REQUIRE(log.finish->tmp_filename == "tmp.gcode");
+    REQUIRE(log.finish->final_filename == "test.gcode");
+    REQUIRE(log.finish->print);
+}
+
+// TODO: Malformed
+// TODO: Missing filename
+// TODO: Incomplete (drop early)
+// TODO: Parallel uploads
+// TODO: Extra spaces
+// TODO: Preamble and epilogue


### PR DESCRIPTION
This rewrites handling of the upload with tracking state as an automaton and assuming anything can be broken up between packets at any time.

This fixes several bugs (see the commit message of the last commit).

It's still far from being perfect. There's some amount of working around the bad design in the http server and other awkward things. It still doesn't handle multiple parallel uploads and uses global variables :cry:. It also introduces another dynamic allocation to the upload path (there was one, now there are two). Also, eventually, I'd like to do something about the `multipart_parser.c` thing ‒ it _almost_ works, but doesn't accept all the things that are valid according to the standard. I've stopped myself there, as they are valid but highly _unlikely_, so it's probably OKish for now.

I'm open to suggestions how to improve it, what other scenarios to test (either in unit tests or integration tests), etc.