### PR TITLE
Lower networking priority

### DIFF
--- a/lib/ESP/prusa/include/system/port/buddy/lwesp_sys_port.h
+++ b/lib/ESP/prusa/include/system/port/buddy/lwesp_sys_port.h
@@ -55,7 +55,7 @@ typedef osPriority lwesp_sys_thread_prio_t;
     #define LWESP_SYS_SEM_NULL    ((lwesp_sys_sem_t)0)
     #define LWESP_SYS_MBOX_NULL   ((lwesp_sys_mbox_t)0)
     #define LWESP_SYS_TIMEOUT     ((uint32_t)osWaitForever)
-    #define LWESP_SYS_THREAD_PRIO (osPriorityNormal)
+    #define LWESP_SYS_THREAD_PRIO (osPriorityBelowNormal)
     #define LWESP_SYS_THREAD_SS   (512)
 
 #else
@@ -70,7 +70,7 @@ typedef osPriority_t lwesp_sys_thread_prio_t;
     #define LWESP_SYS_SEM_NULL    ((lwesp_sys_sem_t)0)
     #define LWESP_SYS_MBOX_NULL   ((lwesp_sys_mbox_t)0)
     #define LWESP_SYS_TIMEOUT     ((uint32_t)osWaitForever)
-    #define LWESP_SYS_THREAD_PRIO (osPriorityNormal)
+    #define LWESP_SYS_THREAD_PRIO (osPriorityBelowNormal)
     #define LWESP_SYS_THREAD_SS   (1024)
 #endif
 

--- a/lib/ESP/prusa/src/system/lwesp_ll_buddy.c
+++ b/lib/ESP/prusa/src/system/lwesp_ll_buddy.c
@@ -187,7 +187,7 @@ esp_ll_init(esp_ll_t *ll) {
             }
         }
         if (UartBufferThread_id == NULL) {
-            osThreadDef(UartBufferThread, StartUartBufferThread, osPriorityNormal, 0, 512);
+            osThreadDef(UartBufferThread, StartUartBufferThread, osPriorityBelowNormal, 0, 512);
             UartBufferThread_id = osThreadCreate(osThread(UartBufferThread), NULL);
             if (UartBufferThread_id == NULL) {
                 _dbg("ESP LL: failed to start UART buffer thread");

--- a/lib/WUI/ethernetif.c
+++ b/lib/WUI/ethernetif.c
@@ -283,7 +283,7 @@ static void low_level_init(struct netif *netif) {
     s_xSemaphore = osSemaphoreCreate(osSemaphore(SEM), 1);
 
     /* create the task that handles the ETH_MAC */
-    osThreadDef(EthIf, ethernetif_input, osPriorityRealtime, 0, INTERFACE_THREAD_STACK_SIZE);
+    osThreadDef(EthIf, ethernetif_input, osPriorityBelowNormal, 0, INTERFACE_THREAD_STACK_SIZE);
     osThreadCreate(osThread(EthIf), netif);
     /* Enable MAC and DMA transmission and reception */
     HAL_ETH_Start(&heth);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -326,7 +326,7 @@ int main(void) {
 
 #ifdef BUDDY_ENABLE_WUI
     /* definition and creation of webServerTask */
-    osThreadDef(webServerTask, StartWebServerTask, osPriorityNormal, 0, 1024);
+    osThreadDef(webServerTask, StartWebServerTask, osPriorityBelowNormal, 0, 1024);
     webServerTaskHandle = osThreadCreate(osThread(webServerTask), NULL);
 #endif
 


### PR DESCRIPTION
Because:
* We are a printer, not a router. If we can't keep up with both, we need
  to primarily _print_.
* Printing is limited in how much resources it can take, network is
  potentially not. Depending on the surroundings not under our control,
  it could eat everything thrown at it.
* Network protocols are built to deal with something being slow and
  unreliable, printing does not.