### PR TITLE
Fix HardFault in Metrics::RecordRuntimeStats

### DIFF
--- a/src/common/app_metrics.cpp
+++ b/src/common/app_metrics.cpp
@@ -23,7 +23,11 @@ void Buddy::Metrics::RecordRuntimeStats() {
     if (ticks_diff(ticks_ms(), last_recorded_ticks) > 3000) {
         int count = uxTaskGetSystemState(task_statuses, sizeof(task_statuses) / sizeof(task_statuses[1]), NULL);
         for (int idx = 0; idx < count; idx++) {
-            size_t s = malloc_usable_size(task_statuses[idx].pxStackBase);
+            const char *stack_base = (char *)task_statuses[idx].pxStackBase;
+            size_t s = 0;
+            /* We can only report free stack space for heap-allocated stack frames. */
+            if (mem_is_heap_allocated(stack_base))
+                s = malloc_usable_size((void *)stack_base);
             const char *task_name = task_statuses[idx].pcTaskName;
             if (strcmp(task_name, "Tmr Svc") == 0)
                 task_name = "TmrSvc";

--- a/src/common/heap.c
+++ b/src/common/heap.c
@@ -100,3 +100,7 @@ void __malloc_unlock(struct _reent *r) {
     if (malloc_lock_counter == 0)
         EXIT_CRITICAL_SECTION(malloc_saved_interrupt_status);
 };
+
+uint32_t mem_is_heap_allocated(const void *ptr) {
+    return (ptr >= (void *)&__HeapBase && ptr < (void *)&__HeapLimit);
+}

--- a/src/common/heap.h
+++ b/src/common/heap.h
@@ -7,6 +7,8 @@ extern "C" {
 uint32_t heap_total_size;
 uint32_t heap_bytes_remaining;
 
+uint32_t mem_is_heap_allocated(const void *ptr);
+
 #ifdef __cplusplus
 }
 #endif //__cplusplus


### PR DESCRIPTION
Make sure to only treat addresses within the heap memory range as heap-allocated while calculating free stack space for a task.