### PR TITLE
cleanup: Consistently declare osMutexId types

### DIFF
--- a/src/common/crc32.c
+++ b/src/common/crc32.c
@@ -6,7 +6,7 @@
 
 #ifdef CRC32_USE_HW
 osMutexDef(crc32_hw_mutex);
-osMutexId(crc32_hw_mutex_id);
+osMutexId crc32_hw_mutex_id;
 #endif //CRC32_USE_HW
 
 void crc32_init(void) {

--- a/src/common/trinamic.cpp
+++ b/src/common/trinamic.cpp
@@ -19,7 +19,7 @@ static uint8_t tmc_sg_axis = 0; // current axis for stalguard result sampling (0
 static tmc_sg_sample_cb_t *tmc_sg_sample_cb = NULL; // sg sample callback
 
 osMutexDef(tmc_mutex);
-osMutexId(tmc_mutex_id);
+osMutexId tmc_mutex_id;
 
 extern "C" {
 

--- a/src/libsysbase_syscalls.c
+++ b/src/libsysbase_syscalls.c
@@ -74,7 +74,7 @@ void __retarget_lock_release_recursive(_LOCK_T lock) {
 
 #else
 
-osMutexId(libsysbase_mutex_id);
+osMutexId libsysbase_mutex_id;
 
 static osMutexId getMutexId(_LOCK_T *lock) {
     // __LOCK_INIT sets _LOCK_T value to 1, use shared lock in that case.

--- a/src/logging/log_dest_syslog.c
+++ b/src/logging/log_dest_syslog.c
@@ -9,7 +9,8 @@
 #include "otp.h"
 
 osMutexDef(syslog_buffer_lock);
-osMutexId(syslog_buffer_lock_id);
+osMutexId syslog_buffer_lock_id;
+
 static bool initialized = false;
 static char *remote_ip_address = "";
 static int remote_port = 6514;


### PR DESCRIPTION
The osMutexId type is sometimes used to define variables using the
funcall-syntax form, which is generally unclear in this context.

Switch all such cases to a more conventional syntax form.