### PR TITLE
Homing can fail

### DIFF
--- a/include/marlin/Configuration_MINI_adv.h
+++ b/include/marlin/Configuration_MINI_adv.h
@@ -474,6 +474,16 @@
 
 // @section homing
 
+//kill command after probing fails
+//#define HALT_ON_PROBING_ERROR
+//after enabling HOMING_MAX_ATTEMPTS, homing can fail
+#define HOMING_MAX_ATTEMPTS 2
+#ifdef HOMING_MAX_ATTEMPTS
+    // ranges in mm - allowed distance between homing probes for XYZ axes
+    constexpr float axis_home_min_diff[] = {-0.2, -0.2, -0.1};
+    constexpr float axis_home_max_diff[] = { 0.2,  0.2,  0.1};
+#endif// HOMING_MAX_ATTEMPTS
+
 // Homing hits each endstop, retracts by these distances, then does a slower bump.
 #define X_HOME_BUMP_MM 0
 #define Y_HOME_BUMP_MM 0


### PR DESCRIPTION
Detect HOMING FAILED and kill the printer.

It adds general detection of homing failure.
As two bumps are enabled only for Z axis, only homing Z axis can fail at the moment.
2 homing attempts are set.
Homing of Z axis can fail, if PINDA is disconnected or broken or its cable is broken.

Algorithm compares position of two samples. Homing is OK if two attempts are close enough. Limits are set to +-0.1 mm for Z axis.

Known issues:
Error text and landing page is missing.