### PR TITLE
gui: Fix dialog title location

### DIFF
--- a/src/guiapi/include/display.h
+++ b/src/guiapi/include/display.h
@@ -65,6 +65,13 @@ public:
     constexpr static void SetPixel(point_ui16_t pt, color_t clr) { SET_PIXEL(pt, clr); }
     constexpr static uint8_t *GetBlock(point_ui16_t start, point_ui16_t end) { return GET_BLOCK(start, end); }
     constexpr static void DrawLine(point_ui16_t pt0, point_ui16_t pt1, color_t clr) { DRAW_LINE(pt0, pt1, clr); }
+    constexpr static void DrawLine(point_i16_t pt0, point_i16_t pt1, color_t clr) {
+        uint16_t l = std::max(int16_t(0), pt0.x);
+        uint16_t t = std::max(int16_t(0), pt0.y);
+        uint16_t r = std::max(int16_t(0), pt1.x);
+        uint16_t b = std::max(int16_t(0), pt1.y);
+        DrawLine(point_ui16(l, t), point_ui16(r, b), clr);
+    }
     constexpr static void DrawRect(Rect16 rc, color_t clr) { DRAW_RECT(rc, clr); }
     constexpr static void FillRect(Rect16 rc, color_t clr) { FIL_RECT(rc, clr); }
     constexpr static bool DrawChar(point_ui16_t pt, unichar c, const font_t *pf, color_t clr_bg, color_t clr_fg) {

--- a/src/guiapi/include/window_msgbox.hpp
+++ b/src/guiapi/include/window_msgbox.hpp
@@ -76,6 +76,7 @@ protected:
 private:
     //some methods to help with construction
     Rect16 getTextRect();
+    Rect16 getLineRect();
     Rect16 getIconRect();
     Rect16 getTitleRect(); // icon must be initialized
     font_t *getTitleFont();


### PR DESCRIPTION
Warning dialog inheritance was changed from MsgBoxBase to MsgBoxIconned. This centered the icon and moved the text. This commit fixes the location and makes the code structure better organized.