### PR TITLE
planner: Guard for an aborted block in buffer_sync_block

### DIFF
--- a/lib/Marlin/Marlin/src/module/planner.cpp
+++ b/lib/Marlin/Marlin/src/module/planner.cpp
@@ -2534,6 +2534,7 @@ void Planner::buffer_sync_block() {
   // Wait for the next available block
   uint8_t next_buffer_head;
   block_t * const block = get_next_free_block(next_buffer_head);
+  if (!block) return;
 
   // Clear block
   memset(block, 0, sizeof(block_t));


### PR DESCRIPTION
While draining get_next_free_block() can return null.
This check was skipped while indroducing "draining".

Check and return early if this happens, as otherwise a sync block while
draining can result in setting block_buffer_head to null with
_unpleasant_ results.