### PR TITLE
Fix marlin timing

### DIFF
--- a/lib/Arduino_Core_Buddy/cores/arduino/stm32/stm32_def.h
+++ b/lib/Arduino_Core_Buddy/cores/arduino/stm32/stm32_def.h
@@ -1,6 +1,8 @@
 #ifndef _STM32_DEF_
 #define _STM32_DEF_
 
+#include "../../../../../include/main.h"
+
 /**
  * @brief STM32 core version number
  */
@@ -20,7 +22,7 @@
     | (STM32_CORE_VERSION_EXTRA))
 
 #ifndef F_CPU
-    #define F_CPU SystemCoreClock
+    #define F_CPU ConstexprSystemCoreClock()
 #endif //F_CPU
 
 #ifndef USE_HAL_DRIVER


### PR DESCRIPTION
Marlin relies on F_CPU to be compile time constant.
There computations with division in delay functions otherwise
and it causes delays to be longer than intended wasting CPU time
in stepper interrupt.