### PR TITLE
selftest: Add missing includes

### DIFF
--- a/src/common/selftest/selftest_MINI.cpp
+++ b/src/common/selftest/selftest_MINI.cpp
@@ -2,6 +2,7 @@
 
 #include <fcntl.h>
 #include <unistd.h>
+#include <climits>
 
 #include "selftest_MINI.h"
 #include "selftest_fan.h"
@@ -11,6 +12,7 @@
 #include "app.h"
 #include "otp.h"
 #include "hwio.h"
+#include "log.h"
 #include "marlin_server.hpp"
 #include "wizard_config.hpp"
 #include "../../Marlin/src/module/stepper.h"


### PR DESCRIPTION
climits: For UINT_MAX
log.h: For LOG_COMPONENT_DEF

These are currently included indirectly through other headers, but this
can cause unexpected build failure if those change and/or when using a
tighter std version.

I have another cleanup PR in the queue that will cause a build failure without this.