### PR TITLE
WUI: Rename temporary upload file

### DIFF
--- a/lib/WUI/http/upload_state.cpp
+++ b/lib/WUI/http/upload_state.cpp
@@ -64,7 +64,7 @@ constexpr const char *const FILENAME = "filename";
 constexpr const char *const FILE = "file";
 constexpr const char *const PRINT = "print";
 // FIXME: Have a separate one for parallel uploads
-constexpr const char *const DEFAULT_UPLOAD_FILENAME = "tmp.gcode";
+constexpr const char *const DEFAULT_UPLOAD_FILENAME = "upload.tmp";
 
 const constexpr size_t MAX_SUBTOKEN = 19;
 

--- a/tests/unit/lib/WUI/http/multipart_upload.cpp
+++ b/tests/unit/lib/WUI/http/multipart_upload.cpp
@@ -230,11 +230,11 @@ TEST_CASE("One Big Chunk") {
 
     const auto &log = test.log();
     REQUIRE(log.start.has_value());
-    REQUIRE(log.start->filename == "tmp.gcode");
+    REQUIRE(log.start->filename == "upload.tmp");
     REQUIRE(log.data.size() == 1);
     REQUIRE(log.data[0] == GCODE_LINE1);
     REQUIRE(log.finish.has_value());
-    REQUIRE(log.finish->tmp_filename == "tmp.gcode");
+    REQUIRE(log.finish->tmp_filename == "upload.tmp");
     REQUIRE(log.finish->final_filename == "test.gcode");
     REQUIRE_FALSE(log.finish->print);
 }
@@ -260,11 +260,11 @@ TEST_CASE("Handling multiple parts") {
 
     const auto &log = test.log();
     REQUIRE(log.start.has_value());
-    REQUIRE(log.start->filename == "tmp.gcode");
+    REQUIRE(log.start->filename == "upload.tmp");
     REQUIRE(log.data.size() == 1);
     REQUIRE(log.data[0] == GCODE_LINE1);
     REQUIRE(log.finish.has_value());
-    REQUIRE(log.finish->tmp_filename == "tmp.gcode");
+    REQUIRE(log.finish->tmp_filename == "upload.tmp");
     REQUIRE(log.finish->final_filename == "test.gcode");
     REQUIRE(log.finish->print == expect_start);
     REQUIRE(test.error() == 0);
@@ -282,14 +282,14 @@ TEST_CASE("Chunked") {
 
     const auto &log = test.log();
     REQUIRE(log.start.has_value());
-    REQUIRE(log.start->filename == "tmp.gcode");
+    REQUIRE(log.start->filename == "upload.tmp");
     string result;
     for (const auto &chunk : log.data) {
         result += chunk;
     }
     REQUIRE(result == GCODE_LINE1);
     REQUIRE(log.finish.has_value());
-    REQUIRE(log.finish->tmp_filename == "tmp.gcode");
+    REQUIRE(log.finish->tmp_filename == "upload.tmp");
     REQUIRE(log.finish->final_filename == "test.gcode");
     REQUIRE(log.finish->print);
     REQUIRE(test.error() == 0);
@@ -301,11 +301,11 @@ TEST_CASE("Extra spaces") {
 
     const auto &log = test.log();
     REQUIRE(log.start.has_value());
-    REQUIRE(log.start->filename == "tmp.gcode");
+    REQUIRE(log.start->filename == "upload.tmp");
     REQUIRE(log.data.size() == 1);
     REQUIRE(log.data[0] == GCODE_LINE1);
     REQUIRE(log.finish.has_value());
-    REQUIRE(log.finish->tmp_filename == "tmp.gcode");
+    REQUIRE(log.finish->tmp_filename == "upload.tmp");
     REQUIRE(log.finish->final_filename == "test.gcode");
     REQUIRE_FALSE(log.finish->print);
     REQUIRE(test.error() == 0);
@@ -321,11 +321,11 @@ TEST_CASE("Prolog and epilogue") {
 
     const auto &log = test.log();
     REQUIRE(log.start.has_value());
-    REQUIRE(log.start->filename == "tmp.gcode");
+    REQUIRE(log.start->filename == "upload.tmp");
     REQUIRE(log.data.size() == 1);
     REQUIRE(log.data[0] == GCODE_LINE1);
     REQUIRE(log.finish.has_value());
-    REQUIRE(log.finish->tmp_filename == "tmp.gcode");
+    REQUIRE(log.finish->tmp_filename == "upload.tmp");
     REQUIRE(log.finish->final_filename == "test.gcode");
     REQUIRE_FALSE(log.finish->print);
     REQUIRE(test.error() == 0);
@@ -352,7 +352,7 @@ TEST_CASE("Incomplete upload") {
 
     const auto &log = test.log();
     REQUIRE(log.start.has_value());
-    REQUIRE(log.start->filename == "tmp.gcode");
+    REQUIRE(log.start->filename == "upload.tmp");
     REQUIRE(log.data.size() == 1);
     REQUIRE(log.data[0] == GCODE_LINE1);
     REQUIRE(log.finish.has_value());
@@ -382,7 +382,7 @@ TEST_CASE("Propagate errors from hooks") {
 
     const auto &log = test.log();
     REQUIRE(log.start.has_value());
-    REQUIRE(log.start->filename == "tmp.gcode");
+    REQUIRE(log.start->filename == "upload.tmp");
     REQUIRE_FALSE(log.finish.has_value());
 }
 


### PR DESCRIPTION
Don't give it a .gcode extension. This'll prevent the GUI from ever
showing it. This previously could happen in various corner cases like:

* When the printer got restarted during upload, the file got left in
  place (at least until overwritten by next upload) and the user selects
  it in the menu.
* When the user opens the print dialog during upload.
* When there are two uploads close after one another ‒ the first one
  signals the GUI to show the single-click print dialog, but if second
  upload starts before it is shown, the dialog would then open the
  temporary file of the second upload (and explode spectacularly, as the
  same file got opened for both reading and writing at the same time).

Naming it differently makes the GUI ignore such file.