### PR TITLE
filament: Turn off homing before (un)load filament

### DIFF
--- a/src/marlin_stubs/pause/pause.cpp
+++ b/src/marlin_stubs/pause/pause.cpp
@@ -734,30 +734,35 @@ void Pause::park_nozzle_and_notify() {
         if (wait_or_stop())
             return;
     }
-    // move to (x_pos, y_pos)
 
-    //home the X or Y axis if it is not homed and we want to move it
-    //homing is after Z move to be clear of all obstacles
-    //Should not affect other operations than Load/Unload/Change filament run from home screen without homing. We are homed during print
-    // FIXME: `current_position.x - park_pos.x != 0` is not a safe condition because `current_position` is unreliable (not homed) use NAN instead.
-    // TODO: make homeaxis non-blocking to allow quick_stop
-    if ((axis_homed & _BV(X_AXIS)) == 0 && current_position.x - park_pos.x != 0) {
-        homeaxis(X_AXIS);
-    }
-    if ((axis_homed & _BV(Y_AXIS)) == 0 && current_position.y - park_pos.y != 0) {
-        homeaxis(Y_AXIS);
-    }
-    if (x_greater_than_y) {
-        Notifier_POS_X N(ClientFSM::Load_unload, getPhaseIndex(), begin_pos, end_pos, parkMoveZPercent(Z_len, XY_len), 100); //from Z% to 100%
-        plan_park_move_to_xyz(park_pos, NOZZLE_PARK_XY_FEEDRATE, NOZZLE_PARK_Z_FEEDRATE);
-        if (wait_or_stop())
-            return;
+    // FIXME: Remove this after fixing the homing below (issues: MBL, endstops, different printers, etc.)
+    if ((axis_known_position & axis_homed & _BV(X_AXIS)) && (axis_known_position & axis_homed & _BV(Y_AXIS))) {
 
-    } else {
-        Notifier_POS_Y N(ClientFSM::Load_unload, getPhaseIndex(), begin_pos, end_pos, parkMoveZPercent(Z_len, XY_len), 100); //from Z% to 100%
-        plan_park_move_to_xyz(park_pos, NOZZLE_PARK_XY_FEEDRATE, NOZZLE_PARK_Z_FEEDRATE);
-        if (wait_or_stop())
-            return;
+        // move to (x_pos, y_pos)
+
+        //home the X or Y axis if it is not homed and we want to move it
+        //homing is after Z move to be clear of all obstacles
+        //Should not affect other operations than Load/Unload/Change filament run from home screen without homing. We are homed during print
+        // FIXME: `current_position.x - park_pos.x != 0` is not a safe condition because `current_position` is unreliable (not homed) use NAN instead.
+        // TODO: make homeaxis non-blocking to allow quick_stop
+        if ((axis_homed & _BV(X_AXIS)) == 0 && current_position.x - park_pos.x != 0) {
+            homeaxis(X_AXIS);
+        }
+        if ((axis_homed & _BV(Y_AXIS)) == 0 && current_position.y - park_pos.y != 0) {
+            homeaxis(Y_AXIS);
+        }
+        if (x_greater_than_y) {
+            Notifier_POS_X N(ClientFSM::Load_unload, getPhaseIndex(), begin_pos, end_pos, parkMoveZPercent(Z_len, XY_len), 100); //from Z% to 100%
+            plan_park_move_to_xyz(park_pos, NOZZLE_PARK_XY_FEEDRATE, NOZZLE_PARK_Z_FEEDRATE);
+            if (wait_or_stop())
+                return;
+
+        } else {
+            Notifier_POS_Y N(ClientFSM::Load_unload, getPhaseIndex(), begin_pos, end_pos, parkMoveZPercent(Z_len, XY_len), 100); //from Z% to 100%
+            plan_park_move_to_xyz(park_pos, NOZZLE_PARK_XY_FEEDRATE, NOZZLE_PARK_Z_FEEDRATE);
+            if (wait_or_stop())
+                return;
+        }
     }
 
     report_current_position();
@@ -776,20 +781,24 @@ void Pause::unpark_nozzle_and_notify() {
     const float Z_len = current_position.z - resume_pos.z; // sign does not matter, does not check Z max val (unlike park_nozzle_and_notify)
     const float XY_len = begin_pos - end_pos;              // sign does not matter
 
-    //home the axis if it is not homed
-    // we can move only one axis during parking and not home the other one and then unpark and move the not homed one, so we need to home it
-    if ((axis_homed & _BV(X_AXIS)) == 0 && current_position.x - park_pos.x != 0) {
-        homeaxis(X_AXIS);
-    }
-    if ((axis_homed & _BV(Y_AXIS)) == 0 && current_position.y - park_pos.y != 0) {
-        homeaxis(Y_AXIS);
-    }
-    if (x_greater_than_y) {
-        Notifier_POS_X N(ClientFSM::Load_unload, getPhaseIndex(), begin_pos, end_pos, 0, parkMoveXYPercent(Z_len, XY_len));
-        do_blocking_move_to_xy(resume_pos, NOZZLE_UNPARK_XY_FEEDRATE);
-    } else {
-        Notifier_POS_Y N(ClientFSM::Load_unload, getPhaseIndex(), begin_pos, end_pos, 0, parkMoveXYPercent(Z_len, XY_len));
-        do_blocking_move_to_xy(resume_pos, NOZZLE_UNPARK_XY_FEEDRATE);
+    // FIXME: Remove this after fixing the homing below (issues: MBL, endstops, different printers, etc.)
+    if ((axis_known_position & axis_homed & _BV(X_AXIS)) && (axis_known_position & axis_homed & _BV(Y_AXIS))) {
+
+        //home the axis if it is not homed
+        // we can move only one axis during parking and not home the other one and then unpark and move the not homed one, so we need to home it
+        if ((axis_homed & _BV(X_AXIS)) == 0 && current_position.x - park_pos.x != 0) {
+            homeaxis(X_AXIS);
+        }
+        if ((axis_homed & _BV(Y_AXIS)) == 0 && current_position.y - park_pos.y != 0) {
+            homeaxis(Y_AXIS);
+        }
+        if (x_greater_than_y) {
+            Notifier_POS_X N(ClientFSM::Load_unload, getPhaseIndex(), begin_pos, end_pos, 0, parkMoveXYPercent(Z_len, XY_len));
+            do_blocking_move_to_xy(resume_pos, NOZZLE_UNPARK_XY_FEEDRATE);
+        } else {
+            Notifier_POS_Y N(ClientFSM::Load_unload, getPhaseIndex(), begin_pos, end_pos, 0, parkMoveXYPercent(Z_len, XY_len));
+            do_blocking_move_to_xy(resume_pos, NOZZLE_UNPARK_XY_FEEDRATE);
+        }
     }
 
     // Move Z_AXIS to saved position, scope for Notifier_POS_Z


### PR DESCRIPTION
Current homing implementation is not robust. Until a better solutions is found it should be turned off.