### PR TITLE
USBHost: Change timeout for read/write to 1s

### DIFF
--- a/lib/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc.c
+++ b/lib/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Src/usbh_msc.c
@@ -779,7 +779,7 @@ USBH_StatusTypeDef USBH_MSC_Read(USBH_HandleTypeDef *phost,
 
   while (USBH_MSC_RdWrProcess(phost, lun) == USBH_BUSY)
   {
-    if (((phost->Timer - timeout) > (10000U * length)) || (phost->device.is_connected == 0U))
+    if (((phost->Timer - timeout) > (1000U * length)) || (phost->device.is_connected == 0U))
     {
       MSC_Handle->state = MSC_IDLE;
       return USBH_FAIL;
@@ -825,7 +825,7 @@ USBH_StatusTypeDef USBH_MSC_Write(USBH_HandleTypeDef *phost,
   timeout = phost->Timer;
   while (USBH_MSC_RdWrProcess(phost, lun) == USBH_BUSY)
   {
-    if (((phost->Timer - timeout) > (10000U * length)) || (phost->device.is_connected == 0U))
+    if (((phost->Timer - timeout) > (1000U * length)) || (phost->device.is_connected == 0U))
     {
       MSC_Handle->state = MSC_IDLE;
       return USBH_FAIL;


### PR DESCRIPTION
Prevent show watchdog screen if USB host error. Watchdog in fw is set to 3s