### PR TITLE
GUI: Change dynamic button size algorithm

### DIFF
--- a/src/gui/dialogs/DialogRadioButton.cpp
+++ b/src/gui/dialogs/DialogRadioButton.cpp
@@ -120,18 +120,18 @@ void RadioButton::draw_n_btns(const size_t btn_count) {
     /// fix size of dialog buttons - MAX_DIALOG_BUTTON_COUNT
     Rect16 splits[GuiDefaults::MAX_DIALOG_BUTTON_COUNT];
     Rect16 spaces[GuiDefaults::MAX_DIALOG_BUTTON_COUNT - 1];
-    uint8_t ratio[GuiDefaults::MAX_DIALOG_BUTTON_COUNT];
+    uint8_t text_width[GuiDefaults::MAX_DIALOG_BUTTON_COUNT];
 
     for (size_t index = 0; index < btn_count; index++) {
         string_view_utf8 txt = _((*texts)[index]);
-        ratio[index] = static_cast<uint8_t>(txt.computeNumUtf8CharsAndRewind());
+        text_width[index] = pfont->w * static_cast<uint8_t>(txt.computeNumUtf8CharsAndRewind());
     }
-    GetRect().HorizontalSplit(splits, spaces, btn_count, GuiDefaults::ButtonSpacing, ratio);
+    GetRect().HorizontalSplit(splits, spaces, btn_count, GuiDefaults::ButtonSpacing, text_width);
 
     for (size_t i = 0; i < btn_count; ++i) {
         string_view_utf8 drawn = _((*texts)[i]);
         char buffer[MAX_TEXT_BUFFER] = { 0 };
-        if ((pfont->w * ratio[i]) > splits[i].Width()) {
+        if (text_width[i] > splits[i].Width()) {
             uint32_t max_btn_label_text = splits[i].Width() / pfont->w;
             size_t length = std::min(max_btn_label_text, MAX_TEXT_BUFFER - 1);
             length = drawn.copyToRAM(buffer, length);

--- a/src/guiapi/include/Rect16.h
+++ b/src/guiapi/include/Rect16.h
@@ -586,9 +586,9 @@ public:
     /// @param[out] splits[] buffer to fill of splitted Rect16
     /// @param[out] spaces[] buffer to fill of spaces between Rect16 splits
     /// @param[in] count number of splits
-    /// @param[in] spacing with of spaces between rectangle's splits (optional = 0)
-    /// @param[in] ratio[] ratio of wanted splits (optional = nullptr)
-    void HorizontalSplit(Rect16 splits[], Rect16 spaces[], const size_t count, const uint16_t spacing = 0, uint8_t ratio[] = nullptr) const;
+    /// @param[in] spacing width of spaces between rectangle's splits (optional = 0)
+    /// @param[in] text_width[] width of texts (optional = nullptr)
+    void HorizontalSplit(Rect16 splits[], Rect16 spaces[], const size_t count, const uint16_t spacing = 0, uint8_t text_width[] = nullptr) const;
 
     ////////////////////////////////////////////////////////////////////////////
     /// @brief Horizontal split with dynamic spaces from parent Rect16
@@ -634,8 +634,8 @@ public:
     /// @param[out] spaces[] buffer to fill of spaces between Rect16 splits
     /// @param[in] count number of splits
     /// @param[in] spacing with of spaces between rectangle's splits (optional = 0)
-    /// @param[in] ratio[] ratio of wanted splits (optional = nullptr)
-    void VerticalSplit(Rect16 splits[], Rect16 spaces[], const size_t count, const uint16_t spacing = 0, uint8_t ratio[] = nullptr) const;
+    /// @param[in] text_width[] text_width of wanted splits (optional = nullptr)
+    void VerticalSplit(Rect16 splits[], Rect16 spaces[], const size_t count, const uint16_t spacing = 0, uint8_t text_width[] = nullptr) const;
 
     ////////////////////////////////////////////////////////////////////////////
     /// @brief Line operation substracts subtrahend

--- a/tests/unit/gui/rectangle_tests.cpp
+++ b/tests/unit/gui/rectangle_tests.cpp
@@ -735,9 +735,9 @@ TEST_CASE("rectangle split", "[rectangle]") {
 
         std::tie(r, count, spacing, ratio, expSplits, expSpaces) = GENERATE(
             std::make_tuple<Rect16, size_t, uint16_t, Ratio, Sequence, Sequence>(
-                { 0, 0, 100, 100 }, 2, 0, { { 1, 1 } }, { { { 0, 0, 50, 100 }, { 50, 0, 50, 100 } } }, { { { 50, 0, 0, 100 } } }),
+                { 0, 0, 100, 100 }, 2, 0, { { 20, 20 } }, { { { 0, 0, 50, 100 }, { 50, 0, 50, 100 } } }, { { { 50, 0, 0, 100 } } }),
             std::make_tuple<Rect16, size_t, uint16_t, Ratio, Sequence, Sequence>(
-                { 0, 0, 120, 100 }, 4, 10, { { 1, 2, 2, 1 } }, { { { 0, 0, 15, 100 }, { 25, 0, 30, 100 }, { 65, 0, 30, 100 }, { 105, 0, 15, 100 } } }, { { { 15, 0, 10, 100 }, { 55, 0, 10, 100 }, { 95, 0, 10, 100 } } }));
+                { 0, 0, 120, 100 }, 4, 10, { { 10, 15, 15, 10 } }, { { { 0, 0, 20, 100 }, { 30, 0, 25, 100 }, { 65, 0, 25, 100 }, { 100, 0, 20, 100 } } }, { { { 20, 0, 10, 100 }, { 55, 0, 10, 100 }, { 90, 0, 10, 100 } } }));
 
         r.HorizontalSplit(splits, spaces, count, spacing, ratio.data());
 


### PR DESCRIPTION
Radio button sizes were set according to text size ratio. Very short text had very small button width. New algorithm sets the same padding size for all buttons which looks more natural.
BFW-2377