### PR TITLE
Better represent marlin var ids in marlin server

### DIFF
--- a/src/common/marlin_server.hpp
+++ b/src/common/marlin_server.hpp
@@ -57,12 +57,12 @@ class FSM_notifier {
         float offset = 0; //offset from lowest value
         uint8_t progress_min = 0;
         uint8_t progress_max = 100;
-        uint8_t var_id;
+        marlin_var_id_t var_id;
         std::optional<uint8_t> last_progress_sent;
         data()
             : type(ClientFSM::_none)
             , phase(0)
-            , var_id(0) {}
+            , var_id(static_cast<marlin_var_id_t>(0)) {}
     };
     //static members
     //there can be only one active instance of FSM_notifier, which use this data
@@ -75,7 +75,7 @@ class FSM_notifier {
 
 protected:
     //protected ctor so this instance cannot be created
-    FSM_notifier(ClientFSM type, uint8_t phase, variant8_t min, variant8_t max, uint8_t progress_min, uint8_t progress_max, uint8_t var_id);
+    FSM_notifier(ClientFSM type, uint8_t phase, variant8_t min, variant8_t max, uint8_t progress_min, uint8_t progress_max, marlin_var_id_t var_id);
     FSM_notifier(const FSM_notifier &) = delete;
     virtual void preSendNotification() {}
     virtual void postSendNotification() {}
@@ -86,14 +86,14 @@ public:
 };
 
 //template used by using statement
-template <int VAR_ID, class T>
+template <marlin_var_id_t VAR_ID, class T>
 class Notifier : public FSM_notifier {
 public:
     Notifier(ClientFSM type, uint8_t phase, T min, T max, uint8_t progress_min, uint8_t progress_max) {};
     //        : FSM_notifier(type, phase, min, max, progress_min, progress_max, VAR_ID) {}
 };
 
-template <int VAR_ID>
+template <marlin_var_id_t VAR_ID>
 class Notifier<VAR_ID, float> : public FSM_notifier {
 public:
     Notifier(ClientFSM type, uint8_t phase, float min, float max, uint8_t progress_min, uint8_t progress_max)

--- a/src/common/marlin_vars.c
+++ b/src/common/marlin_vars.c
@@ -50,20 +50,20 @@ const char *__var_name[] = {
 
 static_assert((sizeof(__var_name) / sizeof(char *)) == (MARLIN_VAR_MAX + 1), "Invalid number of elements in __var_name");
 
-const char *marlin_vars_get_name(uint8_t var_id) {
+const char *marlin_vars_get_name(marlin_var_id_t var_id) {
     if (var_id <= MARLIN_VAR_MAX)
         return __var_name[var_id];
     return "";
 }
 
-int marlin_vars_get_id_by_name(const char *var_name) {
+marlin_var_id_t marlin_vars_get_id_by_name(const char *var_name) {
     for (int i = 0; i <= MARLIN_VAR_MAX; i++)
         if (strcmp(var_name, __var_name[i]) == 0)
             return i;
     return -1;
 }
 
-variant8_t marlin_vars_get_var(marlin_vars_t *vars, uint8_t var_id) {
+variant8_t marlin_vars_get_var(marlin_vars_t *vars, marlin_var_id_t var_id) {
     if (!vars)
         return variant8_empty();
 
@@ -147,10 +147,11 @@ variant8_t marlin_vars_get_var(marlin_vars_t *vars, uint8_t var_id) {
     case MARLIN_VAR_TRAVEL_ACCEL:
         return variant8_flt(vars->travel_acceleration);
     }
-    return variant8_empty();
+
+    abort(); // unreachable
 }
 
-void marlin_vars_set_var(marlin_vars_t *vars, uint8_t var_id, variant8_t var) {
+void marlin_vars_set_var(marlin_vars_t *vars, marlin_var_id_t var_id, variant8_t var) {
     if (!vars)
         return;
 
@@ -284,7 +285,7 @@ void marlin_vars_set_var(marlin_vars_t *vars, uint8_t var_id, variant8_t var) {
     }
 }
 
-int marlin_vars_value_to_str(marlin_vars_t *vars, uint8_t var_id, char *str, unsigned int size) {
+int marlin_vars_value_to_str(marlin_vars_t *vars, marlin_var_id_t var_id, char *str, unsigned int size) {
     if (!vars)
         return 0;
 
@@ -359,7 +360,7 @@ int marlin_vars_value_to_str(marlin_vars_t *vars, uint8_t var_id, char *str, uns
     return 0;
 }
 
-int marlin_vars_str_to_value(marlin_vars_t *vars, uint8_t var_id, const char *str) {
+int marlin_vars_str_to_value(marlin_vars_t *vars, marlin_var_id_t var_id, const char *str) {
     if (!vars)
         return 0;
 

--- a/src/common/marlin_vars.c
+++ b/src/common/marlin_vars.c
@@ -381,6 +381,11 @@ int marlin_vars_str_to_value(marlin_vars_t *vars, marlin_var_id_t var_id, const 
     case MARLIN_VAR_POS_Z:
     case MARLIN_VAR_POS_E:
         return sscanf(str, "%f", &(vars->pos[var_id - MARLIN_VAR_POS_X]));
+    case MARLIN_VAR_CURR_POS_X:
+    case MARLIN_VAR_CURR_POS_Y:
+    case MARLIN_VAR_CURR_POS_Z:
+    case MARLIN_VAR_CURR_POS_E:
+        return sscanf(str, "%f", &(vars->curr_pos[var_id - MARLIN_VAR_CURR_POS_X]));
     case MARLIN_VAR_TEMP_NOZ:
         return sscanf(str, "%f", &(vars->temp_nozzle));
     case MARLIN_VAR_TEMP_BED:

--- a/src/common/marlin_vars.h
+++ b/src/common/marlin_vars.h
@@ -5,7 +5,7 @@
 #include "../../src/gui/file_list_defs.h"
 
 // Marlin variables
-enum {
+typedef enum {
     MARLIN_VAR_MOTION = 0x00,              // R:  uint8, method stepper.axis_is_moving
     MARLIN_VAR_GQUEUE = 0x01,              // R:  uint8, method queue.length
     MARLIN_VAR_PQUEUE = 0x02,              // R:  uint8, variables planner.block_buffer_head/tail
@@ -46,7 +46,7 @@ enum {
     MARLIN_VAR_CURR_POS_E = 0x25,          // R: ==||==
     MARLIN_VAR_TRAVEL_ACCEL = 0x26,        // R: float travel_acceleration
     MARLIN_VAR_MAX = MARLIN_VAR_TRAVEL_ACCEL
-};
+} marlin_var_id_t;
 
 // variable masks
 #define MARLIN_VAR_MSK(v_id)                               (((uint64_t)1) << (uint8_t)(v_id))
@@ -172,22 +172,22 @@ inline int is_abort_state(marlin_print_state_t st) {
 }
 
 // returns variable name
-extern const char *marlin_vars_get_name(uint8_t var_id);
+extern const char *marlin_vars_get_name(marlin_var_id_t var_id);
 
 // returns variable id by name or -1 if not match
-extern int marlin_vars_get_id_by_name(const char *var_name);
+extern marlin_var_id_t marlin_vars_get_id_by_name(const char *var_name);
 
 // get variable value as variant8 directly from vars structure
-extern variant8_t marlin_vars_get_var(marlin_vars_t *vars, uint8_t var_id);
+extern variant8_t marlin_vars_get_var(marlin_vars_t *vars, marlin_var_id_t var_id);
 
 // set variable value as variant8 directly in vars structure
-extern void marlin_vars_set_var(marlin_vars_t *vars, uint8_t var_id, variant8_t var);
+extern void marlin_vars_set_var(marlin_vars_t *vars, marlin_var_id_t var_id, variant8_t var);
 
 // format variable to string
-extern int marlin_vars_value_to_str(marlin_vars_t *vars, uint8_t var_id, char *str, unsigned int size);
+extern int marlin_vars_value_to_str(marlin_vars_t *vars, marlin_var_id_t var_id, char *str, unsigned int size);
 
 // parse variable from string, returns sscanf result (1 = ok)
-extern int marlin_vars_str_to_value(marlin_vars_t *vars, uint8_t var_id, const char *str);
+extern int marlin_vars_str_to_value(marlin_vars_t *vars, marlin_var_id_t var_id, const char *str);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This makes sure we get a compiler warning when we forget to list a case in an switch handling all marlin events.