### PR TITLE
eeprom: Fix initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -752,14 +752,6 @@ if(GUI)
             src/gui/screen_menu_footer_settings.cpp
             src/gui/screen_sheet_rename.cpp
             src/gui/screen_prusa_link.cpp
-            src/gui/test/screen_test.cpp
-            src/gui/test/screen_test_disp_mem.cpp
-            src/gui/test/screen_test_gui.cpp
-            src/gui/test/screen_test_term.cpp
-            src/gui/test/screen_test_msgbox.cpp
-            src/gui/test/screen_test_dlg.cpp
-            src/gui/test/screen_test_wizard_icons.cpp
-            src/gui/test/screen_test_graph.cpp
             src/gui/wizard/selftest.cpp
             src/gui/wizard/firstlay.cpp
             src/gui/wizard/screen_wizard.cpp
@@ -775,8 +767,6 @@ if(GUI)
             src/gui/screen_menu_tune.cpp
             src/gui/screen_menu_fw_update.cpp
             src/gui/screen_menu_esp_update.cpp
-            src/gui/test/screen_menu_test_temperature.cpp
-            src/gui/test/screen_mesh_bed_lv.cpp
             src/gui/screen_menu_eeprom.cpp
             src/gui/footer/footer_item_axis.cpp
             src/gui/footer/footer_item_fans.cpp
@@ -824,7 +814,21 @@ if(GUI)
 endif()
 
 if(GUI AND DEBUG) # gui and debug
-  target_sources(firmware PRIVATE src/gui/screen_menu_experimental_settings_debug.cpp)
+  target_sources(
+    firmware
+    PRIVATE src/gui/screen_menu_experimental_settings_debug.cpp
+            src/gui/test/screen_test.cpp
+            src/gui/test/screen_test_disp_mem.cpp
+            src/gui/test/screen_test_gui.cpp
+            src/gui/test/screen_test_term.cpp
+            src/gui/test/screen_test_msgbox.cpp
+            src/gui/test/screen_test_dlg.cpp
+            src/gui/test/screen_test_wizard_icons.cpp
+            src/gui/test/screen_test_graph.cpp
+            src/gui/test/screen_menu_eeprom_test.cpp
+            src/gui/test/screen_menu_test_temperature.cpp
+            src/gui/test/screen_mesh_bed_lv.cpp
+    )
 elseif(GUI) # gui, not debug
   target_sources(firmware PRIVATE src/gui/screen_menu_experimental_settings_mini.cpp)
 endif()

--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -716,11 +716,8 @@ static bool eeprom_convert_from(eeprom_vars_t &eevars) {
 static bool eeprom_check_crc32(const eeprom_vars_t &eevars) {
     if (eevars.DATASIZE > EEPROM_MAX_DATASIZE)
         return false;
-#if 1 //simple method
     uint32_t crc = crc32_eeprom((uint32_t *)(&eevars), (eevars.DATASIZE - 4) / 4);
     return eevars.CRC32 == crc;
-#else //
-#endif
 }
 
 static void eeprom_update_crc32() {

--- a/src/gui/screen_test.hpp
+++ b/src/gui/screen_test.hpp
@@ -8,15 +8,18 @@
 struct screen_test_data_t : public AddSuperWindow<screen_t> {
     window_text_t test;
     window_text_t back;
+    window_text_button_t tst_eeprom;
     window_text_button_t tst_gui;
     window_text_button_t tst_term;
     window_text_button_t tst_msgbox;
     window_text_button_t tst_wizard_icons;
     window_text_button_t tst_safety_dlg;
+#if 0
     window_text_button_t tst_graph;
     window_text_button_t tst_temperature;
     window_text_button_t tst_heat_err;
     window_text_button_t tst_disp_memory;
+#endif // 0
     window_text_button_t tst_stack_overflow;
     window_text_button_t tst_stack_div0;
     int8_t id_tim;

--- a/src/gui/test/screen_menu_eeprom_test.cpp
+++ b/src/gui/test/screen_menu_eeprom_test.cpp
@@ -1,0 +1,216 @@
+/**
+ * @file screen_menu_eeprom_test.cpp
+ * @author Radek Vana
+ * @date 2022-01-11
+ */
+
+#include "screen_menu_eeprom_test.hpp"
+#include "screen_menu.hpp"
+#include "MItem_menus.hpp"
+#include "eeprom.h"
+#include "WindowMenuSwitch.hpp"
+#include "WindowMenuSpin.hpp"
+#include "menu_spin_config.hpp"
+#include "ScreenHandler.hpp"
+
+enum class ClickCommand : intptr_t { Store,
+    ValueChanged };
+
+/**
+ * @brief store current record
+ *
+ */
+class MI_STORE : public WI_LABEL_t {
+    static constexpr const char *const label = N_("Store");
+
+public:
+    MI_STORE()
+        : WI_LABEL_t(_(label), 0, is_enabled_t::yes, is_hidden_t::no) {}
+
+protected:
+    virtual void click(IWindowMenu &window_menu) override {
+        Screens::Access()->Get()->WindowEvent(nullptr, GUI_event_t::CHILD_CLICK, (void *)ClickCommand::Store);
+    }
+};
+
+class SpinIntPart7 : public WiSpinInt {
+    constexpr static const char *const label = "0xXX-- ---- ---- ----";
+
+public:
+    SpinIntPart7()
+        : WiSpinInt(0, SpinCnf::two_digits_uint, _(label)) {}
+};
+
+class SpinIntPart6 : public WiSpinInt {
+    constexpr static const char *const label = "0x--XX ---- ---- ----";
+
+public:
+    SpinIntPart6()
+        : WiSpinInt(0, SpinCnf::two_digits_uint, _(label)) {}
+};
+
+class SpinIntPart5 : public WiSpinInt {
+    constexpr static const char *const label = "0x---- XX-- ---- ----";
+
+public:
+    SpinIntPart5()
+        : WiSpinInt(0, SpinCnf::two_digits_uint, _(label)) {}
+};
+
+class SpinIntPart4 : public WiSpinInt {
+    constexpr static const char *const label = "0x---- --XX ---- ----";
+
+public:
+    SpinIntPart4()
+        : WiSpinInt(0, SpinCnf::two_digits_uint, _(label)) {}
+};
+
+class SpinIntPart3 : public WiSpinInt {
+    constexpr static const char *const label = "0x---- ---- XX-- ----";
+
+public:
+    SpinIntPart3()
+        : WiSpinInt(0, SpinCnf::two_digits_uint, _(label)) {}
+};
+
+class SpinIntPart2 : public WiSpinInt {
+    constexpr static const char *const label = "0x---- ---- --XX ----";
+
+public:
+    SpinIntPart2()
+        : WiSpinInt(0, SpinCnf::two_digits_uint, _(label)) {}
+};
+
+class SpinIntPart1 : public WiSpinInt {
+    constexpr static const char *const label = "0x---- ---- ---- XX--";
+
+public:
+    SpinIntPart1()
+        : WiSpinInt(0, SpinCnf::two_digits_uint, _(label)) {}
+};
+
+class SpinIntPart0 : public WiSpinInt {
+    constexpr static const char *const label = "0x---- ---- ---- --XX";
+
+public:
+    SpinIntPart0()
+        : WiSpinInt(0, SpinCnf::two_digits_uint, _(label)) {}
+};
+
+class EepromItems : public IWiSwitch {
+    typename TextMemSpace_t::type ArrayMemSpace[EEVAR_CRC32]; //EEVAR_CRC32 == count
+public:
+    variant8_t var;
+
+    EepromItems()
+        : IWiSwitch(0, string_view_utf8::MakeCPUFLASH((const uint8_t *)"RECORD"), 0, is_enabled_t::yes, is_hidden_t::no, GenerateItems())
+        , var(eeprom_get_var(eevar_id(index))) // first records is int, no need to test it
+    {
+    }
+
+    IWiSwitch::Items_t GenerateItems() {
+        const size_t SZ = EEVAR_CRC32;
+        string_view_utf8 *pArr = (string_view_utf8 *)&ArrayMemSpace;
+        for (size_t i = 0; i < SZ; ++i) {
+            pArr[i] = string_view_utf8::MakeCPUFLASH((const uint8_t *)eeprom_get_var_name(eevar_id(i)));
+        }
+        Items_t ret = Items_t(pArr, SZ);
+        return ret;
+    }
+
+    //show only integers .. TODO float, string
+    virtual invalidate_t Change(int /*dif*/) override {
+        ++index;
+        index %= EEVAR_CRC32;
+        bool can_show = false;
+        while (!can_show) {
+            var = eeprom_get_var(eevar_id(index));
+            uint8_t type = variant8_get_type(var);
+            switch (type) {
+            case VARIANT8_I8:
+            case VARIANT8_UI8:
+            case VARIANT8_I16:
+            case VARIANT8_UI16:
+            case VARIANT8_I32:
+            case VARIANT8_UI32:
+                can_show = true;
+                break;
+            default:
+                ++index;
+                index %= EEVAR_CRC32;
+            }
+        }
+
+        Screens::Access()->Get()->WindowEvent(nullptr, GUI_event_t::CHILD_CLICK, (void *)ClickCommand::ValueChanged);
+
+        return invalidate_t::yes;
+    }
+};
+
+/*****************************************************************************/
+//Screen
+using Screen = ScreenMenu<EFooter::Off, MI_RETURN, EepromItems, MI_STORE, SpinIntPart7, SpinIntPart6, SpinIntPart5, SpinIntPart4, SpinIntPart3, SpinIntPart2, SpinIntPart1, SpinIntPart0>;
+
+class ScreenMenuEepromTest : public Screen {
+    constexpr static const char *label = "Eeprom Test";
+
+    void storeValue() {
+        uint32_t value = Item<SpinIntPart7>().GetVal();
+        value <<= 4;
+        value |= Item<SpinIntPart6>().GetVal();
+        value <<= 4;
+        value |= Item<SpinIntPart5>().GetVal();
+        value <<= 4;
+        value |= Item<SpinIntPart4>().GetVal();
+        value <<= 4;
+        value |= Item<SpinIntPart3>().GetVal();
+        value <<= 4;
+        value |= Item<SpinIntPart2>().GetVal();
+        value <<= 4;
+        value |= Item<SpinIntPart1>().GetVal();
+        value <<= 4;
+        value |= Item<SpinIntPart0>().GetVal();
+
+        variant8_t var = variant8_ui32(value);                               // create variant as uint32_t
+        variant8_set_type(&var, variant8_get_type(Item<EepromItems>().var)); // change variant type to correct one
+        eeprom_set_var(eevar_id(Item<EepromItems>().GetIndex()), var);       // store to eeprom
+    }
+
+    void updateValue() {
+        uint32_t value = variant8_get_ui32(Item<EepromItems>().var);
+        Item<SpinIntPart7>().SetVal(int((value >> 28) & 0x0F));
+        Item<SpinIntPart6>().SetVal(int((value >> 24) & 0x0F));
+        Item<SpinIntPart5>().SetVal(int((value >> 20) & 0x0F));
+        Item<SpinIntPart4>().SetVal(int((value >> 16) & 0x0F));
+        Item<SpinIntPart3>().SetVal(int((value >> 12) & 0x0F));
+        Item<SpinIntPart2>().SetVal(int((value >> 8) & 0x0F));
+        Item<SpinIntPart1>().SetVal(int((value >> 4) & 0x0F));
+        Item<SpinIntPart0>().SetVal(int((value >> 0) & 0x0F));
+    }
+
+public:
+    ScreenMenuEepromTest()
+        : Screen(string_view_utf8::MakeCPUFLASH((const uint8_t *)label)) {
+        updateValue();
+    }
+
+    virtual void windowEvent(EventLock /*has private ctor*/, window_t *sender, GUI_event_t ev, void *param) override {
+        if (ev != GUI_event_t::CHILD_CLICK) {
+            SuperWindowEvent(sender, ev, param);
+            return;
+        }
+
+        switch (ClickCommand(intptr_t(param))) {
+        case ClickCommand::Store:
+            storeValue();
+            break;
+        case ClickCommand::ValueChanged:
+            updateValue();
+            break;
+        }
+    }
+};
+
+ScreenFactory::UniquePtr GetScreenMenuEepromTest() {
+    return ScreenFactory::Screen<ScreenMenuEepromTest>();
+}

--- a/src/gui/test/screen_menu_eeprom_test.hpp
+++ b/src/gui/test/screen_menu_eeprom_test.hpp
@@ -1,0 +1,11 @@
+/**
+ * @file screen_menu_eeprom_test.hpp
+ * @author Radek Vana
+ * @brief screen to test eeprom
+ * @date 2022-01-11
+ */
+
+#pragma once
+
+#include "ScreenFactory.hpp"
+ScreenFactory::UniquePtr GetScreenMenuEepromTest();

--- a/src/gui/test/screen_test.cpp
+++ b/src/gui/test/screen_test.cpp
@@ -10,6 +10,7 @@
 #include "screen_test_msgbox.hpp"
 #include "screen_test_wizard_icons.hpp"
 #include "screen_test_dlg.hpp"
+#include "screen_menu_eeprom_test.hpp"
 
 //fererate stack overflow
 static volatile int _recursive = 1;
@@ -22,64 +23,38 @@ static volatile void recursive(uint64_t i) {
 
 screen_test_data_t::screen_test_data_t()
     : AddSuperWindow<screen_t>()
-    , test(this, Rect16(10, 32, 220, 22), is_multiline::no)
-    , back(this, Rect16(10, 54, 220, 22), is_multiline::no, is_closed_on_click_t::yes)
-    , tst_gui(this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(ScreenFactory::Screen<screen_test_gui_data_t>); })
-    , tst_term(this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(ScreenFactory::Screen<screen_test_term_data_t>); })
-    , tst_msgbox(this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(ScreenFactory::Screen<screen_test_msgbox_data_t>); })
-    , tst_wizard_icons(this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(ScreenFactory::Screen<screen_test_wizard_icons>); })
-    , tst_safety_dlg(this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(ScreenFactory::Screen<screen_test_dlg_data_t>); })
-    , tst_graph(this, this->GenerateRect(ShiftDir_t::Bottom), []() { /*screen_open(get_scr_test_graph()->id);*/ })
-    , tst_temperature(this, this->GenerateRect(ShiftDir_t::Bottom), []() { /*screen_open(get_scr_test_temperature()->id);*/ })
-    , tst_heat_err(this, this->GenerateRect(ShiftDir_t::Bottom), []() { /*("TEST BED ERROR", "Bed", 1.0, 2.0, 3.0, 4.0);*/ })
-    , tst_disp_memory(this, this->GenerateRect(ShiftDir_t::Bottom), []() { /*screen_open(get_scr_test_disp_mem()->id);*/ })
-    , tst_stack_overflow(this, this->GenerateRect(ShiftDir_t::Bottom), []() { recursive(0); })
-    , tst_stack_div0(this, this->GenerateRect(ShiftDir_t::Bottom), []() {
-        static volatile int i = 0;
+    , test(this, Rect16(10, 32, 220, 22), is_multiline::no, is_closed_on_click_t::no, string_view_utf8::MakeCPUFLASH((const uint8_t *)"TEST"))
+    , back(this, Rect16(10, 54, 220, 22), is_multiline::no, is_closed_on_click_t::yes, string_view_utf8::MakeCPUFLASH((const uint8_t *)"back"))
+    , tst_eeprom(
+          this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(GetScreenMenuEepromTest); }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"test EEPROM"))
+    , tst_gui(
+          this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(ScreenFactory::Screen<screen_test_gui_data_t>); }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"test GUI"))
+    , tst_term(
+          this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(ScreenFactory::Screen<screen_test_term_data_t>); }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"test TERM"))
+    , tst_msgbox(
+          this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(ScreenFactory::Screen<screen_test_msgbox_data_t>); }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"test MSGBOX"))
+    , tst_wizard_icons(
+          this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(ScreenFactory::Screen<screen_test_wizard_icons>); }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"test Wizard icons"))
+    , tst_safety_dlg(
+          this, this->GenerateRect(ShiftDir_t::Bottom), []() { Screens::Access()->Open(ScreenFactory::Screen<screen_test_dlg_data_t>); }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"test dialog"))
+#if 0
+    , tst_graph(this, this->GenerateRect(ShiftDir_t::Bottom), []() { /*screen_open(get_scr_test_graph()->id);*/ }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"temp graph"))
+    , tst_temperature(this, this->GenerateRect(ShiftDir_t::Bottom), []() { /*screen_open(get_scr_test_temperature()->id);*/ }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"temp - pwm"))
+    , tst_heat_err(this, this->GenerateRect(ShiftDir_t::Bottom), []() { /*("TEST BED ERROR", "Bed", 1.0, 2.0, 3.0, 4.0);*/ }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"HEAT ERROR"))
+    , tst_disp_memory(this, this->GenerateRect(ShiftDir_t::Bottom), []() { /*screen_open(get_scr_test_disp_mem()->id);*/ }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"Disp. R/W"))
+#endif // 0
+    , tst_stack_overflow(
+          this, this->GenerateRect(ShiftDir_t::Bottom), []() { recursive(0); }, string_view_utf8::MakeCPUFLASH((const uint8_t *)"Stack overflow"))
+    , tst_stack_div0(
+          this, this->GenerateRect(ShiftDir_t::Bottom), []() {
+              static volatile int i = 0;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdiv-by-zero"
-        i = i / 0;
+              i = i / 0;
 #pragma GCC diagnostic pop
-    })
+          },
+          string_view_utf8::MakeCPUFLASH((const uint8_t *)"BSOD div 0"))
     , id_tim(gui_timer_create_oneshot(this, 2000))  //id0
     , id_tim1(gui_timer_create_oneshot(this, 2000)) //id0
 {
-    static const char tst[] = "TEST";
-    test.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)tst));
-
-    static const char bck[] = "back";
-    back.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)bck));
-
-    static const char tstg[] = "test GUI";
-    tst_gui.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)tstg));
-
-    static const char tstt[] = "test TERM";
-    tst_term.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)tstt));
-
-    static const char tstm[] = "test MSGBOX";
-    tst_msgbox.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)tstm));
-
-    static const char tswi[] = "test Wizard icons";
-    tst_wizard_icons.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)tswi));
-
-    static const char tssd[] = "test dialog";
-    tst_safety_dlg.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)tssd));
-
-    static const char tmpg[] = "temp graph";
-    tst_graph.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)tmpg));
-
-    static const char tmpp[] = "temp - pwm";
-    tst_temperature.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)tmpp));
-
-    static const char he[] = "HEAT ERROR";
-    tst_heat_err.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)he));
-
-    static const char drw[] = "Disp. R/W";
-    tst_disp_memory.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)drw));
-
-    static const char so[] = "Stack overflow";
-    tst_stack_overflow.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)so));
-
-    static const char d0[] = "BSOD div 0";
-    tst_stack_div0.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)d0));
 }

--- a/src/guiapi/include/menu_spin_config.hpp
+++ b/src/guiapi/include/menu_spin_config.hpp
@@ -24,4 +24,5 @@ struct SpinCnf {
     static const SpinConfigInt steps_per_unit;
     static const SpinConfigInt microstep_exponential; // 2^0 - 2^8 .. 1, 2, 4, .. , 128, 256
     static const SpinConfigInt rms_current;
+    static const SpinConfigInt two_digits_uint;
 };

--- a/src/guiapi/src/menu_spin_config_basic.cpp
+++ b/src/guiapi/src/menu_spin_config_basic.cpp
@@ -22,3 +22,4 @@ const std::array<SpinConfigInt, MenuVars::AXIS_CNT> SpinCnf::axis_ranges = { { S
 const SpinConfigInt SpinCnf::steps_per_unit = SpinConfigInt(MenuVars::steps_per_unit_range);
 const SpinConfigInt SpinCnf::microstep_exponential = SpinConfigInt(MenuVars::microstep_exponential_range);
 const SpinConfigInt SpinCnf::rms_current = SpinConfigInt(MenuVars::axis_rms_currents_range);
+const SpinConfigInt SpinCnf::two_digits_uint = { { 0, 15, 1 } };

--- a/src/guiapi/src/menu_spin_config_with_units.cpp
+++ b/src/guiapi/src/menu_spin_config_with_units.cpp
@@ -32,3 +32,4 @@ const std::array<SpinConfigInt, MenuVars::AXIS_CNT> SpinCnf::axis_ranges = { { S
 const SpinConfigInt SpinCnf::steps_per_unit = SpinConfigInt(MenuVars::steps_per_unit_range, None);
 const SpinConfigInt SpinCnf::microstep_exponential = SpinConfigInt(MenuVars::microstep_exponential_range, None);
 const SpinConfigInt SpinCnf::rms_current = SpinConfigInt(MenuVars::axis_rms_currents_range, mA);
+const SpinConfigInt SpinCnf::two_digits_uint = { { 0, 15, 1 }, None };


### PR DESCRIPTION
eeprom: Fix initialization, read eeprom only once to avoid need of multiple crc checks
disable unused test, because they currently does not fit on screen
BFW-2380