### PR TITLE
prusa_link: Don't set busy when printing

### DIFF
--- a/lib/WUI/wui_REST_api.c
+++ b/lib/WUI/wui_REST_api.c
@@ -39,7 +39,7 @@ void get_printer(char *data, const uint32_t buf_len) {
 
     switch (vars->print_state) {
     case mpsPrinting:
-        printing = busy = true;
+        printing = true;
         ready = operational = false;
         break;
     case mpsPausing_Begin:


### PR DESCRIPTION
The busy flag reportedly means something like changing filament and
similar ‒ times when the printer doesn't want to talk to outside world.

The bigger problem is it disables the controls on the web, which we
don't want during the whole print.