### PR TITLE
Hotfix compiling debug on the master branch

### DIFF
--- a/src/marlin_stubs/M300.cpp
+++ b/src/marlin_stubs/M300.cpp
@@ -1,8 +1,8 @@
 #ifdef _DEBUG
 
+    #include "../common/sound.hpp"
     #include "../../lib/Marlin/Marlin/src/gcode/parser.h"
     #include "PrusaGcodeSuite.hpp"
-    #include "../common/sound.hpp"
 
 /**
  * M300: Play beep sound S<frequency Hz> P<duration ms> V<volume>


### PR DESCRIPTION
Because one header defines a macro called `DEFAULT` and another defines an enum variant `DEBUG` and they collide.