### PR TITLE
app: Add stubs for abort() and isatty()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,6 +661,7 @@ target_sources(
           src/common/sys.cpp
           src/common/sim_nozzle.c
           src/common/heap.c
+          src/common/stubs.c
           src/common/hwio_buddy_2209_02.cpp
           src/common/safe_state.cpp
           src/common/variant8.cpp

--- a/src/common/stubs.c
+++ b/src/common/stubs.c
@@ -1,0 +1,10 @@
+#include "bsod.h"
+
+void abort() {
+    bsod("aborted");
+}
+
+int _isatty(int __attribute__((unused)) fd) {
+    // TTYs are not supported
+    return 0;
+}


### PR DESCRIPTION
The default implementation of abort() doesn't do anything useful at the
moment. Most importantly, it can leave the FW in an incosistent state
with the heaters active.

Define our own implementation to trigger a bsod() instead.

Similarly, implement an _isatty() stub which is required in newlib 4.x.
Unused/eliminated when linking on newlib 3.x.