### PR TITLE
resources: Cleanup include headers

### DIFF
--- a/include/resources/revision.hpp
+++ b/include/resources/revision.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <array>
+#include <cstdint>
 
 namespace buddy::resources {
 

--- a/src/resources/bootstrap.cpp
+++ b/src/resources/bootstrap.cpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <string.h>
 #include <optional>
+#include <cerrno>
 
 #include "bsod.h"
 #include "bbf.hpp"

--- a/src/resources/revision.cpp
+++ b/src/resources/revision.cpp
@@ -1,4 +1,5 @@
 #include "resources/revision.hpp"
+#include <stdio.h>
 
 bool buddy::resources::InstalledRevision::fetch(Revision &revision) {
     FILE *fp = fopen(file_path, "rb");


### PR DESCRIPTION
Spotted several missing includes by using more aggressive standard settings and warnings.