### PR TITLE
Turn off AlTCP

### DIFF
--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -160,7 +160,7 @@ extern "C" {
     #define LWIP_NETIF_HOSTNAME          1
     #define LWIP_HTTPD_SUPPORT_POST      1
     #define LWIP_COMPAT_SOCKETS          1
-    #define LWIP_ALTCP                   1
+    #define LWIP_ALTCP                   0
     #define LWIP_HTTPD_DYNAMIC_FILE_READ 1
     #define LWIP_TIMERS                  1
 

--- a/lib/WUI/nhttp/server.cpp
+++ b/lib/WUI/nhttp/server.cpp
@@ -521,25 +521,12 @@ Server::Buffer *Server::find_empty_buffer() {
 bool Server::start() {
     assert(!listener);
 
-    auto listener_alloc = defs.listener_alloc();
+    listener.reset(defs.listener_alloc());
 
-    altcp_pcb *l = altcp_new_ip_type(&listener_alloc, IPADDR_TYPE_ANY);
-
-    if (l == nullptr) {
-        return false;
-    }
-    listener.reset(l);
-
-    /* set SOF_REUSEADDR to explicitly bind httpd to multiple
-     * interfaces and to allow re-binding after enabling & disabling
-     * ethernet. This is set in the prusa_alloc. */
-    const auto err = altcp_bind(listener.get(), IP_ANY_TYPE, defs.port());
-    if (err != ERR_OK) {
-        listener.reset();
+    if (!listener) {
         return false;
     }
 
-    listener.reset(altcp_listen(listener.release()));
     altcp_arg(listener.get(), this);
     altcp_accept(listener.get(), Server::accept_wrap);
 

--- a/lib/WUI/nhttp/server.h
+++ b/lib/WUI/nhttp/server.h
@@ -63,9 +63,10 @@ public:
      *   but for now, changing the key is very rare and happens in-place.
      */
     virtual const char *get_api_key() const = 0;
-    // TODO: Have our own abstraction layer for tests vs lwIP? This one is ugly and brings a lot of deps in.
-    virtual altcp_allocator_t listener_alloc() const = 0;
-    virtual uint16_t port() const = 0;
+    /**
+     * \brief Allocate the listener socket.
+     */
+    virtual altcp_pcb *listener_alloc() const = 0;
 };
 
 /**

--- a/lib/WUI/wui.c
+++ b/lib/WUI/wui.c
@@ -136,29 +136,3 @@ void StartWebServerTask(void const *argument) {
 const char *wui_get_api_key() {
     return variant8_get_pch(prusa_link_api_key);
 }
-
-struct altcp_pcb *prusa_alloc(void *arg, uint8_t ip_type) {
-    uint32_t active_device_id = netdev_get_active_id();
-    if (active_device_id == NETDEV_ETH_ID || active_device_id == NETDEV_ESP_ID) {
-        struct altcp_pcb *result = altcp_tcp_new_ip_type(ip_type);
-        /*
-         * Hack:
-         * We need the option for listening sockets, because it otherwise
-         * breaks if we turn the interface down and up again (and therefore
-         * close and open a listening socket on the same port). Apparently,
-         * setting interface down does not kill/wipe all its connections/puts
-         * them into TCP_WAIT state.
-         *
-         * This should do nothing for connecting sockets, so it's fine to set.
-         *
-         * This is the wrong place to do it, but there's no other as other
-         * places can't know for sure the actide device didn't change.
-         */
-        if (result != NULL) {
-            ip_set_option((struct tcp_pcb *)result->state, SOF_REUSEADDR);
-        }
-        return result;
-    } else {
-        return NULL;
-    }
-}

--- a/lib/WUI/wui.h
+++ b/lib/WUI/wui.h
@@ -21,8 +21,6 @@ extern "C" {
 *****************************************************************************/
 void StartWebServerTask(void const *argument);
 
-struct altcp_pcb *prusa_alloc(void *arg, uint8_t ip_type);
-
 #ifdef __cplusplus
 }
 #endif // __cplusplus


### PR DESCRIPTION
We don't need it now, we have both interfaces directly on LwIP. Tests
still use AlTCP and the code _syntactically_ does so too (it only turns
off the config option, which creates relevant typedefs/defines to turn
the code into basic TCP manipulation in compile time).

This saves about 3kB of flash and maybe 0.5kB of RAM.