### PR TITLE
marlin: Avoid off-by-1 buffer overflow in M31

### DIFF
--- a/lib/Marlin/Marlin/src/gcode/stats/M31.cpp
+++ b/lib/Marlin/Marlin/src/gcode/stats/M31.cpp
@@ -30,7 +30,7 @@
  * M31: Get the time since the start of SD Print (or last M109)
  */
 void GcodeSuite::M31() {
-  char buffer[21];
+  char buffer[22];
   duration_t(print_job_timer.duration()).toString(buffer);
 
   ui.set_status(buffer);

--- a/lib/Marlin/Marlin/src/libs/duration_t.h
+++ b/lib/Marlin/Marlin/src/libs/duration_t.h
@@ -110,7 +110,7 @@ struct duration_t {
    * @brief Formats the duration as a string
    * @details String will be formated using a "full" representation of duration
    *
-   * @param buffer The array pointed to must be able to accommodate 21 bytes
+   * @param buffer The array pointed to must be able to accommodate 22 bytes
    *
    * Output examples:
    *  123456789012345678901 (strlen)


### PR DESCRIPTION
Spotted through static analysis, but already fixed upstream