### PR TITLE
CI: Check formatting before building/running tests

### DIFF
--- a/utils/holly/build-pr.jenkins
+++ b/utils/holly/build-pr.jenkins
@@ -17,6 +17,25 @@ pipeline {
     }
 
     stages {
+        stage('Check Formatting') {
+            when {
+                expression { env.CHANGE_TARGET }
+            }
+            steps {
+                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                    sh """
+                    export XDG_CACHE_HOME=\$PWD/.precommit
+                    pre-commit install
+                    pre-commit run \
+                        --source remotes/origin/${env.CHANGE_TARGET} \
+                        --origin HEAD \
+                        --show-diff-on-failure \
+                        --hook-stage manual
+                    """
+                }
+            }
+        }
+
         stage('Prepare Build Stages') {
             steps {
                 script {
@@ -72,23 +91,6 @@ pipeline {
                         }
                     }
                 }
-            }
-        }
-
-        stage('Check Formatting') {
-            when {
-                expression { env.CHANGE_TARGET }
-            }
-            steps {
-                sh """
-                export XDG_CACHE_HOME=\$PWD/.precommit
-                pre-commit install
-                pre-commit run \
-                    --source remotes/origin/${env.CHANGE_TARGET} \
-                    --origin HEAD \
-                    --show-diff-on-failure \
-                    --hook-stage manual
-                """
             }
         }
 


### PR DESCRIPTION
Move the formatting check first, but still allow the build to continue (with failure).

This allows users to notice syntax failures early (and possibly abort the build) instead of waiting for a complete build to finish/pass, and get notified later that the syntax check fails.