### PR TITLE
More warning cleanups

### DIFF
--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -1395,7 +1395,7 @@ static int _server_set_var(const char *const name_val_str) {
     bool changed = false;
     char *val_str = strchr(name_val_str, ' ');
     *(val_str++) = 0;
-    if ((var_id = marlin_vars_get_id_by_name(name_val_str)) >= 0) {
+    if ((var_id = marlin_vars_get_id_by_name(name_val_str)) <= MARLIN_VAR_MAX) {
         if (marlin_vars_str_to_value(&(marlin_server.vars), var_id, val_str) == 1) {
             switch (var_id) {
             case MARLIN_VAR_TTEM_NOZ:

--- a/src/common/marlin_vars.c
+++ b/src/common/marlin_vars.c
@@ -62,7 +62,7 @@ marlin_var_id_t marlin_vars_get_id_by_name(const char *var_name) {
     for (int i = 0; i <= MARLIN_VAR_MAX; i++)
         if (strcmp(var_name, __var_name[i]) == 0)
             return i;
-    return -1;
+    return MARLIN_VAR_MAX + 1;
 }
 
 variant8_t marlin_vars_get_var(marlin_vars_t *vars, marlin_var_id_t var_id) {


### PR DESCRIPTION
Remove a few more warnings spotted with gcc 10, showing an actual implementation bug in _server_set_var