### PR TITLE
nhttp: Return json errors when asked for

### DIFF
--- a/lib/WUI/link_content/previews.cpp
+++ b/lib/WUI/link_content/previews.cpp
@@ -24,7 +24,7 @@ optional<ConnectionState> Previews::accept(const RequestParser &parser) const {
 
     // Content of the USB drive is only for authenticated, don't ever try anything without it.
     if (!parser.authenticated()) {
-        return StatusPage(Status::Unauthorized, parser.can_keep_alive());
+        return StatusPage(Status::Unauthorized, parser.can_keep_alive(), parser.accepts_json);
     }
 
     uint16_t width;
@@ -38,12 +38,12 @@ optional<ConnectionState> Previews::accept(const RequestParser &parser) const {
         width = 220;
         height = 140;
     } else {
-        return StatusPage(Status::NotFound, parser.can_keep_alive(), "Thumbnail size specification not recognized");
+        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json, "Thumbnail size specification not recognized");
     }
 
     char fname[FILE_PATH_BUFFER_LEN + extra_size];
     if (!parser.uri_filename(fname, sizeof(fname))) {
-        return StatusPage(Status::NotFound, parser.can_keep_alive(), "This doesn't look like file name");
+        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json, "This doesn't look like file name");
     }
 
     // Strip the extra prefix (without the last /)
@@ -52,9 +52,9 @@ optional<ConnectionState> Previews::accept(const RequestParser &parser) const {
     FILE *f = fopen(fname, "rb");
 
     if (f) {
-        return GCodePreview(f, fname, parser.can_keep_alive(), width, height, parser.if_none_match);
+        return GCodePreview(f, fname, parser.can_keep_alive(), parser.accepts_json, width, height, parser.if_none_match);
     } else {
-        return StatusPage(Status::NotFound, parser.can_keep_alive());
+        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json);
     }
 }
 

--- a/lib/WUI/link_content/static_file.cpp
+++ b/lib/WUI/link_content/static_file.cpp
@@ -33,7 +33,7 @@ optional<ConnectionState> StaticFile::accept(const RequestParser &parser) const 
     FILE *f = fopen(fname, "rb");
     if (f) {
         static const char *extra_hdrs[] = { "Content-Encoding: gzip\r\n", nullptr };
-        return SendFile(f, fname, guess_content_by_ext(fname), parser.can_keep_alive(), parser.if_none_match, extra_hdrs);
+        return SendFile(f, fname, guess_content_by_ext(fname), parser.can_keep_alive(), parser.accepts_json, parser.if_none_match, extra_hdrs);
     }
 
     return nullopt;

--- a/lib/WUI/link_content/usb_files.cpp
+++ b/lib/WUI/link_content/usb_files.cpp
@@ -22,12 +22,12 @@ optional<ConnectionState> UsbFiles::accept(const RequestParser &parser) const {
 
     // Content of the USB drive is only for authenticated, don't ever try anything without it.
     if (!parser.authenticated()) {
-        return StatusPage(Status::Unauthorized, parser.can_keep_alive());
+        return StatusPage(Status::Unauthorized, parser.can_keep_alive(), parser.accepts_json);
     }
 
     char fname[FILE_PATH_BUFFER_LEN];
     if (!parser.uri_filename(fname, sizeof(fname))) {
-        return StatusPage(Status::NotFound, parser.can_keep_alive(), "This doesn't look like file name");
+        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json, "This doesn't look like file name");
     }
 
     if (parser.method == Method::Get) {
@@ -39,12 +39,12 @@ optional<ConnectionState> UsbFiles::accept(const RequestParser &parser) const {
              * protected by the API key and it's the user's files, so
              * that's probably fine.
              */
-            return SendFile(f, fname, guess_content_by_ext(fname), parser.can_keep_alive(), parser.if_none_match);
+            return SendFile(f, fname, guess_content_by_ext(fname), parser.can_keep_alive(), parser.accepts_json, parser.if_none_match);
         }
 
-        return StatusPage(Status::NotFound, parser.can_keep_alive());
+        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json);
     } else {
-        return StatusPage(Status::MethodNotAllowed, parser.can_keep_alive());
+        return StatusPage(Status::MethodNotAllowed, parser.can_keep_alive(), parser.accepts_json);
     }
 }
 

--- a/lib/WUI/nhttp/common_selectors.cpp
+++ b/lib/WUI/nhttp/common_selectors.cpp
@@ -7,7 +7,7 @@ namespace nhttp::handler::selectors {
 
 optional<ConnectionState> ValidateRequest::accept(const RequestParser &request) const {
     if (request.method == Method::UnknownMethod) {
-        return StatusPage(Status::MethodNotAllowed, request.can_keep_alive(), "Unrecognized method");
+        return StatusPage(Status::MethodNotAllowed, request.can_keep_alive(), request.accepts_json, "Unrecognized method");
     }
 
     if (request.error_code != Status::UnknownStatus) {
@@ -16,7 +16,7 @@ optional<ConnectionState> ValidateRequest::accept(const RequestParser &request) 
          * that case since there might be leftovers of the unrecognized request
          * lying around.
          */
-        return StatusPage(request.error_code, request.error_code == Status::BadRequest ? false : request.can_keep_alive());
+        return StatusPage(request.error_code, request.error_code == Status::BadRequest ? false : request.can_keep_alive(), request.accepts_json);
     }
 
     return nullopt;
@@ -25,7 +25,7 @@ optional<ConnectionState> ValidateRequest::accept(const RequestParser &request) 
 const ValidateRequest validate_request;
 
 optional<ConnectionState> UnknownRequest::accept(const RequestParser &request) const {
-    return StatusPage(Status::NotFound, request.can_keep_alive());
+    return StatusPage(Status::NotFound, request.can_keep_alive(), request.accepts_json);
 }
 
 const UnknownRequest unknown_request;

--- a/lib/WUI/nhttp/file_info.cpp
+++ b/lib/WUI/nhttp/file_info.cpp
@@ -91,9 +91,10 @@ JsonResult FileInfo::FileRenderer::renderState(size_t resume_point, JsonOutput &
     // clang-format on
 }
 
-FileInfo::FileInfo(const char *filename, bool can_keep_alive, bool after_upload)
+FileInfo::FileInfo(const char *filename, bool can_keep_alive, bool json_errors, bool after_upload)
     : can_keep_alive(can_keep_alive)
-    , after_upload(after_upload) {
+    , after_upload(after_upload)
+    , json_errors(json_errors) {
     strlcpy(this->filename, filename, sizeof this->filename);
     /*
      * Eat the last slash on directories.
@@ -132,7 +133,7 @@ Step FileInfo::step(std::string_view, bool, uint8_t *output, size_t output_size)
             // Special case it, we return empty list of files.
             renderer = DirRenderer(); // Produces empty file list
         } else {
-            return Step { 0, 0, StatusPage(Status::NotFound, can_keep_alive) };
+            return Step { 0, 0, StatusPage(Status::NotFound, can_keep_alive, json_errors) };
         }
         written = write_headers(output, output_size, after_upload ? Status::Created : Status::Ok, ContentType::ApplicationJson, handling);
 

--- a/lib/WUI/nhttp/file_info.h
+++ b/lib/WUI/nhttp/file_info.h
@@ -20,8 +20,9 @@ namespace nhttp::printer {
 class FileInfo {
 private:
     char filename[FILE_PATH_BUFFER_LEN];
-    bool can_keep_alive;
-    bool after_upload;
+    bool can_keep_alive : 1;
+    bool after_upload : 1;
+    bool json_errors : 1;
     class DirDeleter {
     public:
         void operator()(DIR *d) {
@@ -85,7 +86,7 @@ private:
     std::variant<Uninitialized, FileRenderer, DirRenderer, LastChunk> renderer;
 
 public:
-    FileInfo(const char *filename, bool can_keep_alive, bool after_upload);
+    FileInfo(const char *filename, bool can_keep_alive, bool json_error, bool after_upload);
     bool want_read() const { return false; }
     bool want_write() const { return true; }
     handler::Step step(std::string_view input, bool terminated_by_client, uint8_t *buffer, size_t buffer_size);

--- a/lib/WUI/nhttp/gcode_preview.h
+++ b/lib/WUI/nhttp/gcode_preview.h
@@ -22,10 +22,11 @@ private:
     GCodeThumbDecoder decoder;
     bool headers_sent = false;
     bool can_keep_alive;
+    bool json_errors;
     bool etag_matches = false;
 
 public:
-    GCodePreview(FILE *f, const char *path, bool can_keep_alive, uint16_t width, uint16_t height, uint32_t if_none_match);
+    GCodePreview(FILE *f, const char *path, bool can_keep_alive, bool json_errors, uint16_t width, uint16_t height, uint32_t if_none_match);
     bool want_read() const { return false; }
     bool want_write() const { return true; }
     handler::Step step(std::string_view input, bool terminated_by_client, uint8_t *buffer, size_t buffer_size);

--- a/lib/WUI/nhttp/gcode_upload.cpp
+++ b/lib/WUI/nhttp/gcode_upload.cpp
@@ -36,10 +36,11 @@ void GcodeUpload::FileDeleter::operator()(FILE *f) {
     fclose(f);
 }
 
-GcodeUpload::GcodeUpload(UploadState uploader, size_t length, size_t upload_idx, FilePtr file, UploadedNotify *uploaded)
+GcodeUpload::GcodeUpload(UploadState uploader, bool json_errors, size_t length, size_t upload_idx, FilePtr file, UploadedNotify *uploaded)
     : uploader(move(uploader))
     , uploaded_notify(uploaded)
     , size_rest(length)
+    , json_errors(json_errors)
     , tmp_upload_file(move(file))
     , file_idx(upload_idx) {
 }
@@ -62,18 +63,18 @@ GcodeUpload::~GcodeUpload() {
 void GcodeUpload::delete_file() {
 }
 
-GcodeUpload::UploadResult GcodeUpload::start(const RequestParser &parser, UploadedNotify *uploaded) {
+GcodeUpload::UploadResult GcodeUpload::start(const RequestParser &parser, UploadedNotify *uploaded, bool json_errors) {
     // Note: authentication already checked by the caller.
     // Note: We return errors with connection-close because we don't know if the client sent part of the data.
 
     const auto boundary = parser.boundary();
     if (boundary.empty()) {
-        return StatusPage(Status::BadRequest, false, "Missing boundary");
+        return StatusPage(Status::BadRequest, false, json_errors, "Missing boundary");
     }
 
     // One day we may want to support chunked and connection-close, but we are not there yet.
     if (!parser.content_length.has_value()) {
-        return StatusPage(Status::LengthRequired, false);
+        return StatusPage(Status::LengthRequired, json_errors, false);
     }
 
     static size_t upload_idx = 0;
@@ -83,7 +84,7 @@ GcodeUpload::UploadResult GcodeUpload::start(const RequestParser &parser, Upload
     FilePtr file(fopen(fname, "wb"));
     if (!file) {
         // Missing USB -> Insufficient storage.
-        return StatusPage(Status::InsufficientStorage, false, "Missing USB drive");
+        return StatusPage(Status::InsufficientStorage, false, json_errors, "Missing USB drive");
     }
 
     char boundary_cstr[boundary.size() + 1];
@@ -92,16 +93,16 @@ GcodeUpload::UploadResult GcodeUpload::start(const RequestParser &parser, Upload
     UploadState uploader(boundary_cstr);
 
     if (const auto err = uploader.get_error(); get<0>(err) != Status::Ok) {
-        return StatusPage(get<0>(err), false, get<1>(err));
+        return StatusPage(get<0>(err), false, json_errors, get<1>(err));
     }
 
-    return GcodeUpload(move(uploader), *parser.content_length, file_idx, move(file), uploaded);
+    return GcodeUpload(move(uploader), json_errors, *parser.content_length, file_idx, move(file), uploaded);
 }
 
 Step GcodeUpload::step(string_view input, bool terminated_by_client, uint8_t *, size_t) {
     uploader.setup(this);
     if (terminated_by_client && size_rest > 0) {
-        return { 0, 0, StatusPage(Status::BadRequest, false, "Truncated body") };
+        return { 0, 0, StatusPage(Status::BadRequest, false, json_errors, "Truncated body") };
     }
 
     const size_t read = std::min(input.size(), size_rest);
@@ -110,7 +111,7 @@ Step GcodeUpload::step(string_view input, bool terminated_by_client, uint8_t *, 
     size_rest -= read;
 
     if (const auto err = uploader.get_error(); get<0>(err) != Status::Ok) {
-        return { read, 0, StatusPage(get<0>(err), false, get<1>(err)) };
+        return { read, 0, StatusPage(get<0>(err), false, json_errors, get<1>(err)) };
     }
 
     if (size_rest == 0) {
@@ -122,9 +123,9 @@ Step GcodeUpload::step(string_view input, bool terminated_by_client, uint8_t *, 
             strcpy(filename, USB_MOUNT_POINT);
             const char *orig_filename = uploader.get_filename();
             strlcpy(filename + USB_MOUNT_POINT_LENGTH, orig_filename, sizeof(filename) - USB_MOUNT_POINT_LENGTH);
-            return { read, 0, FileInfo(filename, false, true) };
+            return { read, 0, FileInfo(filename, false, json_errors, true) };
         } else {
-            return { read, 0, StatusPage(Status::BadRequest, false, "Missing file") };
+            return { read, 0, StatusPage(Status::BadRequest, false, json_errors, "Missing file") };
         }
     } else {
         return { read, 0, Continue() };

--- a/lib/WUI/nhttp/gcode_upload.h
+++ b/lib/WUI/nhttp/gcode_upload.h
@@ -31,6 +31,7 @@ private:
     UploadState uploader;
     UploadedNotify *uploaded_notify;
     size_t size_rest;
+    bool json_errors;
     GcodeUpload(UploadState uploader, size_t size_rest);
     class FileDeleter {
     public:
@@ -46,14 +47,14 @@ private:
     virtual Result finish(const char *final_filename, bool start_print) override;
 
     void delete_file();
-    GcodeUpload(UploadState uploader, size_t length, size_t upload_idx, FilePtr file, UploadedNotify *uploaded);
+    GcodeUpload(UploadState uploader, bool json_errors, size_t length, size_t upload_idx, FilePtr file, UploadedNotify *uploaded);
 
 public:
     bool want_read() const { return size_rest > 0; }
     bool want_write() const { return false; }
     handler::Step step(std::string_view input, bool terminated_by_client, uint8_t *output, size_t output_size);
     using UploadResult = std::variant<handler::StatusPage, GcodeUpload>;
-    static UploadResult start(const handler::RequestParser &parser, UploadedNotify *uploaded);
+    static UploadResult start(const handler::RequestParser &parser, UploadedNotify *uploaded, bool json_errors);
     GcodeUpload(const GcodeUpload &other) = delete;
     GcodeUpload(GcodeUpload &&other) = default;
     GcodeUpload &operator=(const GcodeUpload &other) = delete;

--- a/lib/WUI/nhttp/job_command.cpp
+++ b/lib/WUI/nhttp/job_command.cpp
@@ -73,16 +73,17 @@ namespace {
 
 }
 
-JobCommand::JobCommand(size_t content_length, bool can_keep_alive)
+JobCommand::JobCommand(size_t content_length, bool can_keep_alive, bool json_errors)
     : content_length(content_length)
-    , can_keep_alive(can_keep_alive) {
+    , can_keep_alive(can_keep_alive)
+    , json_errors(json_errors) {
     memset(buffer.data(), 0, buffer.size());
 }
 
 Step JobCommand::step(std::string_view input, bool terminated_by_client, uint8_t *, size_t) {
     if (content_length > buffer.size()) {
         // Refuse early, without reading the body -> drop the connection too.
-        return Step { 0, 0, StatusPage(Status::PayloadTooLarge, false) };
+        return Step { 0, 0, StatusPage(Status::PayloadTooLarge, false, json_errors) };
     }
 
     const size_t rest = content_length - buffer_used;
@@ -97,7 +98,7 @@ Step JobCommand::step(std::string_view input, bool terminated_by_client, uint8_t
     if (content_length > buffer_used) {
         // Still waiting for more data.
         if (terminated_by_client) {
-            return Step { to_read, 0, StatusPage(Status::BadRequest, false, "Truncated request") };
+            return Step { to_read, 0, StatusPage(Status::BadRequest, false, json_errors, "Truncated request") };
         } else {
             return Step { to_read, 0, Continue() };
         }
@@ -109,39 +110,39 @@ Step JobCommand::step(std::string_view input, bool terminated_by_client, uint8_t
 StatusPage JobCommand::process() {
     switch (parse_command()) {
     case Command::ErrMem:
-        return StatusPage(Status::PayloadTooLarge, can_keep_alive, "Too many JSON tokens");
+        return StatusPage(Status::PayloadTooLarge, can_keep_alive, json_errors, "Too many JSON tokens");
     case Command::ErrReq:
-        return StatusPage(Status::BadRequest, can_keep_alive, "Couldn't parse JSON");
+        return StatusPage(Status::BadRequest, can_keep_alive, json_errors, "Couldn't parse JSON");
     case Command::ErrUnknownCommand:
         // Any idea for better status than the very generic 400? 404?
         return StatusPage(Status::BadRequest, can_keep_alive, "Unknown job command");
     case Command::Pause:
         if (pause()) {
-            return StatusPage(Status::NoContent, can_keep_alive);
+            return StatusPage(Status::NoContent, can_keep_alive, json_errors);
         } else {
-            return StatusPage(Status::Conflict, can_keep_alive);
+            return StatusPage(Status::Conflict, can_keep_alive, json_errors);
         }
     case Command::Resume:
         if (resume()) {
-            return StatusPage(Status::NoContent, can_keep_alive);
+            return StatusPage(Status::NoContent, can_keep_alive, json_errors);
         } else {
-            return StatusPage(Status::Conflict, can_keep_alive);
+            return StatusPage(Status::Conflict, can_keep_alive, json_errors);
         }
     case Command::PauseToggle:
         if (pause_toggle()) {
-            return StatusPage(Status::NoContent, can_keep_alive);
+            return StatusPage(Status::NoContent, can_keep_alive, json_errors);
         } else {
-            return StatusPage(Status::Conflict, can_keep_alive);
+            return StatusPage(Status::Conflict, can_keep_alive, json_errors);
         }
     case Command::Stop:
         if (stop()) {
-            return StatusPage(Status::NoContent, can_keep_alive);
+            return StatusPage(Status::NoContent, can_keep_alive, json_errors);
         } else {
-            return StatusPage(Status::Conflict, can_keep_alive);
+            return StatusPage(Status::Conflict, can_keep_alive, json_errors);
         }
     default:
         assert(0);
-        return StatusPage(Status::InternalServerError, can_keep_alive, "Invalid command");
+        return StatusPage(Status::InternalServerError, can_keep_alive, json_errors, "Invalid command");
     }
 }
 

--- a/lib/WUI/nhttp/job_command.h
+++ b/lib/WUI/nhttp/job_command.h
@@ -29,6 +29,7 @@ private:
     size_t buffer_used = 0;
     size_t content_length;
     bool can_keep_alive;
+    bool json_errors;
 
     enum class Command {
         ErrMem,
@@ -57,7 +58,7 @@ private:
     bool pause_toggle();
 
 public:
-    JobCommand(size_t content_length, bool can_keep_alive);
+    JobCommand(size_t content_length, bool can_keep_alive, bool json_errors);
     bool want_read() const { return true; }
     bool want_write() const { return false; }
     handler::Step step(std::string_view input, bool terminated_by_client, uint8_t *buffer, size_t buffer_size);

--- a/lib/WUI/nhttp/req_parser.cpp
+++ b/lib/WUI/nhttp/req_parser.cpp
@@ -42,7 +42,8 @@ RequestParser::RequestParser(const Server &server)
     , done(false)
     , version_major(0)
     , version_minor(0)
-    , connection(Connection::Unknown) {}
+    , connection(Connection::Unknown)
+    , accepts_json(false) {}
 
 ExecutionControl RequestParser::event(Event event) {
     switch (event.leaving_state) {
@@ -135,6 +136,9 @@ ExecutionControl RequestParser::event(Event event) {
         break;
     case Names::ConnectionKeepAlive:
         connection = Connection::KeepAlive;
+        break;
+    case Names::AcceptJson:
+        accepts_json = true;
         break;
     case Names::Body:
         done = true;

--- a/lib/WUI/nhttp/req_parser.h
+++ b/lib/WUI/nhttp/req_parser.h
@@ -82,6 +82,11 @@ private:
         Close,
     };
     Connection connection : 2;
+
+public:
+    bool accepts_json : 1;
+
+private:
     std::variant<std::monostate, uint8_t, bool> auth_status;
 
     // TODO: Eventually get rid of stringy URLs and replace by enums/tokens as much as possible

--- a/lib/WUI/nhttp/send_file.cpp
+++ b/lib/WUI/nhttp/send_file.cpp
@@ -7,7 +7,7 @@
 
 namespace nhttp::handler {
 
-SendFile::SendFile(FILE *file, const char *path, ContentType content_type, bool can_keep_alive, uint32_t if_none_match, const char **extra_hdrs)
+SendFile::SendFile(FILE *file, const char *path, ContentType content_type, bool can_keep_alive, bool json_errors, uint32_t if_none_match, const char **extra_hdrs)
     : file(file)
     , content_type(content_type)
     , can_keep_alive(can_keep_alive)
@@ -33,7 +33,8 @@ SendFile::SendFile(FILE *file, const char *path, ContentType content_type, bool 
 
 Step SendFile::step(std::string_view, bool, uint8_t *buffer, size_t buffer_size) {
     if (etag_matches) {
-        return Step { 0, 0, StatusPage(Status::NotModified, connection_handling != ConnectionHandling::Close) };
+        // Note: json_errors are not enabled, because NotModified has no content anyway.
+        return Step { 0, 0, StatusPage(Status::NotModified, connection_handling != ConnectionHandling::Close, false) };
     }
 
     if (!buffer) {

--- a/lib/WUI/nhttp/send_file.h
+++ b/lib/WUI/nhttp/send_file.h
@@ -40,7 +40,7 @@ private:
     const char **extra_hdrs;
 
 public:
-    SendFile(FILE *file, const char *path, ContentType content_type, bool can_keep_alive, uint32_t if_none_match, const char **extra_hdrs = nullptr);
+    SendFile(FILE *file, const char *path, ContentType content_type, bool can_keep_alive, bool json_errors, uint32_t if_none_match, const char **extra_hdrs = nullptr);
     Step step(std::string_view input, bool terminated_by_client, uint8_t *buffer, size_t buffer_size);
     bool want_write() const { return bool(file); }
     bool want_read() const { return false; }

--- a/lib/WUI/nhttp/status_page.h
+++ b/lib/WUI/nhttp/status_page.h
@@ -12,12 +12,14 @@ private:
     const char *extra_content;
     Status status;
     bool can_keep_alive;
+    bool json_content;
 
 public:
-    StatusPage(Status status, bool can_keep_alive, const char *extra_content = "")
+    StatusPage(Status status, bool can_keep_alive, bool json_content, const char *extra_content = "")
         : extra_content(extra_content)
         , status(status)
-        , can_keep_alive(can_keep_alive) {}
+        , can_keep_alive(can_keep_alive)
+        , json_content(json_content) {}
     bool want_read() const { return false; }
     bool want_write() const { return true; }
     Step step(std::string_view input, bool terminated_by_client, uint8_t *output, size_t output_size);

--- a/tests/unit/lib/WUI/automata/generated.cpp
+++ b/tests/unit/lib/WUI/automata/generated.cpp
@@ -221,6 +221,14 @@ TEST_CASE("Connection keep alive") {
     REQUIRE_FALSE(ex.contains_enter(Names::ConnectionClose));
 }
 
+TEST_CASE("Accept json") {
+    using test::http::Names;
+    TestExecution ex(http_request);
+    ex.consume("GET / HTTP/1.1\r\nAccept: application/json\r\n\r\n");
+    REQUIRE(ex.contains_enter(Names::AcceptJson));
+    REQUIRE_FALSE(ex.contains_enter(Names::ConnectionClose));
+}
+
 TEST_CASE("No connection") {
     using test::http::Names;
     TestExecution ex(http_request);

--- a/tests/unit/lib/WUI/nhttp/job_command_tests.cpp
+++ b/tests/unit/lib/WUI/nhttp/job_command_tests.cpp
@@ -24,7 +24,7 @@ std::vector<Cmd> history;
 void do_test(string_view data, optional<Cmd> expected_command) {
     history.clear();
 
-    JobCommand command(data.size(), true);
+    JobCommand command(data.size(), true, false);
     const auto result = command.step(data, false, nullptr, 0);
 
     REQUIRE(result.written == 0);

--- a/tests/unit/lib/WUI/nhttp/server_tests.cpp
+++ b/tests/unit/lib/WUI/nhttp/server_tests.cpp
@@ -202,7 +202,7 @@ public:
                 static const char *extra_hdrs[] = { "Fake: YesOfCourse\r\n", nullptr };
                 return SendStaticMemory("<html><body><h1>Don't tell anyone!</h1>", guess_content_by_ext(filename), parser.can_keep_alive(), extra_hdrs);
             } else {
-                return StatusPage(Status::Unauthorized, parser.can_keep_alive());
+                return StatusPage(Status::Unauthorized, parser.can_keep_alive(), false);
             }
         }
 

--- a/utils/gen-automata/tests.py
+++ b/utils/gen-automata/tests.py
@@ -5,7 +5,7 @@ This script generates few automata for checking the generator works as
 expected. They are generated and used during the unit tests.
 """
 from common import Automaton, LabelType
-from http import connection_header, methods, read_boundary, read_header_value, req_line, request
+from http import accept_header, connection_header, methods, read_boundary, read_header_value, req_line, request
 
 
 def output(name, automaton):
@@ -40,6 +40,7 @@ want_headers = {
     'Content-Length': read_header_value('ContentLength'),
     'Content-Type': read_boundary(),
     'Connection': connection_header(),
+    'Accept': accept_header(),
 }
 http, final = request(want_headers)
 output("http", http)


### PR DESCRIPTION
If the client asks for application/json (the PrusaLink pages), comply
and supply the errors in that format.