### PR TITLE
BFW-2332: Link: Show current gcode name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -573,6 +573,7 @@ target_sources(
           $<$<BOOL:${FILAMENT_SENSOR}>:src/common/thread_measurement.cpp>
           src/common/adc.cpp
           src/common/basename.c
+          src/common/lfn.c
           src/common/i2c.cpp
           src/common/hardware_serial.cpp
           src/common/eeprom.cpp

--- a/lib/WUI/wui_REST_api.c
+++ b/lib/WUI/wui_REST_api.c
@@ -206,9 +206,17 @@ void get_job(char *data, const uint32_t buf_len) {
     }
 
     if (has_job) {
-        const char *filename = basename(vars->media_LFN);
+        /*
+         * The file names. We probably don't work with anything that's unicode
+         * anyway. So we can use the long one for both name and display.
+         *
+         * The path is available only in the short version, unfortunately, but
+         * that's for internal uses of things anyway, so it probably doesn't
+         * matter.
+         */
+        const char *filename = vars->media_LFN;
         JSONIFY_STR(filename);
-        const char *path = vars->media_LFN;
+        const char *path = vars->media_SFN_path;
         JSONIFY_STR(path);
 
         snprintf(data, buf_len,
@@ -216,7 +224,7 @@ void get_job(char *data, const uint32_t buf_len) {
             "\"state\":\"%s\","
             "\"job\":{"
             "\"estimatedPrintTime\":%" PRIu32 ","
-            "\"file\":{\"name\":\"%s\",\"path\":\"%s\"}"
+            "\"file\":{\"name\":\"%s\",\"path\":\"%s\",\"display\":\"%s\"}"
             "}," // } job
             "\"progress\":{"
             "\"completion\":%f,"
@@ -226,7 +234,7 @@ void get_job(char *data, const uint32_t buf_len) {
             "}",
             state,
 
-            vars->print_duration + vars->time_to_end, filename_escaped, path_escaped,
+            vars->print_duration + vars->time_to_end, filename_escaped, path_escaped, filename_escaped,
             ((double)vars->sd_percent_done / 100.0), // We might want to have better resolution that whole percents.
             vars->print_duration, vars->time_to_end);
     } else {

--- a/lib/WUI/wui_api.c
+++ b/lib/WUI/wui_api.c
@@ -38,6 +38,7 @@ static char tmp_filename[FILE_NAME_BUFFER_LEN];
 
 static bool sntp_time_init = false;
 static char wui_media_LFN[FILE_NAME_BUFFER_LEN]; // static buffer for gcode file name
+static char wui_media_SFN_path[FILE_PATH_BUFFER_LEN];
 static atomic_int_least32_t uploaded_gcodes;
 
 void wui_marlin_client_init(void) {
@@ -46,7 +47,16 @@ void wui_marlin_client_init(void) {
     marlin_client_set_event_notify(MARLIN_EVT_MSK_DEF - MARLIN_EVT_MSK_FSM, NULL);
     marlin_client_set_change_notify(MARLIN_VAR_MSK_DEF | MARLIN_VAR_MSK_WUI, NULL);
     if (vars) {
+        /*
+         * Note about synchronizing access to these buffers.
+         *
+         * A marlin client is tied to a thread and we may access it from one or
+         * another (depending on if the PrusaLink runs over wifi or over
+         * ethernet). So we need two. But we can afford to share the buffers,
+         * because only one of them is active at a time.
+         */
         vars->media_LFN = wui_media_LFN;
+        vars->media_SFN_path = wui_media_SFN_path;
     }
 }
 

--- a/src/common/lfn.c
+++ b/src/common/lfn.c
@@ -1,0 +1,47 @@
+#include "lfn.h"
+
+#include <string.h>
+#include <sys/dirent.h>
+
+void get_LFN(char *lfn, size_t lfn_size, char *path) {
+    /*
+     * This is a bit of a hack. It sees the only place we are able to receive
+     * the LFN is by iterating through a directory. So we do so and look for
+     * the matching file.
+     */
+    char *last = rindex(path, '/');
+
+    if (!last) {
+        // This is weird. We have no slash in the path, this shouldn't happen.
+        // So copy it whole just to have something.
+        strlcpy(lfn, path, lfn_size);
+        return;
+    }
+
+    char *fname = last + 1;
+    strlcpy(lfn, fname, lfn_size);
+
+    *last = '\0';
+    DIR *d = opendir(path);
+    *last = '/';
+    if (!d) {
+        return;
+    }
+
+    struct dirent *ent;
+    /*
+     * Even though it doesn't look so from the signature, our readdir
+     * is thread safe. The returned buffer is inside the DIR structure.
+     */
+    while ((ent = readdir(d))) {
+        /*
+         * Allow the input some flexibility - both long and short file
+         * names and case insensitive (it's FAT, after all).
+         */
+        if ((strcasecmp(ent->d_name, fname) == 0) || (strcasecmp(ent->lfn, fname) == 0)) {
+            strlcpy(lfn, ent->lfn, lfn_size);
+            break;
+        }
+    }
+    closedir(d);
+}

--- a/src/common/lfn.h
+++ b/src/common/lfn.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
+/**
+ * \brief Get the long file name of a given file.
+ *
+ * Given a full path to a file, this extracts the long file name (the basename
+ * only, not the path) and stores it to the provided buffer (the lfn_size is
+ * the size of the buffer, and must accomodate space for '\0').
+ *
+ * Note that the path is _not_ constant and it is temporarily modified in-place
+ * (and fixed) later on.
+ *
+ * This is a "best effort" approach. It never fails, but if there's a failure
+ * internally, the short file name from the path might be returned.
+ */
+void get_LFN(char *lfn, size_t lfn_size, char *path);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/integration/test_prusa_link.py
+++ b/tests/integration/test_prusa_link.py
@@ -164,8 +164,9 @@ async def test_printing_job(running_printer_client):
     assert job["state"] == "Printing"
     # Hopefully the test won't take that long
     assert job["progress"]["printTime"] < 300
-    # FIXME: Fails. #BFW-2332
-    # assert job["job"]["file"]["name"] == gcode_name
+    assert job["job"]["file"]["name"] == "box.gcode"
+    assert job["job"]["file"]["display"] == "box.gcode"
+    assert job["job"]["file"]["path"] == "/usb/BOX~1.GCO"
     # It's something around 25 minutes...
     # FIXME: The following sometimes fail too. It seems marlin_vars are not
     # always properly updated?


### PR DESCRIPTION
* The long file name inside marlin was not set (apparently lost when
  transitioning to "common" file API). Return the setting back.
* Adjust the API to contain all the relevant names (in the best
  approximation we can do).
* Enabling the relevant test.