### PR TITLE
USBHost: Add support for get time in ms from FW part

### DIFF
--- a/lib/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Inc/usbh_msc.h
+++ b/lib/Middlewares/ST/STM32_USB_Host_Library/Class/MSC/Inc/usbh_msc.h
@@ -184,6 +184,9 @@ USBH_StatusTypeDef USBH_MSC_Read(USBH_HandleTypeDef *phost, uint8_t lun,
 
 USBH_StatusTypeDef USBH_MSC_Write(USBH_HandleTypeDef *phost, uint8_t lun,
                                   uint32_t address, uint8_t *pbuf, uint32_t length);
+
+uint32_t USBH_MSC_GetIndependentTimerTicks();
+
 /**
   * @}
   */

--- a/src/usbh_diskio.c
+++ b/src/usbh_diskio.c
@@ -22,6 +22,8 @@
 /* Includes ------------------------------------------------------------------*/
 #include "ff_gen_drv.h"
 #include "usbh_diskio.h"
+#include "timing.h"
+
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 
@@ -227,6 +229,10 @@ DRESULT USBH_ioctl(BYTE lun, BYTE cmd, void *buff) {
     return res;
 }
 #endif /* FF_FS_READONLY == 0 */
+
+uint32_t USBH_MSC_GetIndependentTimerTicks() {
+    return ticks_ms();
+}
 
 /* USER CODE BEGIN lastSection */
 /* can be used to modify / undefine previous code or add new code */


### PR DESCRIPTION
This function is need for get time in ms into STM driver.
Prevent watchdog reset if FW unable read tata from USB flash.