### PR TITLE
Revert "marlin: QUICKFIX for wrong calibrated X & Y axis"

### DIFF
--- a/lib/Marlin/Marlin/src/gcode/calibrate/G28.cpp
+++ b/lib/Marlin/Marlin/src/gcode/calibrate/G28.cpp
@@ -218,26 +218,6 @@ void GcodeSuite::G28(const bool always_home_all) {
     }
   #endif
 
-  #ifdef PRINTER_PRUSA_MINI
-    // -- X & Y coords default position
-    current_position.set(X_HOME_POS, Y_HOME_POS);
-    constexpr const int X_home = X_HOME_DIR > 0 ? X_MAX_POS : X_MIN_POS;
-    constexpr const int Y_home = Y_HOME_DIR > 0 ? Y_MAX_POS : Y_MIN_POS;
-
-    float d;
-    d = (LOGICAL_TO_NATIVE(X_home, X_AXIS) - current_position[X_AXIS]);
-    if (!NEAR_ZERO(d)) {
-      position_shift[X_AXIS] += d;
-      update_workspace_offset(X_AXIS);
-    }
-    d = (LOGICAL_TO_NATIVE(Y_home, Y_AXIS) - current_position[Y_AXIS]);
-    if (!NEAR_ZERO(d)) {
-      position_shift[Y_AXIS] += d;
-      update_workspace_offset(Y_AXIS);
-    }
-    sync_plan_position();
-  #endif
-
   if (!homing_needed() && parser.boolval('O')) {
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> homing not needed, skip\n<<< G28");
     return;


### PR DESCRIPTION
This fixes Z safe home position not respected when "G28 Z"
is called after G28.

Repeatedly calling "G28 Z" shifted safe homing position more and
more away from the bed edge with each call.

This may break again selftest - commit removed was hotfix of
problem that after interrupted selftest printer might
have shifted workspace.

This reverts commits:
c233a4cf4d1b19cae704777a48698878692689ef
e4f051449c10052cb2213b12bb6425cb2e39ec2e
17df6dc7cae05a242001f09ea3b6daac47a8beb9

note: This does NOT fix similar safe home position problem https://dev.prusa3d.com/browse/BFW-2277