### PR TITLE
Delay bringing down WiFi for a while

### DIFF
--- a/lib/WUI/espif.h
+++ b/lib/WUI/espif.h
@@ -40,6 +40,9 @@ bool espif_link();
 
 void espif_input_once(struct netif *netif);
 
+/// Perform periodic works of the esp interface.
+void espif_tick();
+
 // UART buffer stuff
 // The data received should fit into the buffer. Or, some guaratees has to be
 // provided to ensure the excessive data can be copied from the RX buffer

--- a/lib/WUI/wui.cpp
+++ b/lib/WUI/wui.cpp
@@ -351,6 +351,7 @@ private:
             if (events & EspData) {
                 events &= ~EspData;
                 espif_input_once(&ifaces[NETDEV_ESP_ID].dev);
+                espif_tick();
             }
 
             if (!initialized) {


### PR DESCRIPTION
* We observe the WiFi/ESP signals a short disconnect (followed by a
  reconnect) very often (every few seconds).
* This caused us to re-request DHCP every time. This floods DHCP servers
  and sometimes gives us a different IP even if we don't want to (for
  example if there are multiple DHCP servers available with different
  pools).
* Wait a bit when ESP signals it went down before doing anything, in the
  hope it'll go up again. If it does, pretend nothing happened at all.

This is a bit of a hack/workaround. We really want to know what's
happening on the ESP side, but that'll take a bit longer to solve.