### PR TITLE
Delete an unused and broken function

### DIFF
--- a/src/common/media.h
+++ b/src/common/media.h
@@ -63,12 +63,6 @@ extern void media_set_removed(void);
 
 extern void media_set_error(media_error_t error);
 
-/// Computes short file name (SFN) path from a (potentially) long file name (LFN)
-/// path in filepath.
-/// @param sfn output buffer to store the SFN path
-/// @param filepath input LFN path, intentionally NOT const -
-extern void media_get_SFN_path(char *sfn, uint32_t sfn_size, char *filepath);
-
 #ifdef __cplusplus
 }
 #endif //__cplusplus


### PR DESCRIPTION
The media_get_SFN_path wasn't used anywhere. Furthermore, it didn't
work:
* It could infinite loop.
* It probably could overwrite data outside of the provided buffer.