### PR TITLE
gui: Improve redraw handling

### DIFF
--- a/src/gui/dialogs/DialogHandler.cpp
+++ b/src/gui/dialogs/DialogHandler.cpp
@@ -127,14 +127,18 @@ void DialogHandler::PreOpen(ClientFSM dialog, uint8_t data) {
     Command(var.u32, var.u16);
 }
 
-void DialogHandler::Loop() {
+redraw_cmd_t DialogHandler::Loop() {
     fsm::variant_t variant = command_queue.Front();
-
+    bool processed = false;
     // execute all commands - fewer redraws
     while (variant.GetCommand() != ClientFSM_Command::none) {
+        processed = true;
         command(variant);
         command_queue.Pop(); //erase item from queue
 
         variant = command_queue.Front();
     }
+    if (variant.GetCommand() != ClientFSM_Command::none)
+        return redraw_cmd_t::skip;
+    return processed ? redraw_cmd_t::redraw : redraw_cmd_t::none;
 }

--- a/src/gui/dialogs/DialogHandler.hpp
+++ b/src/gui/dialogs/DialogHandler.hpp
@@ -4,6 +4,12 @@
 #include "fsm_types.hpp"
 #include "DialogFactory.hpp"
 
+enum class redraw_cmd_t : int {
+    none,
+    skip,
+    redraw,
+};
+
 class DialogHandler {
     static_unique_ptr<IDialogMarlin> ptr;
     DialogFactory::Ctors dialog_ctors;
@@ -25,6 +31,6 @@ public:
     static void Command(uint32_t u32, uint16_t u16);     //static method to be registered as callback, marlin client is in C, so cannot pass fsm::variant_t
     static void PreOpen(ClientFSM dialog, uint8_t data); //can be enforced (pre openned), unlike change/close
 
-    void Loop();                                          //synchronization loop, call it outside event
+    redraw_cmd_t Loop();                                  //synchronization loop, call it outside event
     void WaitUntilClosed(ClientFSM dialog, uint8_t data); // opens dialog, waits until closed, auto loops
 };


### PR DESCRIPTION
If all messages are received then redraw immediately. If a message is still in queue then skip the redraw to avoid 2 redraws one after another (screen blink). If no message is read then only one redraw is called in gui_loop.
BFW-2443