### PR TITLE
GUI: Don't send encoder event if encoder hasn't moved

### DIFF
--- a/src/common/marlin_client.c
+++ b/src/common/marlin_client.c
@@ -734,7 +734,7 @@ static void _send_request_to_server(uint8_t client_id, const char *request) {
     }
 }
 
-// wait for ack event, blocking - used for synchronization, called typicaly at end of client request functions
+// wait for ack event, blocking - used for synchronization, called typically at end of client request functions
 static uint32_t _wait_ack_from_server_with_callback(uint8_t client_id, void (*cb)()) {
     while ((marlin_client[client_id].events & MARLIN_EVT_MSK(MARLIN_EVT_Acknowledge)) == 0) {
         marlin_client_loop();

--- a/src/guiapi/src/window.cpp
+++ b/src/guiapi/src/window.cpp
@@ -415,11 +415,11 @@ void window_t::ResetFocusedWindow() {
 bool window_t::IsCaptured() const { return Screens::Access()->Get()->GetCapturedWindow() == this; }
 
 bool window_t::EventEncoder(int diff) {
-    marlin_notify_server_about_encoder_move();
-    window_t *capture_ptr = Screens::Access()->Get()->GetCapturedWindow();
     if (diff == 0)
         return false;
 
+    marlin_notify_server_about_encoder_move();
+    window_t *capture_ptr = Screens::Access()->Get()->GetCapturedWindow();
     Screens::Access()->ScreenEvent(nullptr, GUI_event_t::ENC_CHANGE, (void *)(intptr_t)diff);
 
     if (!capture_ptr)


### PR DESCRIPTION
Encoder event was sent also when the knob was pressed. This could caused GUI to freeze.