### PR TITLE
Update Prusa-Error-Codes URL.

### DIFF
--- a/lib/Prusa-Error-Codes/.gitrepo
+++ b/lib/Prusa-Error-Codes/.gitrepo
@@ -4,7 +4,7 @@
 ; git-subrepo command. See https://github.com/git-commands/git-subrepo#readme
 ;
 [subrepo]
-	remote = git@github.com:prusa3d/Prusa-Error-Codes.git
+	remote = https://github.com/prusa3d/Prusa-Error-Codes.git
 	branch = master
 	commit = f28dbdbc5c873daa0a77a17127b45de2c49d9a83
 	parent = 7cbf8dcc09cb2606a9b6e9bbf45e562baa0b3227


### PR DESCRIPTION
```
git subrepo pull lib/Prusa-Error-Codes
git-subrepo: Command failed: 'git fetch --no-tags --quiet git@github.com:prusa3d/Prusa-Error-Codes.git master'.
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Github discontinued unencrypted git protocoll access
so https or ssh must be used instead.

note:
[In subrepo doc is stated that:](https://github.com/git-commands/git-subrepo/blob/master/doc/intro-to-subrepo.md#user-content-git-subrepos)
Note that the repo url is the generally pushable form, rather than the publically readable (https://…) form. This is the best practice. Users of your repo don't need access to this url...

I think we can safely ignore this recommendation, as we can push to https://… 