### PR TITLE
PrusaLink: Content-Disposition header for files

### DIFF
--- a/lib/WUI/link_content/usb_files.cpp
+++ b/lib/WUI/link_content/usb_files.cpp
@@ -39,7 +39,11 @@ optional<ConnectionState> UsbFiles::accept(const RequestParser &parser) const {
              * protected by the API key and it's the user's files, so
              * that's probably fine.
              */
-            return SendFile(f, fname, guess_content_by_ext(fname), parser.can_keep_alive(), parser.accepts_json, parser.if_none_match);
+            static const char *const hdrs[] = {
+                "Content-Disposition: attachment\r\n",
+                nullptr,
+            };
+            return SendFile(f, fname, guess_content_by_ext(fname), parser.can_keep_alive(), parser.accepts_json, parser.if_none_match, hdrs);
         }
 
         return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json);

--- a/lib/WUI/nhttp/headers.cpp
+++ b/lib/WUI/nhttp/headers.cpp
@@ -13,7 +13,7 @@ namespace nhttp {
 
 namespace {
 
-    const char *authenticate_hdrs[] = {
+    const char *const authenticate_hdrs[] = {
         "WWW-Authenticate: ApiKey realm=\"Printer API\"\r\n",
         nullptr,
     };
@@ -82,7 +82,7 @@ const StatusText &StatusText::find(Status status) {
     return *texts;
 }
 
-size_t write_headers(uint8_t *buffer, size_t buffer_len, Status status, ContentType content_type, ConnectionHandling handling, std::optional<uint64_t> content_length, std::optional<uint32_t> etag, const char **extra_hdrs) {
+size_t write_headers(uint8_t *buffer, size_t buffer_len, Status status, ContentType content_type, ConnectionHandling handling, std::optional<uint64_t> content_length, std::optional<uint32_t> etag, const char *const *extra_hdrs) {
     // Always leave space for the body-newline separator
     assert(buffer_len > 2);
     buffer_len -= 2;

--- a/lib/WUI/nhttp/headers.h
+++ b/lib/WUI/nhttp/headers.h
@@ -28,7 +28,7 @@ struct StatusText {
      *
      * Most have an empty list.
      */
-    const char **extra_hdrs = nullptr;
+    const char *const *extra_hdrs = nullptr;
 
     /**
      * \brief Performs a lookup of the text.
@@ -54,7 +54,7 @@ struct StatusText {
  *
  * The body separator (two lines) is included.
  */
-size_t write_headers(uint8_t *buffer, size_t buffer_len, Status status, ContentType content_type, ConnectionHandling handling, std::optional<uint64_t> content_length = std::nullopt, std::optional<uint32_t> etag = std::nullopt, const char **extra_hdrs = nullptr);
+size_t write_headers(uint8_t *buffer, size_t buffer_len, Status status, ContentType content_type, ConnectionHandling handling, std::optional<uint64_t> content_length = std::nullopt, std::optional<uint32_t> etag = std::nullopt, const char *const *extra_hdrs = nullptr);
 
 /**
  * \brief Makes a guess about a content type based on a file extension.

--- a/lib/WUI/nhttp/send_file.cpp
+++ b/lib/WUI/nhttp/send_file.cpp
@@ -7,7 +7,7 @@
 
 namespace nhttp::handler {
 
-SendFile::SendFile(FILE *file, const char *path, ContentType content_type, bool can_keep_alive, bool json_errors, uint32_t if_none_match, const char **extra_hdrs)
+SendFile::SendFile(FILE *file, const char *path, ContentType content_type, bool can_keep_alive, bool json_errors, uint32_t if_none_match, const char *const *extra_hdrs)
     : file(file)
     , content_type(content_type)
     , can_keep_alive(can_keep_alive)

--- a/lib/WUI/nhttp/send_file.h
+++ b/lib/WUI/nhttp/send_file.h
@@ -37,10 +37,10 @@ private:
     bool etag_matches = false;
     std::optional<size_t> content_length;
     std::optional<uint32_t> etag;
-    const char **extra_hdrs;
+    const char *const *extra_hdrs;
 
 public:
-    SendFile(FILE *file, const char *path, ContentType content_type, bool can_keep_alive, bool json_errors, uint32_t if_none_match, const char **extra_hdrs = nullptr);
+    SendFile(FILE *file, const char *path, ContentType content_type, bool can_keep_alive, bool json_errors, uint32_t if_none_match, const char *const *extra_hdrs = nullptr);
     Step step(std::string_view input, bool terminated_by_client, uint8_t *buffer, size_t buffer_size);
     bool want_write() const { return bool(file); }
     bool want_read() const { return false; }


### PR DESCRIPTION
So the browser knows it's to be saved, not shown.