### PR TITLE
Remove unneded marlin client

### DIFF
--- a/lib/WUI/wui_api.c
+++ b/lib/WUI/wui_api.c
@@ -47,12 +47,8 @@ void wui_marlin_client_init(void) {
     marlin_client_set_change_notify(MARLIN_VAR_MSK_DEF | MARLIN_VAR_MSK_WUI, NULL);
     if (vars) {
         /*
-         * Note about synchronizing access to these buffers.
-         *
-         * A marlin client is tied to a thread and we may access it from one or
-         * another (depending on if the PrusaLink runs over wifi or over
-         * ethernet). So we need two. But we can afford to share the buffers,
-         * because only one of them is active at a time.
+         * Note: We currently have only a single marlin client for
+         * WUI/networking. So we can use a single buffer there.
          */
         vars->media_LFN = wui_media_LFN;
         vars->media_SFN_path = wui_media_SFN_path;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -13,7 +13,7 @@
 //--------------------------------------
 //marlin api config
 enum {
-    MARLIN_MAX_CLIENTS = 4,    // maximum number of clients registered in same time
+    MARLIN_MAX_CLIENTS = 3,    // maximum number of clients registered in same time
     MARLIN_MAX_REQUEST = 100,  // maximum request length in chars
     MARLIN_SERVER_QUEUE = 128, // size of marlin server input character queue (number of characters)
     MARLIN_CLIENT_QUEUE = 16,  // size of marlin client input message queue (number of messages)


### PR DESCRIPTION
We got rid of one of the threads that were running the web server (now
there's just one, not two) ‒ that means we don't need the extra marlin
client.