### PR TITLE
PrusaLink: include c header for the definition of PRIu* macros

### DIFF
--- a/lib/WUI/nhttp/headers.cpp
+++ b/lib/WUI/nhttp/headers.cpp
@@ -2,12 +2,12 @@
 #include "../../src/common/sha256.h"
 
 #include <cassert>
-#include <cinttypes>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
 
 #include <sys/stat.h>
+#include <inttypes.h> // PRIu* macros (not available in <cinttypes>)
 
 namespace nhttp {
 


### PR DESCRIPTION
On gcc10+ \<cinttypes\> doesn't include the definition of PRIu* macros.
Too keep both forward and backward compatibility, include the lower
\<inttypes.h\> which does.