### PR TITLE
Fix and unify critical sections.

### DIFF
--- a/lib/Marlin/Marlin/src/HAL/HAL_STM32_F4_F7/HAL.h
+++ b/lib/Marlin/Marlin/src/HAL/HAL_STM32_F4_F7/HAL.h
@@ -107,8 +107,8 @@
   #define analogInputToDigitalPin(p) (p)
 #endif
 
-#define CRITICAL_SECTION_START  uint32_t primask = __get_PRIMASK(); __disable_irq()
-#define CRITICAL_SECTION_END    if (!primask) __enable_irq()
+#define CRITICAL_SECTION_START  const uint32_t primask = __get_PRIMASK(); __disable_irq()
+#define CRITICAL_SECTION_END    __set_PRIMASK(primask)
 #define ISRS_ENABLED() (!__get_PRIMASK())
 #define ENABLE_ISRS()  __enable_irq()
 #define DISABLE_ISRS() __disable_irq()

--- a/lib/Marlin/Marlin/src/module/stepper.cpp
+++ b/lib/Marlin/Marlin/src/module/stepper.cpp
@@ -2357,7 +2357,7 @@ void Stepper::report_positions() {
   // MUST ONLY BE CALLED BY AN ISR,
   // No other ISR should ever interrupt this!
   void Stepper::babystep(const AxisEnum axis, const bool direction) {
-    cli();
+    CRITICAL_SECTION_START;
 
     switch (axis) {
 
@@ -2449,7 +2449,7 @@ void Stepper::report_positions() {
 
       default: break;
     }
-    sei();
+    CRITICAL_SECTION_END;
   }
 
 #endif // BABYSTEPPING

--- a/src/common/disable_interrupts.h
+++ b/src/common/disable_interrupts.h
@@ -1,0 +1,95 @@
+/**
+ * @file
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <cmsis_gcc.h>
+
+namespace buddy {
+
+/**
+ * @brief Disable all maskable interrupts
+ *
+ * Disabling all interrupts may be needed in case of dealing with stepper data
+ * or in case timing with nanosecond precision is needed.
+ *
+ * In other cases use CriticalSection instead.
+ *
+ * Interrupts are disabled when object is constructed by its default constructor
+ * and resumed to original state once destroyed.
+ *
+ * When the motors are moving disabling all interrupts for more than
+ *
+ * - 500 ns frequently may produce motor noise
+ * (Induce stepping error bigger than 1% at 200 mm/s 200 step motor 16 microsteps or 400 step motor 8 microsteps)
+ *
+ * - 50 us produce multiple microsteps done at once (noise, may cause motor over-current in no-current-feedback-mode)
+ * - 400 us may cause motor stall (400 step motors)
+ * - 800 us -//- (200 step motors)
+ *
+ * Example usage:
+ * @code
+ * void singleCriticalSectionFunction() {
+ *     // non-critical code
+ *     {
+ *         buddy::DisableInterrupts disable_interrupts;
+ *         // critical code
+ *     }
+ *     // non-critical code
+ * }
+ * @endcode
+ *
+ * Example multiple critical sections in single function:
+ * @code
+ * void multipleCriticalSectionsFunction() {
+ *     buddy::DisableInterrupts interrupts(false);
+ *     // non-critical code
+ *
+ *     interrupts.disable();
+ *     // critical code
+ *     interrupts.resume();
+ *
+ *     // non-critical code
+ *
+ *     interrupts.disable();
+ *     // critical code
+ *     interrupts.resume();
+ *
+ *     // non-critical code
+ *
+ *     interrupts.disable();
+ *     // critical code
+ * }
+ * @endcode
+ */
+class DisableInterrupts {
+public:
+    DisableInterrupts(bool disableNow = true)
+        : m_primask(__get_PRIMASK()) {
+        if (disableNow)
+            disable();
+    }
+
+    ~DisableInterrupts() {
+        resume();
+    }
+
+    void disable() {
+        __disable_irq();
+    }
+
+    void resume() {
+        __set_PRIMASK(m_primask);
+    }
+
+    DisableInterrupts(const DisableInterrupts &other) = delete;
+    DisableInterrupts &operator=(const DisableInterrupts &other) = delete;
+
+private:
+    uint32_t m_primask;
+};
+
+} /* namespace Buddy */

--- a/src/common/include/rtos_api.hpp
+++ b/src/common/include/rtos_api.hpp
@@ -22,6 +22,19 @@ public:
     static inline uint32_t GetTick() { return HAL_GetTick(); }
 };
 
+/**
+ * To be used for:
+ * - Implementing atomic operations
+ * on data shared between tasks and RTOS aware
+ * interrupts.
+ * - Precisely timed operations, which can
+ * be interrupted for less than 10 microseconds
+ * by high priority non OS aware interrupt.
+ *
+ * For atomic operations on stepper interrupt
+ * data or timing with nanosecond precision use
+ * DisableInterrupt instead.
+ */
 class CriticalSection {
 public:
     CriticalSection() { taskENTER_CRITICAL(); }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include "adc.hpp"
 #include "SEGGER_SYSVIEW.h"
 #include "logging.h"
+#include "common/disable_interrupts.h"
 
 #ifdef BUDDY_ENABLE_WUI
     #include "wui.h"
@@ -125,8 +126,14 @@ char uart6slave_line[32];
 /**
  * @brief initialization of eeprom and prerequisites, to be able to use
  *        it to initialize static variables and objects
- * This is called during startup before main and before initialization
- *        of static variables but after setting them to 0
+ *
+ *  This is called during startup before main and before initialization
+ *  of static variables but after setting them to 0
+ *
+ *  This function temporarily unmasks interrupts,
+ *  so it might be dangerous to call it in some contexts.
+ *
+ *
  */
 extern "C" void EepromSystemInit() {
     //__HAL_RCC_GET_FLAG(RCC_FLAG_LPWRRST);
@@ -160,13 +167,13 @@ extern "C" void EepromSystemInit() {
     tick_timer_init();
     crc32_init();
 
-    int irq = __get_PRIMASK() & 1;
+    // Temporarily enable interrupts and restore
+    // original state when disable_interrupts go out of scope
+    // (non-standard usage of DisableInterrupts)
+    buddy::DisableInterrupts disable_interrupts(false);
     __enable_irq();
 
     eeprom_init();
-
-    if (irq == 0)
-        __disable_irq();
 }
 
 /**


### PR DESCRIPTION
CRITICAL_SECTION_START:
make primask const to catch more usage faults.

CRITICAL_SECTION_END:
__set_PRIMASK(primask) might be more efficient
than if (!primask) __enable_irq()
due to the fact that "cpsie i" ASM instruction is not allowed in ASM condition

Stepper::babystep() might enable interrupts unintentionally before the fix.
We call it from marlin server so better to be safe than sorry.

sys_reset() remove redundant code:
1. Return value of __get_PRIMASK doesn't need to be masked.
2. irq variable is not needed as interrupt masking state is not restored.
3. irq type doesn't match __get_PRIMASK() return value.
4. "cpsid i" ASM instruction is not allowed in condition so who knows what kind of code was generated.

sys_pll_enable(), sys_pll_disable(), sys_spi_set_prescaler() and st7789v_reset() fix:
1. Before the fix, logic was inverted and totally wrong.
__get_PRIMASK() returns 1 if interrupts are masked, 0 if interrupts are enabled
So before the fix interrupts were disabled in the beginning only when already disabled (masked).
And interrupts were enabled in the end if those were disabled before calling this function.
2. Return value of __get_PRIMASK doesn't need to be masked.
3. irq type didn't match __get_PRIMASK() return value.
4. "cpsie i" ASM instruction is not allowed in condition
so who knows what kind of code was generated when __enable_irq() is put
in if condition.
5. irq variable renamed to primask, as irq is misleading as it has opposite meaning.
6. irq was made const.

sys_sscg_disable(void) and sys_sscg_enable(void) might enable interrupts
unintentionally before the fix.

sys_sscg_disable(void) might return with interrupts still disabled as one
of its return point didn't handle interrupts before the fix.

EepromSystemInit():
1. Before the fix, logic was inverted and totally wrong.
__get_PRIMASK() returns 1 if interrupts are masked, 0 if interrupts are enabled
So interrupts were disabled before returning of this function
if those were enabled before calling this function.
2. Return value of __get_PRIMASK doesn't need to be masked.
3. irq type didn't match __get_PRIMASK() return value.
4. "cpsid i" ASM instruction is not allowed in condition
so who knows what kind of code was generated when __disable_irq() is put
in if condition.
5. irq variable renamed to primask, as irq is misleading as it has opposite meaning.
6. irq was made const.