### PR TITLE
Eeprom fixes

### DIFF
--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -883,7 +883,7 @@ uint32_t sheet_next_calibrated() {
     uint8_t index = variant8_get_ui8(eeprom_get_var(EEVAR_ACTIVE_SHEET));
 
     for (int8_t i = 1; i < MAX_SHEETS; ++i) {
-        if (sheet_select((index + i) % MAX_SHEETS))
+        if (sheet_profile_select((index + i) % MAX_SHEETS))
             return (index + i) % MAX_SHEETS;
     }
 #else
@@ -903,28 +903,16 @@ bool sheet_is_calibrated(uint32_t index) {
 #endif
 }
 
-bool sheet_select(uint32_t index) {
+bool sheet_profile_select(uint32_t index) {
 #if (EEPROM_FEATURES & EEPROM_FEATURE_SHEETS)
-    if (index >= MAX_SHEETS || !sheet_is_calibrated(index))
+    if (index >= MAX_SHEETS)
         return false;
     float z_offset = FLT_MAX;
     eeprom_get_var(static_cast<enum eevar_id>(EEVAR_SHEET_PROFILE0 + index), &z_offset, sizeof(z_offset));
 
     uint8_t index_ui8 = index;
     eeprom_set_var(EEVAR_ACTIVE_SHEET, &index_ui8, sizeof(index_ui8));
-    eeprom_set_var(EEVAR_ZOFFSET, &z_offset, sizeof(float));
-    return true;
-#else
-    log_info(EEPROM, "called %s while EEPROM_FEATURE_SHEETS is disabled", __PRETTY_FUNCTION__);
-    return index == 0;
-#endif
-}
-
-bool sheet_calibrate(uint32_t index) {
-#if (EEPROM_FEATURES & EEPROM_FEATURE_SHEETS)
-    if (index >= MAX_SHEETS)
-        return false;
-    eeprom_set_var(EEVAR_ACTIVE_SHEET, &index, sizeof(index));
+    eeprom_set_var(EEVAR_ZOFFSET_DO_NOT_USE_DIRECTLY, &z_offset, sizeof(float));
     return true;
 #else
     log_info(EEPROM, "called %s while EEPROM_FEATURE_SHEETS is disabled", __PRETTY_FUNCTION__);

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -25,18 +25,20 @@ enum {
 
 enum eevar_id {
     // basic variables
-    EEVAR_VERSION = 0x00,         // uint16_t eeprom version
-    EEVAR_FEATURES = 0x01,        // uint16_t feature mask
-    EEVAR_DATASIZE = 0x02,        // uint16_t eeprom data size
-    EEVAR_FW_VERSION = 0x03,      // uint16_t encoded firmware version (e.g. 403 for 4.0.3)
-    EEVAR_FW_BUILD = 0x04,        // uint16_t firmware build number
-    EEVAR_FILAMENT_TYPE = 0x05,   // uint8_t  filament type
-    EEVAR_FILAMENT_COLOR = 0x06,  // uint32_t filament color (rgb)
-    EEVAR_RUN_SELFTEST = 0x07,    // uint8_t  selftest flag
-    EEVAR_RUN_XYZCALIB = 0x08,    // uint8_t  xyz calibration flag
-    EEVAR_RUN_FIRSTLAY = 0x09,    // uint8_t  first layer calibration flag
-    EEVAR_FSENSOR_ENABLED = 0x0a, // uint8_t  fsensor state
-    EEVAR_ZOFFSET = 0x0b,         // float    zoffset
+    EEVAR_VERSION = 0x00,                     // uint16_t eeprom version
+    EEVAR_FEATURES = 0x01,                    // uint16_t feature mask
+    EEVAR_DATASIZE = 0x02,                    // uint16_t eeprom data size
+    EEVAR_FW_VERSION = 0x03,                  // uint16_t encoded firmware version (e.g. 403 for 4.0.3)
+    EEVAR_FW_BUILD = 0x04,                    // uint16_t firmware build number
+    EEVAR_FILAMENT_TYPE = 0x05,               // uint8_t  filament type
+    EEVAR_FILAMENT_COLOR = 0x06,              // uint32_t filament color (rgb)
+    EEVAR_RUN_SELFTEST = 0x07,                // uint8_t  selftest flag
+    EEVAR_RUN_XYZCALIB = 0x08,                // uint8_t  xyz calibration flag
+    EEVAR_RUN_FIRSTLAY = 0x09,                // uint8_t  first layer calibration flag
+    EEVAR_FSENSOR_ENABLED = 0x0a,             // uint8_t  fsensor state
+    EEVAR_ZOFFSET_DO_NOT_USE_DIRECTLY = 0x0b, // float zoffset
+// use float eeprom_get_z_offset() / bool eeprom_set_z_offset(float value) instead
+// because EEVAR_ZOFFSET_DO_NOT_USE_DIRECTLY is unused in case sheets are enabled
 
 // nozzle PID variables
 #if (EEPROM_FEATURES & EEPROM_FEATURE_PID_NOZ)
@@ -211,6 +213,25 @@ extern void eeprom_clear(void);
 
 // PUT test
 int8_t eeprom_test_PUT(const unsigned int);
+
+/**
+ * @brief reads Z offset, directly or from current sheet if sheets are enabled
+ *
+ * @return float Z offset
+ */
+float eeprom_get_z_offset();
+
+/**
+ * @brief writes Z offset, directly or to current sheet if sheets are enabled
+ *
+ * @param value value to set
+ * @return true successfully set
+ * @return false sheet index stored in eeprom corrupted
+ */
+bool eeprom_set_z_offset(float value);
+
+// TODO sheet accesing functions should not be part of eeprom
+// eeprom should not have knowledge about how sheet calibration process
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Iterate across the profiles and switch to the next calibrated.

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -18,9 +18,21 @@ enum {
 #define EEPROM_FEATURE_LAN     0x0004
 #define EEPROM_FEATURE_SHEETS  0x0008
 #define EEPROM_FEATURES        (EEPROM_FEATURE_PID_NOZ | EEPROM_FEATURE_PID_BED | EEPROM_FEATURE_LAN | EEPROM_FEATURE_SHEETS)
-
+#define DEFAULT_HOST_NAME      "PrusaMINI"
 enum {
     MAX_SHEET_NAME_LENGTH = 8,
+};
+
+// sheets must be defined even when they are not used, to be able to import data from old eeprom
+typedef struct
+{
+    char name[MAX_SHEET_NAME_LENGTH]; //!< Can be null terminated, doesn't need to be null terminated
+    float z_offset;                   //!< Z_BABYSTEP_MIN .. Z_BABYSTEP_MAX = Z_BABYSTEP_MIN*2/1000 [mm] .. Z_BABYSTEP_MAX*2/1000 [mm]
+} Sheet;
+
+enum {
+    MAX_SHEETS = 8,
+    EEPROM_SHEET_SIZEOF = sizeof(Sheet)
 };
 
 enum eevar_id {

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -234,19 +234,10 @@ extern bool sheet_is_calibrated(uint32_t);
 /// @brief Select the given print sheet profile as an active for the printer.
 ///
 /// In case the index of the given print sheet profile is bigger than the
-/// MAX_SHEETS or sheet is not calibrated method return false.
+/// MAX_SHEETS return false.
 /// @param[in] index Index of the sheet profile
 /// @return True when the profile can be selected, False othewise.
-extern bool sheet_select(uint32_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Calibrate the given print sheet profile as an active for the printer.
-///
-/// In case the index of the given print sheet profile is bigger than the
-/// MAX_SHEETS method return false.
-/// @param[in] index Index of the sheet profile
-/// @return True when the profile can be selected, False othewise.
-extern bool sheet_calibrate(uint32_t);
+extern bool sheet_profile_select(uint32_t);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Reset the given print sheet profile to the uncalibrated state.

--- a/src/common/eeprom_v10.hpp
+++ b/src/common/eeprom_v10.hpp
@@ -1,0 +1,159 @@
+/**
+ * @file eeprom_v10.hpp
+ * @author Radek Vana
+ * @brief old version of eeprom, to be able to import it
+ * version 10 from release 4.3.3-RC
+ * without padding and crc since they are not imported and would not match anyway
+ * @date 2022-01-17
+ */
+
+#include "eeprom_v9.hpp"
+
+namespace eeprom::v10 {
+
+#pragma once
+#pragma pack(push)
+#pragma pack(1)
+
+/**
+ * @brief body od eeprom v10
+ * without head, padding and crc
+ */
+struct vars_body_t {
+    uint8_t FILAMENT_TYPE;
+    uint32_t FILAMENT_COLOR;
+    uint8_t RUN_SELFTEST;
+    uint8_t RUN_XYZCALIB;
+    uint8_t RUN_FIRSTLAY;
+    uint8_t FSENSOR_ENABLED;
+    float ZOFFSET;
+    float PID_NOZ_P;
+    float PID_NOZ_I;
+    float PID_NOZ_D;
+    float PID_BED_P;
+    float PID_BED_I;
+    float PID_BED_D;
+    uint8_t LAN_FLAG;
+    uint32_t LAN_IP4_ADDR;
+    uint32_t LAN_IP4_MSK;
+    uint32_t LAN_IP4_GW;
+    uint32_t LAN_IP4_DNS1;
+    uint32_t LAN_IP4_DNS2;
+    char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
+    int8_t TIMEZONE;
+    uint8_t SOUND_MODE;
+    uint8_t SOUND_VOLUME;
+    uint16_t LANGUAGE;
+    uint8_t FILE_SORT;
+    uint8_t MENU_TIMEOUT;
+    uint8_t ACTIVE_SHEET;
+    Sheet SHEET_PROFILE0;
+    Sheet SHEET_PROFILE1;
+    Sheet SHEET_PROFILE2;
+    Sheet SHEET_PROFILE3;
+    Sheet SHEET_PROFILE4;
+    Sheet SHEET_PROFILE5;
+    Sheet SHEET_PROFILE6;
+    Sheet SHEET_PROFILE7;
+    uint32_t SELFTEST_RESULT;
+    uint8_t DEVHASH_IN_QR;
+    uint32_t FOOTER_SETTING;
+    uint32_t FOOTER_DRAW_TYPE;
+    uint8_t FAN_CHECK_ENABLED;
+    uint8_t FS_AUTOLOAD_ENABLED;
+    float EEVAR_ODOMETER_X;
+    float EEVAR_ODOMETER_Y;
+    float EEVAR_ODOMETER_Z;
+    float EEVAR_ODOMETER_E0;
+    float AXIS_STEPS_PER_UNIT_X;
+    float AXIS_STEPS_PER_UNIT_Y;
+    float AXIS_STEPS_PER_UNIT_Z;
+    float AXIS_STEPS_PER_UNIT_E0;
+    uint16_t AXIS_MICROSTEPS_X;
+    uint16_t AXIS_MICROSTEPS_Y;
+    uint16_t AXIS_MICROSTEPS_Z;
+    uint16_t AXIS_MICROSTEPS_E0;
+    uint16_t AXIS_RMS_CURRENT_MA_X;
+    uint16_t AXIS_RMS_CURRENT_MA_Y;
+    uint16_t AXIS_RMS_CURRENT_MA_Z;
+    uint16_t AXIS_RMS_CURRENT_MA_E0;
+    float AXIS_Z_MAX_POS_MM;
+    uint32_t ODOMETER_TIME;
+};
+
+#pragma pack(pop)
+
+static constexpr float default_axis_steps_flt[4] = DEFAULT_AXIS_STEPS_PER_UNIT;
+
+constexpr vars_body_t body_defaults = {
+    0,                         // EEVAR_FILAMENT_TYPE
+    0,                         // EEVAR_FILAMENT_COLOR
+    1,                         // EEVAR_RUN_SELFTEST
+    1,                         // EEVAR_RUN_XYZCALIB
+    1,                         // EEVAR_RUN_FIRSTLAY
+    1,                         // EEVAR_FSENSOR_ENABLED
+    0,                         // EEVAR_ZOFFSET
+    DEFAULT_Kp,                // EEVAR_PID_NOZ_P
+    scalePID_i(DEFAULT_Ki),    // EEVAR_PID_NOZ_I
+    scalePID_d(DEFAULT_Kd),    // EEVAR_PID_NOZ_D
+    DEFAULT_bedKp,             // EEVAR_PID_BED_P
+    scalePID_i(DEFAULT_bedKi), // EEVAR_PID_BED_I
+    scalePID_d(DEFAULT_bedKd), // EEVAR_PID_BED_D
+    0,                         // EEVAR_LAN_FLAG
+    0,                         // EEVAR_LAN_IP4_ADDR
+    0,                         // EEVAR_LAN_IP4_MSK
+    0,                         // EEVAR_LAN_IP4_GW
+    0,                         // EEVAR_LAN_IP4_DNS1
+    0,                         // EEVAR_LAN_IP4_DNS2
+    DEFAULT_HOST_NAME,         // EEVAR_LAN_HOSTNAME
+    0,                         // EEVAR_TIMEZONE
+    0xff,                      // EEVAR_SOUND_MODE
+    5,                         // EEVAR_SOUND_VOLUME
+    0xffff,                    // EEVAR_LANGUAGE
+    0,                         // EEVAR_FILE_SORT
+    1,                         // EEVAR_MENU_TIMEOUT
+    0,                         // EEVAR_ACTIVE_SHEET
+    { "Smooth1", 0.0f },
+    { "Smooth2", FLT_MAX },
+    { "Textur1", FLT_MAX },
+    { "Textur2", FLT_MAX },
+    { "Custom1", FLT_MAX },
+    { "Custom2", FLT_MAX },
+    { "Custom3", FLT_MAX },
+    { "Custom4", FLT_MAX },
+    0,                                                                          // EEVAR_SELFTEST_RESULT
+    1,                                                                          // EEVAR_DEVHASH_IN_QR
+    footer::eeprom::Encode(footer::DefaultItems),                               // EEVAR_FOOTER_SETTING
+    uint32_t(footer::ItemDrawCnf::Default()),                                   // EEVAR_FOOTER_DRAW_TYPE
+    1,                                                                          // EEVAR_FAN_CHECK_ENABLED
+    0,                                                                          // EEVAR_FS_AUTOLOAD_ENABLED
+    0,                                                                          // EEVAR_ODOMETER_X
+    0,                                                                          // EEVAR_ODOMETER_Y
+    0,                                                                          // EEVAR_ODOMETER_Z
+    0,                                                                          // EEVAR_ODOMETER_E0
+    default_axis_steps_flt[0] * ((DEFAULT_INVERT_X_DIR == true) ? -1.f : 1.f),  // AXIS_STEPS_PER_UNIT_X
+    default_axis_steps_flt[1] * ((DEFAULT_INVERT_Y_DIR == true) ? -1.f : 1.f),  // AXIS_STEPS_PER_UNIT_Y
+    default_axis_steps_flt[2] * ((DEFAULT_INVERT_Z_DIR == true) ? -1.f : 1.f),  // AXIS_STEPS_PER_UNIT_Z
+    default_axis_steps_flt[3] * ((DEFAULT_INVERT_E0_DIR == true) ? -1.f : 1.f), // AXIS_STEPS_PER_UNIT_E0
+    X_MICROSTEPS,                                                               // AXIS_MICROSTEPS_X
+    Y_MICROSTEPS,                                                               // AXIS_MICROSTEPS_Y
+    Z_MICROSTEPS,                                                               // AXIS_MICROSTEPS_Z
+    E0_MICROSTEPS,                                                              // AXIS_MICROSTEPS_E0
+    X_CURRENT,                                                                  // AXIS_RMS_CURRENT_MA_X
+    Y_CURRENT,                                                                  // AXIS_RMS_CURRENT_MA_Y
+    Z_CURRENT,                                                                  // AXIS_RMS_CURRENT_MA_Z
+    E0_CURRENT,                                                                 // AXIS_RMS_CURRENT_MA_E0
+    DEFAULT_Z_MAX_POS,                                                          // AXIS_Z_MAX_POS_MM
+    0,                                                                          // EEVAR_ODOMETER_TIME
+};
+
+inline vars_body_t convert(const eeprom::v9::vars_body_t &src) {
+    vars_body_t ret = body_defaults;
+
+    // copy entire v9 struct
+    memcpy(&ret, &src, sizeof(eeprom::v9::vars_body_t));
+
+    return ret;
+}
+
+} // namespace

--- a/src/common/eeprom_v10.hpp
+++ b/src/common/eeprom_v10.hpp
@@ -19,44 +19,7 @@ namespace eeprom::v10 {
  * @brief body od eeprom v10
  * without head, padding and crc
  */
-struct vars_body_t {
-    uint8_t FILAMENT_TYPE;
-    uint32_t FILAMENT_COLOR;
-    uint8_t RUN_SELFTEST;
-    uint8_t RUN_XYZCALIB;
-    uint8_t RUN_FIRSTLAY;
-    uint8_t FSENSOR_ENABLED;
-    float ZOFFSET;
-    float PID_NOZ_P;
-    float PID_NOZ_I;
-    float PID_NOZ_D;
-    float PID_BED_P;
-    float PID_BED_I;
-    float PID_BED_D;
-    uint8_t LAN_FLAG;
-    uint32_t LAN_IP4_ADDR;
-    uint32_t LAN_IP4_MSK;
-    uint32_t LAN_IP4_GW;
-    uint32_t LAN_IP4_DNS1;
-    uint32_t LAN_IP4_DNS2;
-    char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
-    int8_t TIMEZONE;
-    uint8_t SOUND_MODE;
-    uint8_t SOUND_VOLUME;
-    uint16_t LANGUAGE;
-    uint8_t FILE_SORT;
-    uint8_t MENU_TIMEOUT;
-    uint8_t ACTIVE_SHEET;
-    Sheet SHEET_PROFILE0;
-    Sheet SHEET_PROFILE1;
-    Sheet SHEET_PROFILE2;
-    Sheet SHEET_PROFILE3;
-    Sheet SHEET_PROFILE4;
-    Sheet SHEET_PROFILE5;
-    Sheet SHEET_PROFILE6;
-    Sheet SHEET_PROFILE7;
-    uint32_t SELFTEST_RESULT;
-    uint8_t DEVHASH_IN_QR;
+struct vars_body_t : public eeprom::v9::vars_body_t {
     uint32_t FOOTER_SETTING;
     uint32_t FOOTER_DRAW_TYPE;
     uint8_t FAN_CHECK_ENABLED;
@@ -83,46 +46,12 @@ struct vars_body_t {
 
 #pragma pack(pop)
 
+static_assert(sizeof(vars_body_t) == sizeof(eeprom::v9::vars_body_t) + sizeof(uint32_t) * 3 + sizeof(uint8_t) * 2 + sizeof(float) * 9 + sizeof(uint16_t) * 8, "eeprom body size does not match");
+
 static constexpr float default_axis_steps_flt[4] = DEFAULT_AXIS_STEPS_PER_UNIT;
 
 constexpr vars_body_t body_defaults = {
-    0,                         // EEVAR_FILAMENT_TYPE
-    0,                         // EEVAR_FILAMENT_COLOR
-    1,                         // EEVAR_RUN_SELFTEST
-    1,                         // EEVAR_RUN_XYZCALIB
-    1,                         // EEVAR_RUN_FIRSTLAY
-    1,                         // EEVAR_FSENSOR_ENABLED
-    0,                         // EEVAR_ZOFFSET
-    DEFAULT_Kp,                // EEVAR_PID_NOZ_P
-    scalePID_i(DEFAULT_Ki),    // EEVAR_PID_NOZ_I
-    scalePID_d(DEFAULT_Kd),    // EEVAR_PID_NOZ_D
-    DEFAULT_bedKp,             // EEVAR_PID_BED_P
-    scalePID_i(DEFAULT_bedKi), // EEVAR_PID_BED_I
-    scalePID_d(DEFAULT_bedKd), // EEVAR_PID_BED_D
-    0,                         // EEVAR_LAN_FLAG
-    0,                         // EEVAR_LAN_IP4_ADDR
-    0,                         // EEVAR_LAN_IP4_MSK
-    0,                         // EEVAR_LAN_IP4_GW
-    0,                         // EEVAR_LAN_IP4_DNS1
-    0,                         // EEVAR_LAN_IP4_DNS2
-    DEFAULT_HOST_NAME,         // EEVAR_LAN_HOSTNAME
-    0,                         // EEVAR_TIMEZONE
-    0xff,                      // EEVAR_SOUND_MODE
-    5,                         // EEVAR_SOUND_VOLUME
-    0xffff,                    // EEVAR_LANGUAGE
-    0,                         // EEVAR_FILE_SORT
-    1,                         // EEVAR_MENU_TIMEOUT
-    0,                         // EEVAR_ACTIVE_SHEET
-    { "Smooth1", 0.0f },
-    { "Smooth2", FLT_MAX },
-    { "Textur1", FLT_MAX },
-    { "Textur2", FLT_MAX },
-    { "Custom1", FLT_MAX },
-    { "Custom2", FLT_MAX },
-    { "Custom3", FLT_MAX },
-    { "Custom4", FLT_MAX },
-    0,                                                                          // EEVAR_SELFTEST_RESULT
-    1,                                                                          // EEVAR_DEVHASH_IN_QR
+    eeprom::v9::body_defaults,
     footer::eeprom::Encode(footer::DefaultItems),                               // EEVAR_FOOTER_SETTING
     uint32_t(footer::ItemDrawCnf::Default()),                                   // EEVAR_FOOTER_DRAW_TYPE
     1,                                                                          // EEVAR_FAN_CHECK_ENABLED

--- a/src/common/eeprom_v11.hpp
+++ b/src/common/eeprom_v11.hpp
@@ -19,66 +19,7 @@ namespace eeprom::v11 {
  * @brief body od eeprom v10
  * without head, padding and crc
  */
-struct vars_body_t {
-    uint8_t FILAMENT_TYPE;
-    uint32_t FILAMENT_COLOR;
-    uint8_t RUN_SELFTEST;
-    uint8_t RUN_XYZCALIB;
-    uint8_t RUN_FIRSTLAY;
-    uint8_t FSENSOR_ENABLED;
-    float ZOFFSET;
-    float PID_NOZ_P;
-    float PID_NOZ_I;
-    float PID_NOZ_D;
-    float PID_BED_P;
-    float PID_BED_I;
-    float PID_BED_D;
-    uint8_t LAN_FLAG;
-    uint32_t LAN_IP4_ADDR;
-    uint32_t LAN_IP4_MSK;
-    uint32_t LAN_IP4_GW;
-    uint32_t LAN_IP4_DNS1;
-    uint32_t LAN_IP4_DNS2;
-    char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
-    int8_t TIMEZONE;
-    uint8_t SOUND_MODE;
-    uint8_t SOUND_VOLUME;
-    uint16_t LANGUAGE;
-    uint8_t FILE_SORT;
-    uint8_t MENU_TIMEOUT;
-    uint8_t ACTIVE_SHEET;
-    Sheet SHEET_PROFILE0;
-    Sheet SHEET_PROFILE1;
-    Sheet SHEET_PROFILE2;
-    Sheet SHEET_PROFILE3;
-    Sheet SHEET_PROFILE4;
-    Sheet SHEET_PROFILE5;
-    Sheet SHEET_PROFILE6;
-    Sheet SHEET_PROFILE7;
-    uint32_t SELFTEST_RESULT;
-    uint8_t DEVHASH_IN_QR;
-    uint32_t FOOTER_SETTING;
-    uint32_t FOOTER_DRAW_TYPE;
-    uint8_t FAN_CHECK_ENABLED;
-    uint8_t FS_AUTOLOAD_ENABLED;
-    float EEVAR_ODOMETER_X;
-    float EEVAR_ODOMETER_Y;
-    float EEVAR_ODOMETER_Z;
-    float EEVAR_ODOMETER_E0;
-    float AXIS_STEPS_PER_UNIT_X;
-    float AXIS_STEPS_PER_UNIT_Y;
-    float AXIS_STEPS_PER_UNIT_Z;
-    float AXIS_STEPS_PER_UNIT_E0;
-    uint16_t AXIS_MICROSTEPS_X;
-    uint16_t AXIS_MICROSTEPS_Y;
-    uint16_t AXIS_MICROSTEPS_Z;
-    uint16_t AXIS_MICROSTEPS_E0;
-    uint16_t AXIS_RMS_CURRENT_MA_X;
-    uint16_t AXIS_RMS_CURRENT_MA_Y;
-    uint16_t AXIS_RMS_CURRENT_MA_Z;
-    uint16_t AXIS_RMS_CURRENT_MA_E0;
-    float AXIS_Z_MAX_POS_MM;
-    uint32_t ODOMETER_TIME;
+struct vars_body_t : public eeprom::v10::vars_body_t {
     uint8_t EEVAR_ACTIVE_NETDEV;
     uint8_t EEVAR_PL_RUN;
     char EEVAR_PL_API_KEY[PL_API_KEY_SIZE];
@@ -95,80 +36,22 @@ struct vars_body_t {
 
 #pragma pack(pop)
 
-static constexpr float default_axis_steps_flt[4] = DEFAULT_AXIS_STEPS_PER_UNIT;
+static_assert(sizeof(vars_body_t) == sizeof(eeprom::v10::vars_body_t) + sizeof(uint8_t) * 3 + PL_API_KEY_SIZE + LAN_HOSTNAME_MAX_LEN + 1 + WIFI_MAX_SSID_LEN + 1 + WIFI_MAX_PASSWD_LEN + 1 + sizeof(uint32_t) * 5, "eeprom body size does not match");
 
 constexpr vars_body_t body_defaults = {
-    0,                         // EEVAR_FILAMENT_TYPE
-    0,                         // EEVAR_FILAMENT_COLOR
-    1,                         // EEVAR_RUN_SELFTEST
-    1,                         // EEVAR_RUN_XYZCALIB
-    1,                         // EEVAR_RUN_FIRSTLAY
-    1,                         // EEVAR_FSENSOR_ENABLED
-    0,                         // EEVAR_ZOFFSET_DO_NOT_USE_DIRECTLY
-    DEFAULT_Kp,                // EEVAR_PID_NOZ_P
-    scalePID_i(DEFAULT_Ki),    // EEVAR_PID_NOZ_I
-    scalePID_d(DEFAULT_Kd),    // EEVAR_PID_NOZ_D
-    DEFAULT_bedKp,             // EEVAR_PID_BED_P
-    scalePID_i(DEFAULT_bedKi), // EEVAR_PID_BED_I
-    scalePID_d(DEFAULT_bedKd), // EEVAR_PID_BED_D
-    0,                         // EEVAR_LAN_FLAG
-    0,                         // EEVAR_LAN_IP4_ADDR
-    0,                         // EEVAR_LAN_IP4_MSK
-    0,                         // EEVAR_LAN_IP4_GW
-    0,                         // EEVAR_LAN_IP4_DNS1
-    0,                         // EEVAR_LAN_IP4_DNS2
-    DEFAULT_HOST_NAME,         // EEVAR_LAN_HOSTNAME
-    0,                         // EEVAR_TIMEZONE
-    0xff,                      // EEVAR_SOUND_MODE
-    5,                         // EEVAR_SOUND_VOLUME
-    0xffff,                    // EEVAR_LANGUAGE
-    0,                         // EEVAR_FILE_SORT
-    1,                         // EEVAR_MENU_TIMEOUT
-    0,                         // EEVAR_ACTIVE_SHEET
-    { "Smooth1", 0.0f },
-    { "Smooth2", FLT_MAX },
-    { "Textur1", FLT_MAX },
-    { "Textur2", FLT_MAX },
-    { "Custom1", FLT_MAX },
-    { "Custom2", FLT_MAX },
-    { "Custom3", FLT_MAX },
-    { "Custom4", FLT_MAX },
-    0,                                                                          // EEVAR_SELFTEST_RESULT
-    1,                                                                          // EEVAR_DEVHASH_IN_QR
-    footer::eeprom::Encode(footer::DefaultItems),                               // EEVAR_FOOTER_SETTING
-    uint32_t(footer::ItemDrawCnf::Default()),                                   // EEVAR_FOOTER_DRAW_TYPE
-    1,                                                                          // EEVAR_FAN_CHECK_ENABLED
-    0,                                                                          // EEVAR_FS_AUTOLOAD_ENABLED
-    0,                                                                          // EEVAR_ODOMETER_X
-    0,                                                                          // EEVAR_ODOMETER_Y
-    0,                                                                          // EEVAR_ODOMETER_Z
-    0,                                                                          // EEVAR_ODOMETER_E0
-    default_axis_steps_flt[0] * ((DEFAULT_INVERT_X_DIR == true) ? -1.f : 1.f),  // AXIS_STEPS_PER_UNIT_X
-    default_axis_steps_flt[1] * ((DEFAULT_INVERT_Y_DIR == true) ? -1.f : 1.f),  // AXIS_STEPS_PER_UNIT_Y
-    default_axis_steps_flt[2] * ((DEFAULT_INVERT_Z_DIR == true) ? -1.f : 1.f),  // AXIS_STEPS_PER_UNIT_Z
-    default_axis_steps_flt[3] * ((DEFAULT_INVERT_E0_DIR == true) ? -1.f : 1.f), // AXIS_STEPS_PER_UNIT_E0
-    X_MICROSTEPS,                                                               // AXIS_MICROSTEPS_X
-    Y_MICROSTEPS,                                                               // AXIS_MICROSTEPS_Y
-    Z_MICROSTEPS,                                                               // AXIS_MICROSTEPS_Z
-    E0_MICROSTEPS,                                                              // AXIS_MICROSTEPS_E0
-    X_CURRENT,                                                                  // AXIS_RMS_CURRENT_MA_X
-    Y_CURRENT,                                                                  // AXIS_RMS_CURRENT_MA_Y
-    Z_CURRENT,                                                                  // AXIS_RMS_CURRENT_MA_Z
-    E0_CURRENT,                                                                 // AXIS_RMS_CURRENT_MA_E0
-    DEFAULT_Z_MAX_POS,                                                          // AXIS_Z_MAX_POS_MM
-    0,                                                                          // EEVAR_ODOMETER_TIME
-    0,                                                                          // EEVAR_ACTIVE_NETDEV
-    1,                                                                          // EEVAR_PL_RUN
-    "",                                                                         // EEVAR_PL_API_KEY
-    0,                                                                          // EEVAR_WIFI_FLAG
-    0,                                                                          // EEVAR_WIFI_IP4_ADDR
-    0,                                                                          // EEVAR_WIFI_IP4_MSK
-    0,                                                                          // EEVAR_WIFI_IP4_GW
-    0,                                                                          // EEVAR_WIFI_IP4_DNS1
-    0,                                                                          // EEVAR_WIFI_IP4_DNS2
-    DEFAULT_HOST_NAME,                                                          // EEVAR_WIFI_HOSTNAME
-    "",                                                                         // EEVAR_WIFI_AP_SSID
-    "",                                                                         // EEVAR_WIFI_AP_PASSWD
+    eeprom::v10::body_defaults,
+    0,                 // EEVAR_ACTIVE_NETDEV
+    1,                 // EEVAR_PL_RUN
+    "",                // EEVAR_PL_API_KEY
+    0,                 // EEVAR_WIFI_FLAG
+    0,                 // EEVAR_WIFI_IP4_ADDR
+    0,                 // EEVAR_WIFI_IP4_MSK
+    0,                 // EEVAR_WIFI_IP4_GW
+    0,                 // EEVAR_WIFI_IP4_DNS1
+    0,                 // EEVAR_WIFI_IP4_DNS2
+    DEFAULT_HOST_NAME, // EEVAR_WIFI_HOSTNAME
+    "",                // EEVAR_WIFI_AP_SSID
+    "",                // EEVAR_WIFI_AP_PASSWD
 };
 
 inline vars_body_t convert(const eeprom::v10::vars_body_t &src) {

--- a/src/common/eeprom_v11.hpp
+++ b/src/common/eeprom_v11.hpp
@@ -1,0 +1,183 @@
+/**
+ * @file eeprom_v11.hpp
+ * @author Radek Vana
+ * @brief old version of eeprom, to be able to import it
+ * version 11 from TODO add after released
+ * without padding and crc since they are not imported and would not match anyway
+ * @date 2022-01-17
+ */
+
+#include "eeprom_v10.hpp"
+
+namespace eeprom::v11 {
+
+#pragma once
+#pragma pack(push)
+#pragma pack(1)
+
+/**
+ * @brief body od eeprom v10
+ * without head, padding and crc
+ */
+struct vars_body_t {
+    uint8_t FILAMENT_TYPE;
+    uint32_t FILAMENT_COLOR;
+    uint8_t RUN_SELFTEST;
+    uint8_t RUN_XYZCALIB;
+    uint8_t RUN_FIRSTLAY;
+    uint8_t FSENSOR_ENABLED;
+    float ZOFFSET;
+    float PID_NOZ_P;
+    float PID_NOZ_I;
+    float PID_NOZ_D;
+    float PID_BED_P;
+    float PID_BED_I;
+    float PID_BED_D;
+    uint8_t LAN_FLAG;
+    uint32_t LAN_IP4_ADDR;
+    uint32_t LAN_IP4_MSK;
+    uint32_t LAN_IP4_GW;
+    uint32_t LAN_IP4_DNS1;
+    uint32_t LAN_IP4_DNS2;
+    char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
+    int8_t TIMEZONE;
+    uint8_t SOUND_MODE;
+    uint8_t SOUND_VOLUME;
+    uint16_t LANGUAGE;
+    uint8_t FILE_SORT;
+    uint8_t MENU_TIMEOUT;
+    uint8_t ACTIVE_SHEET;
+    Sheet SHEET_PROFILE0;
+    Sheet SHEET_PROFILE1;
+    Sheet SHEET_PROFILE2;
+    Sheet SHEET_PROFILE3;
+    Sheet SHEET_PROFILE4;
+    Sheet SHEET_PROFILE5;
+    Sheet SHEET_PROFILE6;
+    Sheet SHEET_PROFILE7;
+    uint32_t SELFTEST_RESULT;
+    uint8_t DEVHASH_IN_QR;
+    uint32_t FOOTER_SETTING;
+    uint32_t FOOTER_DRAW_TYPE;
+    uint8_t FAN_CHECK_ENABLED;
+    uint8_t FS_AUTOLOAD_ENABLED;
+    float EEVAR_ODOMETER_X;
+    float EEVAR_ODOMETER_Y;
+    float EEVAR_ODOMETER_Z;
+    float EEVAR_ODOMETER_E0;
+    float AXIS_STEPS_PER_UNIT_X;
+    float AXIS_STEPS_PER_UNIT_Y;
+    float AXIS_STEPS_PER_UNIT_Z;
+    float AXIS_STEPS_PER_UNIT_E0;
+    uint16_t AXIS_MICROSTEPS_X;
+    uint16_t AXIS_MICROSTEPS_Y;
+    uint16_t AXIS_MICROSTEPS_Z;
+    uint16_t AXIS_MICROSTEPS_E0;
+    uint16_t AXIS_RMS_CURRENT_MA_X;
+    uint16_t AXIS_RMS_CURRENT_MA_Y;
+    uint16_t AXIS_RMS_CURRENT_MA_Z;
+    uint16_t AXIS_RMS_CURRENT_MA_E0;
+    float AXIS_Z_MAX_POS_MM;
+    uint32_t ODOMETER_TIME;
+    uint8_t EEVAR_ACTIVE_NETDEV;
+    uint8_t EEVAR_PL_RUN;
+    char EEVAR_PL_API_KEY[PL_API_KEY_SIZE];
+    uint8_t WIFI_FLAG;
+    uint32_t WIFI_IP4_ADDR;
+    uint32_t WIFI_IP4_MSK;
+    uint32_t WIFI_IP4_GW;
+    uint32_t WIFI_IP4_DNS1;
+    uint32_t WIFI_IP4_DNS2;
+    char WIFI_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
+    char WIFI_AP_SSID[WIFI_MAX_SSID_LEN + 1];
+    char WIFI_AP_PASSWD[WIFI_MAX_PASSWD_LEN + 1];
+};
+
+#pragma pack(pop)
+
+static constexpr float default_axis_steps_flt[4] = DEFAULT_AXIS_STEPS_PER_UNIT;
+
+constexpr vars_body_t body_defaults = {
+    0,                         // EEVAR_FILAMENT_TYPE
+    0,                         // EEVAR_FILAMENT_COLOR
+    1,                         // EEVAR_RUN_SELFTEST
+    1,                         // EEVAR_RUN_XYZCALIB
+    1,                         // EEVAR_RUN_FIRSTLAY
+    1,                         // EEVAR_FSENSOR_ENABLED
+    0,                         // EEVAR_ZOFFSET_DO_NOT_USE_DIRECTLY
+    DEFAULT_Kp,                // EEVAR_PID_NOZ_P
+    scalePID_i(DEFAULT_Ki),    // EEVAR_PID_NOZ_I
+    scalePID_d(DEFAULT_Kd),    // EEVAR_PID_NOZ_D
+    DEFAULT_bedKp,             // EEVAR_PID_BED_P
+    scalePID_i(DEFAULT_bedKi), // EEVAR_PID_BED_I
+    scalePID_d(DEFAULT_bedKd), // EEVAR_PID_BED_D
+    0,                         // EEVAR_LAN_FLAG
+    0,                         // EEVAR_LAN_IP4_ADDR
+    0,                         // EEVAR_LAN_IP4_MSK
+    0,                         // EEVAR_LAN_IP4_GW
+    0,                         // EEVAR_LAN_IP4_DNS1
+    0,                         // EEVAR_LAN_IP4_DNS2
+    DEFAULT_HOST_NAME,         // EEVAR_LAN_HOSTNAME
+    0,                         // EEVAR_TIMEZONE
+    0xff,                      // EEVAR_SOUND_MODE
+    5,                         // EEVAR_SOUND_VOLUME
+    0xffff,                    // EEVAR_LANGUAGE
+    0,                         // EEVAR_FILE_SORT
+    1,                         // EEVAR_MENU_TIMEOUT
+    0,                         // EEVAR_ACTIVE_SHEET
+    { "Smooth1", 0.0f },
+    { "Smooth2", FLT_MAX },
+    { "Textur1", FLT_MAX },
+    { "Textur2", FLT_MAX },
+    { "Custom1", FLT_MAX },
+    { "Custom2", FLT_MAX },
+    { "Custom3", FLT_MAX },
+    { "Custom4", FLT_MAX },
+    0,                                                                          // EEVAR_SELFTEST_RESULT
+    1,                                                                          // EEVAR_DEVHASH_IN_QR
+    footer::eeprom::Encode(footer::DefaultItems),                               // EEVAR_FOOTER_SETTING
+    uint32_t(footer::ItemDrawCnf::Default()),                                   // EEVAR_FOOTER_DRAW_TYPE
+    1,                                                                          // EEVAR_FAN_CHECK_ENABLED
+    0,                                                                          // EEVAR_FS_AUTOLOAD_ENABLED
+    0,                                                                          // EEVAR_ODOMETER_X
+    0,                                                                          // EEVAR_ODOMETER_Y
+    0,                                                                          // EEVAR_ODOMETER_Z
+    0,                                                                          // EEVAR_ODOMETER_E0
+    default_axis_steps_flt[0] * ((DEFAULT_INVERT_X_DIR == true) ? -1.f : 1.f),  // AXIS_STEPS_PER_UNIT_X
+    default_axis_steps_flt[1] * ((DEFAULT_INVERT_Y_DIR == true) ? -1.f : 1.f),  // AXIS_STEPS_PER_UNIT_Y
+    default_axis_steps_flt[2] * ((DEFAULT_INVERT_Z_DIR == true) ? -1.f : 1.f),  // AXIS_STEPS_PER_UNIT_Z
+    default_axis_steps_flt[3] * ((DEFAULT_INVERT_E0_DIR == true) ? -1.f : 1.f), // AXIS_STEPS_PER_UNIT_E0
+    X_MICROSTEPS,                                                               // AXIS_MICROSTEPS_X
+    Y_MICROSTEPS,                                                               // AXIS_MICROSTEPS_Y
+    Z_MICROSTEPS,                                                               // AXIS_MICROSTEPS_Z
+    E0_MICROSTEPS,                                                              // AXIS_MICROSTEPS_E0
+    X_CURRENT,                                                                  // AXIS_RMS_CURRENT_MA_X
+    Y_CURRENT,                                                                  // AXIS_RMS_CURRENT_MA_Y
+    Z_CURRENT,                                                                  // AXIS_RMS_CURRENT_MA_Z
+    E0_CURRENT,                                                                 // AXIS_RMS_CURRENT_MA_E0
+    DEFAULT_Z_MAX_POS,                                                          // AXIS_Z_MAX_POS_MM
+    0,                                                                          // EEVAR_ODOMETER_TIME
+    0,                                                                          // EEVAR_ACTIVE_NETDEV
+    1,                                                                          // EEVAR_PL_RUN
+    "",                                                                         // EEVAR_PL_API_KEY
+    0,                                                                          // EEVAR_WIFI_FLAG
+    0,                                                                          // EEVAR_WIFI_IP4_ADDR
+    0,                                                                          // EEVAR_WIFI_IP4_MSK
+    0,                                                                          // EEVAR_WIFI_IP4_GW
+    0,                                                                          // EEVAR_WIFI_IP4_DNS1
+    0,                                                                          // EEVAR_WIFI_IP4_DNS2
+    DEFAULT_HOST_NAME,                                                          // EEVAR_WIFI_HOSTNAME
+    "",                                                                         // EEVAR_WIFI_AP_SSID
+    "",                                                                         // EEVAR_WIFI_AP_PASSWD
+};
+
+inline vars_body_t convert(const eeprom::v10::vars_body_t &src) {
+    vars_body_t ret = body_defaults;
+
+    // copy entire v9 struct
+    memcpy(&ret, &src, sizeof(eeprom::v10::vars_body_t));
+
+    return ret;
+}
+
+} // namespace

--- a/src/common/eeprom_v4.hpp
+++ b/src/common/eeprom_v4.hpp
@@ -1,0 +1,50 @@
+/**
+ * @file eeprom_v4.hpp
+ * @author Radek Vana
+ * @brief old version of eeprom, to be able to import it
+ * version 4, from release 4.0.5-RC1
+ * without padding and crc since they are not imported and would not match anyway
+ * @date 2022-01-17
+ */
+
+#include <stdint.h>
+#include "eeprom.h"
+
+namespace eeprom::v4 {
+
+#pragma once
+#pragma pack(push)
+#pragma pack(1)
+
+/**
+ * @brief body od eeprom v4
+ * without head, padding and crc
+ */
+struct vars_body_t {
+    uint8_t FILAMENT_TYPE;
+    uint32_t FILAMENT_COLOR;
+    uint8_t RUN_SELFTEST;
+    uint8_t RUN_XYZCALIB;
+    uint8_t RUN_FIRSTLAY;
+    uint8_t FSENSOR_ENABLED;
+    float ZOFFSET;
+    float PID_NOZ_P;
+    float PID_NOZ_I;
+    float PID_NOZ_D;
+    float PID_BED_P;
+    float PID_BED_I;
+    float PID_BED_D;
+    uint8_t LAN_FLAG;
+    uint32_t LAN_IP4_ADDR;
+    uint32_t LAN_IP4_MSK;
+    uint32_t LAN_IP4_GW;
+    uint32_t LAN_IP4_DNS1;
+    uint32_t LAN_IP4_DNS2;
+    uint32_t CONNECT_IP4_ADDR;
+    char CONNECT_TOKEN[CONNECT_TOKEN_SIZE + 1];
+    char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
+};
+
+#pragma pack(pop)
+
+} // namespace

--- a/src/common/eeprom_v6.hpp
+++ b/src/common/eeprom_v6.hpp
@@ -1,0 +1,87 @@
+/**
+ * @file eeprom_v6.hpp
+ * @author Radek Vana
+ * @brief old version of eeprom, to be able to import it
+ * version 6 from release 4.1.0-RC1
+ * without padding and crc since they are not imported and would not match anyway
+ * @date 2022-01-17
+ */
+
+#include "eeprom_v4.hpp"
+
+namespace eeprom::v6 {
+
+#pragma once
+#pragma pack(push)
+#pragma pack(1)
+
+/**
+ * @brief body od eeprom v6
+ * without head, padding and crc
+ */
+struct vars_body_t {
+    uint8_t FILAMENT_TYPE;
+    uint32_t FILAMENT_COLOR;
+    uint8_t RUN_SELFTEST;
+    uint8_t RUN_XYZCALIB;
+    uint8_t RUN_FIRSTLAY;
+    uint8_t FSENSOR_ENABLED;
+    float ZOFFSET;
+    float PID_NOZ_P;
+    float PID_NOZ_I;
+    float PID_NOZ_D;
+    float PID_BED_P;
+    float PID_BED_I;
+    float PID_BED_D;
+    uint8_t LAN_FLAG;
+    uint32_t LAN_IP4_ADDR;
+    uint32_t LAN_IP4_MSK;
+    uint32_t LAN_IP4_GW;
+    uint32_t LAN_IP4_DNS1;
+    uint32_t LAN_IP4_DNS2;
+    char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
+    int8_t TIMEZONE;
+    uint8_t SOUND_MODE;
+};
+
+#pragma pack(pop)
+
+constexpr vars_body_t body_defaults = {
+    0,                         // EEVAR_FILAMENT_TYPE
+    0,                         // EEVAR_FILAMENT_COLOR
+    1,                         // EEVAR_RUN_SELFTEST
+    1,                         // EEVAR_RUN_XYZCALIB
+    1,                         // EEVAR_RUN_FIRSTLAY
+    1,                         // EEVAR_FSENSOR_ENABLED
+    0,                         // EEVAR_ZOFFSET
+    DEFAULT_Kp,                // EEVAR_PID_NOZ_P
+    scalePID_i(DEFAULT_Ki),    // EEVAR_PID_NOZ_I
+    scalePID_d(DEFAULT_Kd),    // EEVAR_PID_NOZ_D
+    DEFAULT_bedKp,             // EEVAR_PID_BED_P
+    scalePID_i(DEFAULT_bedKi), // EEVAR_PID_BED_I
+    scalePID_d(DEFAULT_bedKd), // EEVAR_PID_BED_D
+    0,                         // EEVAR_LAN_FLAG
+    0,                         // EEVAR_LAN_IP4_ADDR
+    0,                         // EEVAR_LAN_IP4_MSK
+    0,                         // EEVAR_LAN_IP4_GW
+    0,                         // EEVAR_LAN_IP4_DNS1
+    0,                         // EEVAR_LAN_IP4_DNS2
+    DEFAULT_HOST_NAME,         // EEVAR_LAN_HOSTNAME
+    0,                         // EEVAR_TIMEZONE
+    0xff,                      // EEVAR_SOUND_MODE
+};
+
+inline vars_body_t convert(const eeprom::v4::vars_body_t &src) {
+    vars_body_t ret = body_defaults;
+
+    // copy range from FILAMENT_TYPE to LAN_IP4_DNS2
+    size_t sz = ((uint8_t *)&src.CONNECT_IP4_ADDR) - ((uint8_t *)&src.FILAMENT_TYPE);
+    memcpy(&ret, &src, sz);
+
+    // copy LAN_HOSTNAME
+    memcpy(&ret.LAN_HOSTNAME, &src.LAN_HOSTNAME, LAN_HOSTNAME_MAX_LEN + 1);
+
+    return ret;
+}
+
+} // namespace

--- a/src/common/eeprom_v7.hpp
+++ b/src/common/eeprom_v7.hpp
@@ -19,60 +19,18 @@ namespace eeprom::v7 {
  * @brief body od eeprom v7
  * without head, padding and crc
  */
-struct vars_body_t {
-    uint8_t FILAMENT_TYPE;
-    uint32_t FILAMENT_COLOR;
-    uint8_t RUN_SELFTEST;
-    uint8_t RUN_XYZCALIB;
-    uint8_t RUN_FIRSTLAY;
-    uint8_t FSENSOR_ENABLED;
-    float ZOFFSET;
-    float PID_NOZ_P;
-    float PID_NOZ_I;
-    float PID_NOZ_D;
-    float PID_BED_P;
-    float PID_BED_I;
-    float PID_BED_D;
-    uint8_t LAN_FLAG;
-    uint32_t LAN_IP4_ADDR;
-    uint32_t LAN_IP4_MSK;
-    uint32_t LAN_IP4_GW;
-    uint32_t LAN_IP4_DNS1;
-    uint32_t LAN_IP4_DNS2;
-    char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
-    int8_t TIMEZONE;
-    uint8_t SOUND_MODE;
+struct vars_body_t : public eeprom::v6::vars_body_t {
     uint8_t SOUND_VOLUME;
     uint16_t LANGUAGE;
 };
-
 #pragma pack(pop)
 
+static_assert(sizeof(vars_body_t) == sizeof(eeprom::v6::vars_body_t) + sizeof(vars_body_t::SOUND_VOLUME) + sizeof(vars_body_t::LANGUAGE), "eeprom body size does not match");
+
 constexpr vars_body_t body_defaults = {
-    0,                         // EEVAR_FILAMENT_TYPE
-    0,                         // EEVAR_FILAMENT_COLOR
-    1,                         // EEVAR_RUN_SELFTEST
-    1,                         // EEVAR_RUN_XYZCALIB
-    1,                         // EEVAR_RUN_FIRSTLAY
-    1,                         // EEVAR_FSENSOR_ENABLED
-    0,                         // EEVAR_ZOFFSET
-    DEFAULT_Kp,                // EEVAR_PID_NOZ_P
-    scalePID_i(DEFAULT_Ki),    // EEVAR_PID_NOZ_I
-    scalePID_d(DEFAULT_Kd),    // EEVAR_PID_NOZ_D
-    DEFAULT_bedKp,             // EEVAR_PID_BED_P
-    scalePID_i(DEFAULT_bedKi), // EEVAR_PID_BED_I
-    scalePID_d(DEFAULT_bedKd), // EEVAR_PID_BED_D
-    0,                         // EEVAR_LAN_FLAG
-    0,                         // EEVAR_LAN_IP4_ADDR
-    0,                         // EEVAR_LAN_IP4_MSK
-    0,                         // EEVAR_LAN_IP4_GW
-    0,                         // EEVAR_LAN_IP4_DNS1
-    0,                         // EEVAR_LAN_IP4_DNS2
-    DEFAULT_HOST_NAME,         // EEVAR_LAN_HOSTNAME
-    0,                         // EEVAR_TIMEZONE
-    0xff,                      // EEVAR_SOUND_MODE
-    5,                         // EEVAR_SOUND_VOLUME
-    0xffff,                    // EEVAR_LANGUAGE
+    eeprom::v6::body_defaults,
+    5,      // EEVAR_SOUND_VOLUME
+    0xffff, // EEVAR_LANGUAGE
 };
 
 inline vars_body_t convert(const eeprom::v6::vars_body_t &src) {

--- a/src/common/eeprom_v7.hpp
+++ b/src/common/eeprom_v7.hpp
@@ -1,0 +1,87 @@
+/**
+ * @file eeprom_v7.hpp
+ * @author Radek Vana
+ * @brief old version of eeprom, to be able to import it
+ * version 7 from release 4.2.0-RC1
+ * without padding and crc since they are not imported and would not match anyway
+ * @date 2022-01-17
+ */
+
+#include "eeprom_v6.hpp"
+
+namespace eeprom::v7 {
+
+#pragma once
+#pragma pack(push)
+#pragma pack(1)
+
+/**
+ * @brief body od eeprom v7
+ * without head, padding and crc
+ */
+struct vars_body_t {
+    uint8_t FILAMENT_TYPE;
+    uint32_t FILAMENT_COLOR;
+    uint8_t RUN_SELFTEST;
+    uint8_t RUN_XYZCALIB;
+    uint8_t RUN_FIRSTLAY;
+    uint8_t FSENSOR_ENABLED;
+    float ZOFFSET;
+    float PID_NOZ_P;
+    float PID_NOZ_I;
+    float PID_NOZ_D;
+    float PID_BED_P;
+    float PID_BED_I;
+    float PID_BED_D;
+    uint8_t LAN_FLAG;
+    uint32_t LAN_IP4_ADDR;
+    uint32_t LAN_IP4_MSK;
+    uint32_t LAN_IP4_GW;
+    uint32_t LAN_IP4_DNS1;
+    uint32_t LAN_IP4_DNS2;
+    char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
+    int8_t TIMEZONE;
+    uint8_t SOUND_MODE;
+    uint8_t SOUND_VOLUME;
+    uint16_t LANGUAGE;
+};
+
+#pragma pack(pop)
+
+constexpr vars_body_t body_defaults = {
+    0,                         // EEVAR_FILAMENT_TYPE
+    0,                         // EEVAR_FILAMENT_COLOR
+    1,                         // EEVAR_RUN_SELFTEST
+    1,                         // EEVAR_RUN_XYZCALIB
+    1,                         // EEVAR_RUN_FIRSTLAY
+    1,                         // EEVAR_FSENSOR_ENABLED
+    0,                         // EEVAR_ZOFFSET
+    DEFAULT_Kp,                // EEVAR_PID_NOZ_P
+    scalePID_i(DEFAULT_Ki),    // EEVAR_PID_NOZ_I
+    scalePID_d(DEFAULT_Kd),    // EEVAR_PID_NOZ_D
+    DEFAULT_bedKp,             // EEVAR_PID_BED_P
+    scalePID_i(DEFAULT_bedKi), // EEVAR_PID_BED_I
+    scalePID_d(DEFAULT_bedKd), // EEVAR_PID_BED_D
+    0,                         // EEVAR_LAN_FLAG
+    0,                         // EEVAR_LAN_IP4_ADDR
+    0,                         // EEVAR_LAN_IP4_MSK
+    0,                         // EEVAR_LAN_IP4_GW
+    0,                         // EEVAR_LAN_IP4_DNS1
+    0,                         // EEVAR_LAN_IP4_DNS2
+    DEFAULT_HOST_NAME,         // EEVAR_LAN_HOSTNAME
+    0,                         // EEVAR_TIMEZONE
+    0xff,                      // EEVAR_SOUND_MODE
+    5,                         // EEVAR_SOUND_VOLUME
+    0xffff,                    // EEVAR_LANGUAGE
+};
+
+inline vars_body_t convert(const eeprom::v6::vars_body_t &src) {
+    vars_body_t ret = body_defaults;
+
+    // copy entire v6 struct
+    memcpy(&ret, &src, sizeof(eeprom::v6::vars_body_t));
+
+    return ret;
+}
+
+} // namespace

--- a/src/common/eeprom_v9.hpp
+++ b/src/common/eeprom_v9.hpp
@@ -1,0 +1,113 @@
+/**
+ * @file eeprom_v9.hpp
+ * @author Radek Vana
+ * @brief old version of eeprom, to be able to import it
+ * version 9 from release 4.3.0 RC1
+ * without padding and crc since they are not imported and would not match anyway
+ * @date 2022-01-17
+ */
+
+#include "eeprom_v7.hpp"
+
+namespace eeprom::v9 {
+
+#pragma once
+#pragma pack(push)
+#pragma pack(1)
+
+/**
+ * @brief body od eeprom v9
+ * without head, padding and crc
+ */
+struct vars_body_t {
+    uint8_t FILAMENT_TYPE;
+    uint32_t FILAMENT_COLOR;
+    uint8_t RUN_SELFTEST;
+    uint8_t RUN_XYZCALIB;
+    uint8_t RUN_FIRSTLAY;
+    uint8_t FSENSOR_ENABLED;
+    float ZOFFSET;
+    float PID_NOZ_P;
+    float PID_NOZ_I;
+    float PID_NOZ_D;
+    float PID_BED_P;
+    float PID_BED_I;
+    float PID_BED_D;
+    uint8_t LAN_FLAG;
+    uint32_t LAN_IP4_ADDR;
+    uint32_t LAN_IP4_MSK;
+    uint32_t LAN_IP4_GW;
+    uint32_t LAN_IP4_DNS1;
+    uint32_t LAN_IP4_DNS2;
+    char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
+    int8_t TIMEZONE;
+    uint8_t SOUND_MODE;
+    uint8_t SOUND_VOLUME;
+    uint16_t LANGUAGE;
+    uint8_t FILE_SORT;
+    uint8_t MENU_TIMEOUT;
+    uint8_t ACTIVE_SHEET;
+    Sheet SHEET_PROFILE0;
+    Sheet SHEET_PROFILE1;
+    Sheet SHEET_PROFILE2;
+    Sheet SHEET_PROFILE3;
+    Sheet SHEET_PROFILE4;
+    Sheet SHEET_PROFILE5;
+    Sheet SHEET_PROFILE6;
+    Sheet SHEET_PROFILE7;
+    uint32_t SELFTEST_RESULT;
+    uint8_t DEVHASH_IN_QR;
+};
+
+#pragma pack(pop)
+
+constexpr vars_body_t body_defaults = {
+    0,                         // EEVAR_FILAMENT_TYPE
+    0,                         // EEVAR_FILAMENT_COLOR
+    1,                         // EEVAR_RUN_SELFTEST
+    1,                         // EEVAR_RUN_XYZCALIB
+    1,                         // EEVAR_RUN_FIRSTLAY
+    1,                         // EEVAR_FSENSOR_ENABLED
+    0,                         // EEVAR_ZOFFSET
+    DEFAULT_Kp,                // EEVAR_PID_NOZ_P
+    scalePID_i(DEFAULT_Ki),    // EEVAR_PID_NOZ_I
+    scalePID_d(DEFAULT_Kd),    // EEVAR_PID_NOZ_D
+    DEFAULT_bedKp,             // EEVAR_PID_BED_P
+    scalePID_i(DEFAULT_bedKi), // EEVAR_PID_BED_I
+    scalePID_d(DEFAULT_bedKd), // EEVAR_PID_BED_D
+    0,                         // EEVAR_LAN_FLAG
+    0,                         // EEVAR_LAN_IP4_ADDR
+    0,                         // EEVAR_LAN_IP4_MSK
+    0,                         // EEVAR_LAN_IP4_GW
+    0,                         // EEVAR_LAN_IP4_DNS1
+    0,                         // EEVAR_LAN_IP4_DNS2
+    DEFAULT_HOST_NAME,         // EEVAR_LAN_HOSTNAME
+    0,                         // EEVAR_TIMEZONE
+    0xff,                      // EEVAR_SOUND_MODE
+    5,                         // EEVAR_SOUND_VOLUME
+    0xffff,                    // EEVAR_LANGUAGE
+    0,                         // EEVAR_FILE_SORT
+    1,                         // EEVAR_MENU_TIMEOUT
+    0,                         // EEVAR_ACTIVE_SHEET
+    { "Smooth1", 0.0f },
+    { "Smooth2", FLT_MAX },
+    { "Textur1", FLT_MAX },
+    { "Textur2", FLT_MAX },
+    { "Custom1", FLT_MAX },
+    { "Custom2", FLT_MAX },
+    { "Custom3", FLT_MAX },
+    { "Custom4", FLT_MAX },
+    0, // EEVAR_SELFTEST_RESULT
+    1, // EEVAR_DEVHASH_IN_QR
+};
+
+inline vars_body_t convert(const eeprom::v7::vars_body_t &src) {
+    vars_body_t ret = body_defaults;
+
+    // copy entire v7 struct
+    memcpy(&ret, &src, sizeof(eeprom::v7::vars_body_t));
+
+    return ret;
+}
+
+} // namespace

--- a/src/common/eeprom_v9.hpp
+++ b/src/common/eeprom_v9.hpp
@@ -19,31 +19,7 @@ namespace eeprom::v9 {
  * @brief body od eeprom v9
  * without head, padding and crc
  */
-struct vars_body_t {
-    uint8_t FILAMENT_TYPE;
-    uint32_t FILAMENT_COLOR;
-    uint8_t RUN_SELFTEST;
-    uint8_t RUN_XYZCALIB;
-    uint8_t RUN_FIRSTLAY;
-    uint8_t FSENSOR_ENABLED;
-    float ZOFFSET;
-    float PID_NOZ_P;
-    float PID_NOZ_I;
-    float PID_NOZ_D;
-    float PID_BED_P;
-    float PID_BED_I;
-    float PID_BED_D;
-    uint8_t LAN_FLAG;
-    uint32_t LAN_IP4_ADDR;
-    uint32_t LAN_IP4_MSK;
-    uint32_t LAN_IP4_GW;
-    uint32_t LAN_IP4_DNS1;
-    uint32_t LAN_IP4_DNS2;
-    char LAN_HOSTNAME[LAN_HOSTNAME_MAX_LEN + 1];
-    int8_t TIMEZONE;
-    uint8_t SOUND_MODE;
-    uint8_t SOUND_VOLUME;
-    uint16_t LANGUAGE;
+struct vars_body_t : public eeprom::v7::vars_body_t {
     uint8_t FILE_SORT;
     uint8_t MENU_TIMEOUT;
     uint8_t ACTIVE_SHEET;
@@ -61,34 +37,13 @@ struct vars_body_t {
 
 #pragma pack(pop)
 
+static_assert(sizeof(vars_body_t) == sizeof(eeprom::v7::vars_body_t) + sizeof(vars_body_t::FILE_SORT) + sizeof(vars_body_t::MENU_TIMEOUT) + sizeof(vars_body_t::ACTIVE_SHEET) + 8 * sizeof(Sheet) + sizeof(vars_body_t::SELFTEST_RESULT) + sizeof(vars_body_t::DEVHASH_IN_QR), "eeprom body size does not match");
+
 constexpr vars_body_t body_defaults = {
-    0,                         // EEVAR_FILAMENT_TYPE
-    0,                         // EEVAR_FILAMENT_COLOR
-    1,                         // EEVAR_RUN_SELFTEST
-    1,                         // EEVAR_RUN_XYZCALIB
-    1,                         // EEVAR_RUN_FIRSTLAY
-    1,                         // EEVAR_FSENSOR_ENABLED
-    0,                         // EEVAR_ZOFFSET
-    DEFAULT_Kp,                // EEVAR_PID_NOZ_P
-    scalePID_i(DEFAULT_Ki),    // EEVAR_PID_NOZ_I
-    scalePID_d(DEFAULT_Kd),    // EEVAR_PID_NOZ_D
-    DEFAULT_bedKp,             // EEVAR_PID_BED_P
-    scalePID_i(DEFAULT_bedKi), // EEVAR_PID_BED_I
-    scalePID_d(DEFAULT_bedKd), // EEVAR_PID_BED_D
-    0,                         // EEVAR_LAN_FLAG
-    0,                         // EEVAR_LAN_IP4_ADDR
-    0,                         // EEVAR_LAN_IP4_MSK
-    0,                         // EEVAR_LAN_IP4_GW
-    0,                         // EEVAR_LAN_IP4_DNS1
-    0,                         // EEVAR_LAN_IP4_DNS2
-    DEFAULT_HOST_NAME,         // EEVAR_LAN_HOSTNAME
-    0,                         // EEVAR_TIMEZONE
-    0xff,                      // EEVAR_SOUND_MODE
-    5,                         // EEVAR_SOUND_VOLUME
-    0xffff,                    // EEVAR_LANGUAGE
-    0,                         // EEVAR_FILE_SORT
-    1,                         // EEVAR_MENU_TIMEOUT
-    0,                         // EEVAR_ACTIVE_SHEET
+    eeprom::v7::body_defaults,
+    0, // EEVAR_FILE_SORT
+    1, // EEVAR_MENU_TIMEOUT
+    0, // EEVAR_ACTIVE_SHEET
     { "Smooth1", 0.0f },
     { "Smooth2", FLT_MAX },
     { "Textur1", FLT_MAX },

--- a/src/common/marlin_client.c
+++ b/src/common/marlin_client.c
@@ -505,10 +505,6 @@ float marlin_set_target_bed(float val) {
     return variant8_get_flt(marlin_set_var(MARLIN_VAR_TTEM_BED, variant8_flt(val)));
 }
 
-float marlin_set_z_offset(float val) {
-    return variant8_get_flt(marlin_set_var(MARLIN_VAR_Z_OFFSET, variant8_flt(val)));
-}
-
 uint8_t marlin_set_fan_speed(uint8_t val) {
     return variant8_get_ui8(marlin_set_var(MARLIN_VAR_FANSPEED, variant8_ui8(val)));
 }

--- a/src/common/marlin_client.h
+++ b/src/common/marlin_client.h
@@ -150,7 +150,6 @@ extern uint8_t marlin_get_pqueue_max(void);
 extern float marlin_set_target_nozzle(float val);
 extern float marlin_set_display_nozzle(float val);
 extern float marlin_set_target_bed(float val);
-extern float marlin_set_z_offset(float val);
 extern uint8_t marlin_set_fan_speed(uint8_t val);
 extern uint16_t marlin_set_print_speed(uint16_t val);
 extern uint16_t marlin_set_flow_factor(uint16_t val);

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -378,7 +378,9 @@ int marlin_server_inject_gcode(const char *gcode) {
 }
 
 void marlin_server_settings_save(void) {
-    eeprom_set_var(EEVAR_ZOFFSET, variant8_flt(probe_offset.z));
+    if (!eeprom_set_z_offset(probe_offset.z)) {
+        assert(0 /* Z offset write failed */);
+    }
     eeprom_set_var(EEVAR_PID_BED_P, variant8_flt(Temperature::temp_bed.pid.Kp));
     eeprom_set_var(EEVAR_PID_BED_I, variant8_flt(Temperature::temp_bed.pid.Ki));
     eeprom_set_var(EEVAR_PID_BED_D, variant8_flt(Temperature::temp_bed.pid.Kd));
@@ -392,7 +394,7 @@ void marlin_server_settings_save(void) {
 void marlin_server_settings_load(void) {
     (void)settings.reset();
 #if HAS_BED_PROBE
-    probe_offset.z = variant8_get_flt(eeprom_get_var(EEVAR_ZOFFSET));
+    probe_offset.z = eeprom_get_z_offset();
 #endif
     Temperature::temp_bed.pid.Kp = variant8_get_flt(eeprom_get_var(EEVAR_PID_BED_P));
     Temperature::temp_bed.pid.Ki = variant8_get_flt(eeprom_get_var(EEVAR_PID_BED_I));

--- a/src/gui/dialogs/liveadjust_z.cpp
+++ b/src/gui/dialogs/liveadjust_z.cpp
@@ -108,7 +108,10 @@ WindowLiveAdjustZ::WindowLiveAdjustZ(window_t *parent, point_i16_t pt)
 void WindowLiveAdjustZ::Save() {
     /// store new z offset value into a marlin_vars & EEPROM
     variant8_t var = variant8_flt(number.GetValue());
-    eeprom_set_var(EEVAR_ZOFFSET, var);
+    if (!eeprom_set_z_offset(number.GetValue())) {
+        // could be during print, better not cause BSOD, just freeze in debug
+        assert(0 /* Z offset write failed */);
+    }
     marlin_set_var(MARLIN_VAR_Z_OFFSET, var);
     /// force update marlin vars
     marlin_update_vars(MARLIN_VAR_MSK(MARLIN_VAR_Z_OFFSET));

--- a/src/gui/screen_menu_steel_sheets.cpp
+++ b/src/gui/screen_menu_steel_sheets.cpp
@@ -121,12 +121,12 @@ protected:
             break;
         case profile_action::Select:
             log_debug(GUI, "MI_SHEET_SELECT");
-            sheet_select(Index::value);
+            sheet_profile_select(Index::value);
             marlin_set_z_offset(variant8_get_flt(eeprom_get_var(EEVAR_ZOFFSET)));
             break;
         case profile_action::Calibrate:
             log_debug(GUI, "MI_SHEET_CALIBRATE");
-            sheet_calibrate(Index::value);
+            sheet_profile_select(Index::value);
             ScreenWizard::Run(wizard_run_type_t::firstlay);
             break;
         case profile_action::Rename:

--- a/src/gui/screen_menu_steel_sheets.cpp
+++ b/src/gui/screen_menu_steel_sheets.cpp
@@ -122,7 +122,6 @@ protected:
         case profile_action::Select:
             log_debug(GUI, "MI_SHEET_SELECT");
             sheet_profile_select(Index::value);
-            marlin_set_z_offset(variant8_get_flt(eeprom_get_var(EEVAR_ZOFFSET)));
             break;
         case profile_action::Calibrate:
             log_debug(GUI, "MI_SHEET_CALIBRATE");

--- a/src/gui/wizard/firstlay.cpp
+++ b/src/gui/wizard/firstlay.cpp
@@ -12,6 +12,7 @@
 #include "DialogHandler.hpp"
 #include <algorithm>         // std::max
 #include "screen_wizard.hpp" // ChangeStartState
+#include "bsod.h"
 
 enum {
     FKNOWN = 0x01,      //filament is known
@@ -119,8 +120,10 @@ WizardState_t StateFnc_FIRSTLAY_MSBX_USEVAL() {
         }
         // this MakeRAM is safe - buff is allocated in RAM for the lifetime of MsgBox
         if (MsgBox(string_view_utf8::MakeRAM((const uint8_t *)buff), Responses_YesNo) == Response::No) {
-            marlin_set_z_offset(z_offset_def);
-            eeprom_set_var(EEVAR_ZOFFSET, variant8_flt(z_offset_def));
+            eeprom_set_z_offset(z_offset_def);
+            if (!eeprom_set_z_offset(z_offset_def)) {
+                bsod("Z offset write failed");
+            }
         }
     }
 

--- a/src/guiapi/src/MItem_menus.cpp
+++ b/src/guiapi/src/MItem_menus.cpp
@@ -186,7 +186,6 @@ MI_CURRENT_PROFILE::MI_CURRENT_PROFILE()
 void MI_CURRENT_PROFILE::click(IWindowMenu & /*window_menu*/) {
     sheet_next_calibrated();
     UpdateLabel();
-    marlin_set_z_offset(variant8_get_flt(eeprom_get_var(EEVAR_ZOFFSET)));
 }
 
 void MI_CURRENT_PROFILE::UpdateLabel() {


### PR DESCRIPTION
Ensure CRC calculation, minimize I2C traffic
Rename sheet_select to sheet_profile_select
Remove sheet_calibrate method 
Rename sheet_select to sheet_profile_select and allow not calibrated sheet selection
Change Z offset API
Rewrite eeprom update - define structure for all previous versions
Improve sheet templates to inherit from non template parent - to save codesize (2kB) and make debug easier