### PR TITLE
Fix TCP timers

### DIFF
--- a/lib/WUI/lwipopts.h
+++ b/lib/WUI/lwipopts.h
@@ -82,7 +82,7 @@ extern "C" {
     /*----- Value in opt.h for MEM_ALIGNMENT: 1 -----*/
     #define MEM_ALIGNMENT 4
     /*----- Value in opt.h for MEMP_NUM_SYS_TIMEOUT: (LWIP_TCP + IP_REASSEMBLY + LWIP_ARP + (2*LWIP_DHCP) + LWIP_AUTOIP + LWIP_IGMP + LWIP_DNS + (PPP_SUPPORT*6*MEMP_NUM_PPP_PCB) + (LWIP_IPV6 ? (1 + LWIP_IPV6_REASS + LWIP_IPV6_MLD) : 0)) -*/
-    #define MEMP_NUM_SYS_TIMEOUT 6
+    #define MEMP_NUM_SYS_TIMEOUT 7
     /*----- Value in opt.h for LWIP_ETHERNET: LWIP_ARP || PPPOE_SUPPORT -*/
     #define LWIP_ETHERNET 1
     /*----- Value in opt.h for LWIP_DNS_SECURE: (LWIP_DNS_SECURE_RAND_XID | LWIP_DNS_SECURE_NO_MULTIPLE_OUTSTANDING | LWIP_DNS_SECURE_RAND_SRC_PORT) -*/
@@ -162,6 +162,7 @@ extern "C" {
     #define LWIP_COMPAT_SOCKETS          0
     #define LWIP_ALTCP                   1
     #define LWIP_HTTPD_DYNAMIC_FILE_READ 1
+    #define LWIP_TIMERS                  1
 
     #define HTTPD_SERVER_AGENT "PrusaLink"
     #define LWIP_DNS           1


### PR DESCRIPTION
Apparently, we didn't have them working, the reason being that there
were not enough slots available and as TCP turns its timer off and on
again, it lost the slot eventually.

This fixes:

* Connections timing out.
* Reaping connections in time-wait.
* Retransmits.
* Likely other „weird“ connection problems related to this.