### PR TITLE
marlin_server: "C" linkage consistency and cleanup

### DIFF
--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -51,7 +51,9 @@ static_assert(MARLIN_VAR_MAX < 64, "MarlinAPI: Too many variables");
 
 #include "selftest_MINI.h"
 
-typedef struct {
+namespace {
+
+struct marlin_server_t {
     marlin_vars_t vars;                              // cached variables
     marlin_mesh_t mesh;                              // meshbed leveling
     uint64_t notify_events[MARLIN_MAX_CLIENTS];      // event notification mask - message filter
@@ -81,18 +83,12 @@ typedef struct {
     uint8_t pqueue;           // calculated number of records in planner queue
     uint8_t gqueue;           // copy of queue.length - number of commands in gcode queue
     uint8_t resume_fan_speed; // resume fan speed
-} marlin_server_t;
+};
+
+marlin_server_t marlin_server; // server structure - initialize task to zero
 
 fsm::Queue fsm_event_queues[MARLIN_MAX_CLIENTS];
-bool can_stop_wait_for_heatup_var = false;
-bool can_stop_wait_for_heatup() { return can_stop_wait_for_heatup_var; }
-void can_stop_wait_for_heatup(bool val) { can_stop_wait_for_heatup_var = val; }
 
-extern "C" {
-marlin_server_t marlin_server; // server structure - initialize task to zero
-}
-
-namespace {
 template <WarningType p_warning, bool p_disableHotend>
 class ErrorChecker {
 public:
@@ -152,6 +148,11 @@ ErrorChecker<WarningType::HotendFanError, true> hotendFanErrorChecker;
 ErrorChecker<WarningType::PrintFanError, false> printFanErrorChecker;
 HotendErrorChecker hotendErrorChecker;
 } //end anonymous namespace
+
+bool can_stop_wait_for_heatup_var = false;
+bool can_stop_wait_for_heatup() { return can_stop_wait_for_heatup_var; }
+void can_stop_wait_for_heatup(bool val) { can_stop_wait_for_heatup_var = val; }
+
 extern "C" {
 
 LOG_COMPONENT_DEF(MarlinServer, LOG_SEVERITY_INFO);

--- a/src/common/marlin_server.h
+++ b/src/common/marlin_server.h
@@ -8,6 +8,10 @@
 
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
+
 // server flags
 // FIXME define the same type for these and marlin_server.flags
 static const uint16_t MARLIN_SFLG_STARTED = 0x0001; // server started (set in marlin_server_init)
@@ -20,10 +24,6 @@ static const uint16_t MARLIN_SFLG_EXCMODE = 0x0010; // exclusive mode enabled (c
 static const uint8_t MARLIN_UPDATE_PERIOD = 100;
 
 typedef void(marlin_server_idle_t)(void);
-
-#ifdef __cplusplus
-extern "C" {
-#endif //__cplusplus
 
 // callback for idle operation inside marlin (called from ExtUI handler onIdle)
 extern marlin_server_idle_t *marlin_server_idle_cb;


### PR DESCRIPTION
Make both marlin_server and fsm_event_queues static, since they're internal to marlin_server.cpp.

Ensure all types defined inside "extern C" linkage are also declared as such for consistency (notably, marlin_server_idle_t).