### PR TITLE
signature: Add FW signature state into QR code and URL

### DIFF
--- a/src/common/shared_config.h
+++ b/src/common/shared_config.h
@@ -17,7 +17,7 @@ static const uint8_t APPENDIX_FLAG_MASK = 0x01;
 typedef struct {
     uint8_t fw_update_flag;
     uint8_t model_specific_flags; // ~ "reserved1" originally
-    uint8_t reserved2;
+    uint8_t fw_signature;
     uint8_t reserved3;
     uint8_t reserved4;
     uint8_t reserved5;

--- a/src/common/support_utils.cpp
+++ b/src/common/support_utils.cpp
@@ -60,9 +60,8 @@ void printerCode(char *str) {
         str[i] = to32((uint8_t *)hash, i * 5);
     }
 
-    /// set first 2 bits (sign, appendix)
-    /// TODO FW sign
-    if (0) {
+    /// set signature state
+    if (signature_exist()) {
         setBit((uint8_t *)hash, 7);
         // setBit(str[0], 7);
     }
@@ -189,4 +188,11 @@ bool appendix_exist() {
 #endif
         return pinState == GPIO_PIN_RESET;
     }
+}
+
+bool signature_exist() {
+    const version_t *bootloader = (const version_t *)BOOTLOADER_VERSION_ADDRESS;
+    if (bootloader->major >= 1 && bootloader->minor >= 2)
+        return ram_data_exchange.fw_signature;
+    return false;
 }

--- a/src/common/support_utils.h
+++ b/src/common/support_utils.h
@@ -16,6 +16,7 @@ extern void create_path_info_4service(char *str, const uint32_t str_size);
 extern void printerCode(char *str);
 
 extern bool appendix_exist();
+extern bool signature_exist();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
FW signature state is taken from the bootloader's shared RAM.
BFW-2384