### PR TITLE
pause: Change filament without return to original position

### DIFF
--- a/src/marlin_stubs/pause/M600.cpp
+++ b/src/marlin_stubs/pause/M600.cpp
@@ -83,6 +83,7 @@ void GcodeSuite::M600() {
 #endif
 
     park_point.z += current_position.z;
+    static const xyze_float_t no_return = { NAN, NAN, NAN, current_position.e };
     Pause &pause = Pause::Instance();
 
     //NAN == default
@@ -91,7 +92,7 @@ void GcodeSuite::M600() {
     pause.SetFastLoadLength(parser.seen('L') ? parser.value_axis_units(E_AXIS) : NAN);
     pause.SetPurgeLength(NAN);
     pause.SetParkPoint(park_point);
-    pause.SetResumePoint(current_position);
+    pause.SetResumePoint(parser.seen('N') ? no_return : current_position);
     pause.SetRetractLength(std::abs(parser.seen('E') ? parser.value_axis_units(E_AXIS) : NAN)); // Initial retract before move to filament change position
 
     float disp_temp = marlin_server_get_temp_to_display();

--- a/src/marlin_stubs/pause/pause.cpp
+++ b/src/marlin_stubs/pause/pause.cpp
@@ -567,6 +567,8 @@ void Pause::park_nozzle_and_notify() {
 }
 
 void Pause::unpark_nozzle_and_notify() {
+    if (resume_pos.x == NAN || resume_pos.y == NAN || resume_pos.z == NAN)
+        return;
 
     setPhase(PhasesLoadUnload::Unparking);
     // Move XY to starting position, then Z
@@ -703,7 +705,7 @@ Pause::FSM_HolderLoadUnload::~FSM_HolderLoadUnload() {
 
     const float min_layer_h = 0.05f;
     //do not unpark and wait for temp if not homed or z park len is 0
-    if (!axes_need_homing() && std::abs(current_position.z - pause.resume_pos.z) >= min_layer_h) {
+    if (!axes_need_homing() && pause.resume_pos.z != NAN && std::abs(current_position.z - pause.resume_pos.z) >= min_layer_h) {
         pause.ensureSafeTemperatureNotifyProgress(0, 100);
         pause.unpark_nozzle_and_notify();
     }


### PR DESCRIPTION
If you print in more colors you don't want to return to point where you finished because it will spill a drop of filament of different color there. M600 R will allow to continue at the right place.