### PR TITLE
Fix and unify critical sections.

### DIFF
--- a/lib/Marlin/Marlin/src/HAL/HAL_STM32_F4_F7/HAL.h
+++ b/lib/Marlin/Marlin/src/HAL/HAL_STM32_F4_F7/HAL.h
@@ -107,8 +107,8 @@
   #define analogInputToDigitalPin(p) (p)
 #endif
 
-#define CRITICAL_SECTION_START  uint32_t primask = __get_PRIMASK(); __disable_irq()
-#define CRITICAL_SECTION_END    if (!primask) __enable_irq()
+#define CRITICAL_SECTION_START  const uint32_t primask = __get_PRIMASK(); __disable_irq()
+#define CRITICAL_SECTION_END    __set_PRIMASK(primask)
 #define ISRS_ENABLED() (!__get_PRIMASK())
 #define ENABLE_ISRS()  __enable_irq()
 #define DISABLE_ISRS() __disable_irq()

--- a/lib/Marlin/Marlin/src/module/stepper.cpp
+++ b/lib/Marlin/Marlin/src/module/stepper.cpp
@@ -2357,7 +2357,7 @@ void Stepper::report_positions() {
   // MUST ONLY BE CALLED BY AN ISR,
   // No other ISR should ever interrupt this!
   void Stepper::babystep(const AxisEnum axis, const bool direction) {
-    cli();
+    CRITICAL_SECTION_START;
 
     switch (axis) {
 
@@ -2449,7 +2449,7 @@ void Stepper::report_positions() {
 
       default: break;
     }
-    sei();
+    CRITICAL_SECTION_END;
   }
 
 #endif // BABYSTEPPING

--- a/src/common/disable_interrupts.h
+++ b/src/common/disable_interrupts.h
@@ -1,0 +1,91 @@
+/**
+ * @file
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <cmsis_gcc.h>
+
+namespace buddy {
+
+/**
+ * @brief Disable all maskable interrupts
+ *
+ * Disabling all interrupts may be needed in case of dealing with stepper data
+ * or in case timing with nanosecond precision is needed.
+ *
+ * In other cases use CriticalSection instead.
+ *
+ * Interrupts are disabled when object is constructed by its default constructor
+ * and resumed to original state once destroyed.
+ *
+ * When the motors are moving disabling all interrupts for more than
+ *
+ * - 500 ns frequently may produce motor noise
+ * (Induce stepping error bigger than 1% at 200 mm/s 200 step motor 16 microsteps or 400 step motor 8 microsteps)
+ *
+ * - 50 us produce multiple microsteps done at once (noise, may cause motor over-current in no-current-feedback-mode)
+ * - 400 us may cause motor stall (400 step motors)
+ * - 800 us -//- (200 step motors)
+ *
+ * Example usage:
+ * @code
+ * void singleCriticalSectionFunction() {
+ *     // non-critical code
+ *     {
+ *         buddy::DisableInterrupts disableInterrupts;
+ *         // critical code
+ *     }
+ *     // non-critical code
+ * }
+ * @endcode
+ *
+ * Example multiple critical sections in single function:
+ * @code
+ * void multipleCriticalSectionsFunction() {
+ *     buddy::DisableInterrupts interrupts(false);
+ *     // non-critical code
+ *
+ *     interrupts.disable();
+ *     // critical code
+ *     interrupts.resume();
+ *
+ *     // non-critical code
+ *
+ *     interrupts.disable();
+ *     // critical code
+ *     interrupts.resume();
+ *
+ *     // non-critical code
+ *
+ *     interrupts.disable();
+ *     // critical code
+ * }
+ * @endcode
+ */
+class DisableInterrupts {
+public:
+    DisableInterrupts(bool disableNow = true)
+        : m_primask(__get_PRIMASK()) {
+        if (disableNow)
+            disable();
+    }
+    ~DisableInterrupts() {
+        resume();
+    }
+    void disable() {
+        __disable_irq();
+    }
+    void resume() {
+        __set_PRIMASK(m_primask);
+    }
+    DisableInterrupts(const DisableInterrupts &other) = delete;
+    DisableInterrupts &operator=(const DisableInterrupts &other) = delete;
+
+private:
+    uint32_t m_primask;
+};
+
+} /* namespace Buddy */

--- a/src/common/include/rtos_api.hpp
+++ b/src/common/include/rtos_api.hpp
@@ -22,6 +22,19 @@ public:
     static inline uint32_t GetTick() { return HAL_GetTick(); }
 };
 
+/**
+ * To be used for:
+ * - Implementing atomic operations
+ * on data shared between tasks and RTOS aware
+ * interrupts.
+ * - Precisely timed operations, which can
+ * be interrupted for less than 10 microseconds
+ * by high priority non OS aware interrupt.
+ *
+ * For atomic operations on stepper interrupt
+ * data or timing with nanosecond precision use
+ * DisableInterrupt instead.
+ */
 class CriticalSection {
 public:
     CriticalSection() { taskENTER_CRITICAL(); }

--- a/src/common/sys.cpp
+++ b/src/common/sys.cpp
@@ -5,6 +5,7 @@
 #include "stm32f4xx_hal.h"
 #include "st25dv64k.h"
 #include "log.h"
+#include "disable_interrupts.h"
 
 #define DFU_REQUEST_RTC_BKP_REGISTER RTC->BKP0R
 
@@ -29,8 +30,7 @@ void sys_reset(void) {
     static_assert(sizeof(data_exchange_t) == 16, "invalid sizeof(data_exchange_t)");
 
     uint32_t aircr = SCB->AIRCR & 0x0000ffff; //read AIRCR, mask VECTKEY
-    if (__get_PRIMASK() & 1)
-        __disable_irq(); //disable irq if enabled
+    __disable_irq();
     aircr |= 0x05fa0000; //set VECTKEY
     aircr |= 0x00000004; //set SYSRESETREQ
     SCB->AIRCR = aircr;  //write AIRCR
@@ -93,7 +93,6 @@ int sys_pll_is_enabled(void) {
 }
 
 void sys_pll_disable(void) {
-    int irq = __get_PRIMASK() & 1;
     RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
     RCC_ClkInitTypeDef RCC_ClkInitStruct = { 0 };
     uint32_t FLatency;
@@ -103,18 +102,13 @@ void sys_pll_disable(void) {
         return;                                            //already disabled - exit
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_OFF;          //set PLL off
     RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_HSE; //set CLK source HSE
-    if (irq)
-        __disable_irq();                                                        //disable irq while switching clock
+
+    buddy::DisableInterrupts disableInterrupts;
     HAL_RCC_ClockConfig(&RCC_ClkInitStruct, sys_calc_flash_latency(HSE_VALUE)); //set Clk config first
     HAL_RCC_OscConfig(&RCC_OscInitStruct);                                      //set Osc config
-    if (irq)
-        __enable_irq();
-    //HAL_RCC_GetOscConfig(&RCC_OscInitStruct);
-    //HAL_RCC_GetClockConfig(&RCC_ClkInitStruct, &FLatency);
 }
 
 void sys_pll_enable(void) {
-    int irq = __get_PRIMASK() & 1;
     RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
     RCC_ClkInitTypeDef RCC_ClkInitStruct = { 0 };
 
@@ -146,14 +140,10 @@ void sys_pll_enable(void) {
         return;                                               //already enabled - exit
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;              //set PLL off
     RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK; //set CLK source HSE
-    if (irq)
-        __disable_irq();                                                           //disable irq while switching clock
+
+    buddy::DisableInterrupts disableInterrupts;
     HAL_RCC_OscConfig(&RCC_OscInitStruct);                                         //set Osc config first
     HAL_RCC_ClockConfig(&RCC_ClkInitStruct, sys_calc_flash_latency(sys_pll_freq)); //set Clk config
-    if (irq)
-        __enable_irq();
-    //HAL_RCC_GetOscConfig(&RCC_OscInitStruct);
-    //HAL_RCC_GetClockConfig(&RCC_ClkInitStruct, &FLatency);
 }
 
 int sys_sscg_is_enabled(void) {
@@ -162,7 +152,7 @@ int sys_sscg_is_enabled(void) {
 
 void sys_sscg_disable(void) {
     uint32_t sscgr = RCC->SSCGR;
-    __disable_irq();
+    buddy::DisableInterrupts disableInterrupts;
     if ((sscgr & RCC_SSCGR_SSCGEN_Msk) == 0)
         return;
     sscgr &= ~((1 << RCC_SSCGR_SSCGEN_Pos) & RCC_SSCGR_SSCGEN_Msk);
@@ -172,7 +162,6 @@ void sys_sscg_disable(void) {
     log_debug(Buddy, "written SSCGR = 0x%08lx (%lu)", sscgr, sscgr);
     sscgr = RCC->SSCGR;
     log_debug(Buddy, "readback SSCGR = 0x%08lx (%lu)", sscgr, sscgr);
-    __enable_irq();
 }
 
 void sys_sscg_enable(void) {
@@ -184,14 +173,13 @@ void sys_sscg_enable(void) {
     if (incstep == 0)
         return;
     sscgr |= (1 << RCC_SSCGR_SSCGEN_Pos) & RCC_SSCGR_SSCGEN_Msk;
-    __disable_irq();
+    buddy::DisableInterrupts disableInterrupts;
     sys_pll_disable();
     RCC->SSCGR = sscgr;
     sys_pll_enable();
     log_debug(Buddy, "written SSCGR = 0x%08lx (%lu)", sscgr, sscgr);
     sscgr = RCC->SSCGR;
     log_debug(Buddy, "readback SSCGR = 0x%08lx (%lu)", sscgr, sscgr);
-    __enable_irq();
 }
 
 void sys_sscg_set_config(int freq, int depth) {
@@ -266,14 +254,10 @@ uint32_t _spi_prescaler(int prescaler_num) {
 }
 
 void sys_spi_set_prescaler(int prescaler_num) {
-    int irq = __get_PRIMASK() & 1;
-    if (irq)
-        __disable_irq(); //disable irq while switching clock
+    buddy::DisableInterrupts disableInterrupts;
     HAL_SPI_DeInit(&hspi2);
     hspi2.Init.BaudRatePrescaler = _spi_prescaler(prescaler_num);
     HAL_SPI_Init(&hspi2);
-    if (irq)
-        __enable_irq();
 }
 
 int sys_fw_update_is_enabled(void) {

--- a/src/guiapi/src/st7789v.cpp
+++ b/src/guiapi/src/st7789v.cpp
@@ -11,6 +11,7 @@
 #include "bsod.h"
 #include "raster_opfn_c.h"
 #include "st7789v_impl.hpp"
+#include "disable_interrupts.h"
 
 #ifdef ST7789V_USE_RTOS
     #include "cmsis_os.h"
@@ -134,13 +135,9 @@ static void st7789v_reset(void) {
     volatile uint16_t delay = 0;
     {
         InputEnabler rstInput(displayRst, Pull::up);
-        int irq = __get_PRIMASK() & 1;
-        if (irq)
-            __disable_irq();
+        buddy::DisableInterrupts disableInterrupts;
         while (rstInput.read() == Pin::State::low)
             delay++;
-        if (irq)
-            __enable_irq();
     }
     st7789v_set_rst();
     st7789v_reset_delay = delay;
@@ -313,7 +310,10 @@ void st7789v_init_ctl_pins(void) {
     st7789v_set_cs();
     st7789v_set_rs();
 }
-
+/**
+ * Warning: All interrupts are disabled in st7789v_reset() while measuring
+ * delay to detect Jogwheel revision.
+ */
 void st7789v_init(void) {
 #ifdef ST7789V_USE_RTOS
     st7789v_task_handle = osThreadGetId();


### PR DESCRIPTION
Fix of st7789v_reset() might fix issue of wrongly detected rotary encoder model.

CRITICAL_SECTION_START:
make primask const to catch more usage faults.

CRITICAL_SECTION_END:
__set_PRIMASK(primask) might be more efficient
than if (!primask) __enable_irq()
due to the fact that "cpsie i" ASM instruction is not allowed in ASM condition

Stepper::babystep() might enable interrupts unintentionally before the fix.
We call it from marlin server so better to be safe than sorry.

sys_reset() remove redundant code:
1. Return value of __get_PRIMASK doesn't need to be masked.
2. irq variable is not needed as interrupt masking state is not restored.
3. irq type doesn't match __get_PRIMASK() return value.
4. "cpsid i" ASM instruction is not allowed in condition so who knows what kind of code was generated.

sys_pll_enable(), sys_pll_disable(), sys_spi_set_prescaler() and st7789v_reset() fix:
1. Before the fix, logic was inverted and totally wrong.
__get_PRIMASK() returns 1 if interrupts are masked, 0 if interrupts are enabled
So before the fix interrupts were disabled in the beginning only when already disabled (masked).
And interrupts were enabled in the end if those were disabled before calling this function.
2. Return value of __get_PRIMASK doesn't need to be masked.
3. irq type didn't match __get_PRIMASK() return value.
4. "cpsie i" ASM instruction is not allowed in condition
so who knows what kind of code was generated when __enable_irq() is put
in if condition.
5. irq variable renamed to primask, as irq is misleading as it has opposite meaning.
6. irq was made const.

sys_sscg_disable(void) and sys_sscg_enable(void) might enable interrupts
unintentionally before the fix.

sys_sscg_disable(void) might return with interrupts still disabled as one
of its return point didn't handle interrupts before the fix.

EepromSystemInit():
1. Before the fix, logic was inverted and totally wrong.
__get_PRIMASK() returns 1 if interrupts are masked, 0 if interrupts are enabled
So interrupts were disabled before returning of this function
if those were enabled before calling this function.
2. Return value of __get_PRIMASK doesn't need to be masked.
3. irq type didn't match __get_PRIMASK() return value.
4. "cpsid i" ASM instruction is not allowed in condition
so who knows what kind of code was generated when __disable_irq() is put
in if condition.
5. irq variable renamed to primask, as irq is misleading as it has opposite meaning.
6. irq was made const.