### PR TITLE
WUI: Don't forget AP security

### DIFF
--- a/lib/WUI/netdev.c
+++ b/lib/WUI/netdev.c
@@ -309,7 +309,7 @@ uint32_t netdev_set_dhcp(uint32_t netdev_id) {
     if (pConfig != NULL) {
         CHANGE_FLAG_TO_DHCP(pConfig->lan.flag);
         pConfig->var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
-        save_net_params(pConfig, NULL, netdev_id);
+        save_net_params(pConfig, netdev_id == NETDEV_ESP_ID ? &ap : NULL, netdev_id);
         pConfig->var_mask = 0;
         return res;
     } else {
@@ -393,7 +393,7 @@ uint32_t netdev_set_static(uint32_t netdev_id) {
     if (pConfig != NULL) {
         CHANGE_FLAG_TO_STATIC(pConfig->lan.flag);
         pConfig->var_mask = ETHVAR_MSK(ETHVAR_LAN_FLAGS);
-        save_net_params(pConfig, NULL, netdev_id);
+        save_net_params(pConfig, netdev_id == NETDEV_ESP_ID ? &ap : NULL, netdev_id);
         pConfig->var_mask = 0;
         return res;
     } else {


### PR DESCRIPTION
When the save_net_params is called without an ap, but with saving flags,
it would forget the AP security. Make sure it is always called with the
ap when called on the wifi iface.

This is not the bestest and nicest code I've ever written, but there's a plan to do an overhaul of networking threads, init, setup, etc anyway (and it should come soon-ish), so I'm doing somewhat minimal patch to make it work in the meantime.