### PR TITLE
Fix Marlin server communication

### DIFF
--- a/src/common/marlin_vars.c
+++ b/src/common/marlin_vars.c
@@ -65,6 +65,8 @@ marlin_var_id_t marlin_vars_get_id_by_name(const char *var_name) {
 
 variant8_t marlin_vars_get_var(marlin_vars_t *vars, marlin_var_id_t var_id) {
     if (!vars)
+        // FIXME: send no variant (needs new variant type) instead of empty one.
+        // Empty variant is a usable / sendable variant.
         return variant8_empty();
 
     switch (var_id) {

--- a/src/common/marlin_vars.h
+++ b/src/common/marlin_vars.h
@@ -178,6 +178,7 @@ extern const char *marlin_vars_get_name(marlin_var_id_t var_id);
 extern marlin_var_id_t marlin_vars_get_id_by_name(const char *var_name);
 
 // get variable value as variant8 directly from vars structure
+// \returns empty variant if the variable is not readable
 extern variant8_t marlin_vars_get_var(marlin_vars_t *vars, marlin_var_id_t var_id);
 
 // set variable value as variant8 directly in vars structure


### PR DESCRIPTION
If an event was not sent immediately, it was never sent again because the information was stored in a wrong variable.