### PR TITLE
GUI: Adjust help text positions

### DIFF
--- a/src/gui/screen_menu_fw_update.cpp
+++ b/src/gui/screen_menu_fw_update.cpp
@@ -13,6 +13,8 @@
 #include "i18n.h"
 #include "ScreenHandler.hpp"
 
+static const constexpr uint8_t blank_space_h = 10; // Visual bottom padding for HELP string
+
 class MI_UPDATE_LABEL : public WI_LABEL_t {
     static constexpr const char *const label = N_("FW Update");
 
@@ -81,7 +83,7 @@ public:
 
 protected:
     static inline uint16_t get_help_h() {
-        return helper_lines * (resource_font(helper_font)->h);
+        return helper_lines * (resource_font(helper_font)->h + 1); // +1 for line paddings
     }
 };
 
@@ -89,7 +91,7 @@ ScreenMenuFwUpdate::ScreenMenuFwUpdate()
     : AddSuperWindow<screen_t>(nullptr)
     , menu(this, GuiDefaults::RectScreenBody - Rect16::Height_t(get_help_h()), &container)
     , header(this)
-    , help(this, Rect16(GuiDefaults::RectScreen.Left(), uint16_t(GuiDefaults::RectFooter.Top()) - get_help_h(), GuiDefaults::RectScreen.Width(), get_help_h()), is_multiline::yes)
+    , help(this, Rect16(GuiDefaults::RectScreen.Left(), uint16_t(GuiDefaults::RectFooter.Top()) - get_help_h() - blank_space_h, GuiDefaults::RectScreen.Width(), get_help_h()), is_multiline::yes)
     , footer(this) {
     header.SetText(_(label));
     help.font = resource_font(helper_font);

--- a/src/gui/version_info_ST7789V.cpp
+++ b/src/gui/version_info_ST7789V.cpp
@@ -19,6 +19,7 @@
 #include "../common/otp.h"
 
 static const constexpr uint8_t VERSION_INFO_STR_MAXLEN = 150;
+static const constexpr uint8_t blank_space_h = 10; // Visual bottom padding for HELP string
 
 using MenuContainer = WinMenuContainer<MI_RETURN>;
 
@@ -39,7 +40,7 @@ public:
 
 protected:
     static inline uint16_t get_help_h() {
-        return helper_lines * (resource_font(helper_font)->h);
+        return helper_lines * (resource_font(helper_font)->h + 1); // +1 for line paddings
     }
 };
 
@@ -47,7 +48,7 @@ ScreenMenuVersionInfo::ScreenMenuVersionInfo()
     : AddSuperWindow<screen_t>(nullptr)
     , menu(this, GuiDefaults::RectScreenBody - Rect16::Height_t(get_help_h()), &container)
     , header(this)
-    , help(this, Rect16(GuiDefaults::RectScreen.Left(), uint16_t(GuiDefaults::RectFooter.Top()) - get_help_h(), GuiDefaults::RectScreen.Width(), get_help_h()), is_multiline::yes)
+    , help(this, Rect16(GuiDefaults::RectScreen.Left(), uint16_t(GuiDefaults::RectFooter.Top()) - get_help_h() - blank_space_h, GuiDefaults::RectScreen.Width(), get_help_h()), is_multiline::yes)
     , footer(this) {
     header.SetText(_(label));
     help.font = resource_font(helper_font);


### PR DESCRIPTION
Multiline footer causes text misalignments, adjust help text position in FW update screen.