### PR TITLE
Remove useless comparison

### DIFF
--- a/lib/WUI/nhttp/server.cpp
+++ b/lib/WUI/nhttp/server.cpp
@@ -29,7 +29,7 @@ bool Server::InactivityTimeout::past() const {
      * If sys_now already overflown and scheduled didn't (it's very large), the
      * diff is something small because it almost underflows.
      */
-    return (diff >= 0 && diff < UINT32_MAX / 2);
+    return diff < UINT32_MAX / 2;
 }
 
 void Server::Slot::release_buffer() {


### PR DESCRIPTION
Was harmless, but useless. When it gets under zero, it underflows (as
already noted in the comment).