### PR TITLE
WUI: Proper locking during network setup

### DIFF
--- a/lib/WUI/link_content/basic_gets.cpp
+++ b/lib/WUI/link_content/basic_gets.cpp
@@ -117,18 +117,8 @@ JsonResult get_printer(size_t resume_point, JsonOutput &output) {
 }
 
 JsonResult get_version(size_t resume_point, JsonOutput &output) {
-    /*
-     * FIXME: The netdev_get_hostname doesn't properly synchronize. That needs
-     * a fix of its own. But to not make things even worse than they are, we
-     * make sure to copy it out to our side first and make sure it doesn't
-     * change during the JSON stringification which could lead to a different
-     * length of the output and stack smashing.
-     */
-    const char *hostname_unsynchronized = netdev_get_hostname(netdev_get_active_id());
-    const size_t hostname_in_len = strlen(hostname_unsynchronized);
-    char hostname[hostname_in_len + 1];
-    memcpy(hostname, hostname_unsynchronized, hostname_in_len);
-    hostname[hostname_in_len] = '\0';
+    char hostname[ETH_HOSTNAME_LEN + 1];
+    netdev_get_hostname(netdev_get_active_id(), hostname, sizeof hostname);
 
     // Keep the indentation of the JSON in here!
     // clang-format off

--- a/lib/WUI/netdev.h
+++ b/lib/WUI/netdev.h
@@ -147,8 +147,9 @@ netdev_ip_obtained_t netdev_get_ip_obtained_type(uint32_t);
 /// @param[in] dev_id device ID. One of
 ///             - #NETDEV_ETH_ID
 ///             - #NETDEV_ESP_ID
-/// @return hostname
-const char *netdev_get_hostname(uint32_t);
+/// @param[out] buffer Where to store the hostname (copying it out for thread protection).
+/// @param[in] buffer_len The size of the buffer (including space for \0).
+void netdev_get_hostname(uint32_t, char *buffer, size_t buffer_len);
 
 ////////////////////////////////////////////////////////////////////////////
 /// @brief Retrive IPv4 configuration. IP address, network mask, gateway address


### PR DESCRIPTION
* Lock a mutex whenever we access shared data.
* This doesn't happen on hot-path / packet handling, only during
  "management" (setup, reading info for GUI, ...)
* It is probably a bit more conservative (locking more than necessary).
  It's easier to overlock than prove that it's not needed and as it's
  not on the hot path, better safe than sorry.