### PR TITLE
Disable caching for downloading gcodes

### DIFF
--- a/lib/WUI/nhttp/send_file.cpp
+++ b/lib/WUI/nhttp/send_file.cpp
@@ -5,6 +5,8 @@
 
 #include <sys/stat.h>
 
+using std::nullopt;
+
 namespace nhttp::handler {
 
 SendFile::SendFile(FILE *file, const char *path, ContentType content_type, bool can_keep_alive, bool json_errors, uint32_t if_none_match, const char *const *extra_hdrs)
@@ -29,6 +31,11 @@ SendFile::SendFile(FILE *file, const char *path, ContentType content_type, bool 
     } else {
         connection_handling = ConnectionHandling::Close;
     }
+}
+
+void SendFile::disable_caching() {
+    etag_matches = false;
+    etag = nullopt;
 }
 
 Step SendFile::step(std::string_view, bool, uint8_t *buffer, size_t buffer_size) {

--- a/lib/WUI/nhttp/send_file.h
+++ b/lib/WUI/nhttp/send_file.h
@@ -44,6 +44,12 @@ public:
     Step step(std::string_view input, bool terminated_by_client, uint8_t *buffer, size_t buffer_size);
     bool want_write() const { return bool(file); }
     bool want_read() const { return false; }
+    /*
+     * Disables etags & if_none_match handling.
+     *
+     * This is due to some browsers reportedly malhandling Content-Disposition: attachement + etags.
+     */
+    void disable_caching();
 };
 
 }


### PR DESCRIPTION
Reportedly, there are browsers that mishandle the combination of
Content-Disposition: atachment + etag based caching. Being conservative
and avoiding that.