### PR TITLE
cleanup: Tighter header inclusion

### DIFF
--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -12,6 +12,7 @@
 #include "bsod.h"
 #include "timing.h"
 #include "cmsis_os.h"
+#include "log.h"
 
 #include "../Marlin/src/lcd/extensible_ui/ui_api.h"
 #include "../Marlin/src/gcode/queue.h"

--- a/src/common/marlin_server.h
+++ b/src/common/marlin_server.h
@@ -6,6 +6,8 @@
 #include "marlin_errors.h"
 #include "client_fsm_types.h"
 
+#include <stddef.h>
+
 // server flags
 // FIXME define the same type for these and marlin_server.flags
 static const uint16_t MARLIN_SFLG_STARTED = 0x0001; // server started (set in marlin_server_init)

--- a/src/common/marlin_vars.c
+++ b/src/common/marlin_vars.c
@@ -1,9 +1,11 @@
 // marlin_vars.c
 
 #include "marlin_vars.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <stdlib.h>
 
 // variable name constants (dbg)
 const char *__var_name[] = {

--- a/src/common/variant8.cpp
+++ b/src/common/variant8.cpp
@@ -569,8 +569,8 @@ variant8_t variant8_from_str(uint8_t type, char *str) {
     case VARIANT8_USER: {
         uint32_t usr32;
         uint16_t usr16;
-        uint8_t usr8;
-        int n = sscanf(str, "%lu %hu %hhu", &usr32, &usr16, &usr8);
+        uint16_t usr8; // wider than necessary due to missing SCNu8/%hhu on newlib-nano
+        int n = sscanf(str, "%" SCNu32 " %" SCNu16 " %" SCNu16, &usr32, &usr16, &usr8);
         if (n == 3)
             return variant8_user(usr32, usr16, usr8);
     }

--- a/src/common/variant8.cpp
+++ b/src/common/variant8.cpp
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <malloc.h>
 
 #define VARIANT8_DBG_MALLOC

--- a/src/common/variant8.h
+++ b/src/common/variant8.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <inttypes.h>
-#include <stdlib.h>
 #include <stdbool.h>
 
 enum {


### PR DESCRIPTION
Reduce include pollution by shuffling some headers around.
Detailed requirements in the commit messages.