### PR TITLE
Gcode upload: Check filename early

### DIFF
--- a/lib/WUI/nhttp/gcode_upload.h
+++ b/lib/WUI/nhttp/gcode_upload.h
@@ -44,6 +44,7 @@ private:
 
     virtual Result data(std::string_view data) override;
     virtual Result finish(const char *final_filename, bool start_print) override;
+    virtual Result check_filename(const char *filename) const override;
 
     void delete_file();
     GcodeUpload(UploadState uploader, size_t length, size_t upload_idx, FilePtr file, UploadedNotify *uploaded);

--- a/lib/WUI/nhttp/upload_state.cpp
+++ b/lib/WUI/nhttp/upload_state.cpp
@@ -303,6 +303,10 @@ int UploadState::headers_complete() {
         if (filename[0] != '\0') {
             // Make sure this is not overwritten next time.
             have_valid_filename = true;
+            error = hooks->check_filename(filename.begin());
+            if (!err_ok()) {
+                return 1;
+            }
         } else {
             error = make_tuple(Status::BadRequest, "Missing/empty file name");
             return 1;

--- a/lib/WUI/nhttp/upload_state.h
+++ b/lib/WUI/nhttp/upload_state.h
@@ -34,6 +34,11 @@ public:
     virtual ~UploadHooks() = default;
     virtual Result data(std::string_view data) = 0;
     virtual Result finish(const char *final_filename, bool start_print) = 0;
+    // Early check of a filename validity.
+    //
+    // Used once the file name is known, possibly before all the data is
+    // uploaded.
+    virtual Result check_filename(const char *final_filename) const = 0;
 };
 
 class UploadState {

--- a/tests/unit/lib/WUI/nhttp/multipart_upload.cpp
+++ b/tests/unit/lib/WUI/nhttp/multipart_upload.cpp
@@ -40,6 +40,10 @@ public:
         return make_tuple(Status::Ok, nullptr);
     }
 
+    virtual Result check_filename(const char *filename) const override {
+        return make_tuple(Status::Ok, nullptr);
+    }
+
     virtual Result finish(const char *final_filename, bool start_print) override {
         REQUIRE_FALSE(termination.has_value());
         termination = Finish {


### PR DESCRIPTION
Try creating the file as early as we know it. That way, if it's not
fine, we tell the user right away, not after 10 minutes of uploading it.