### PR TITLE
Delay deciding the ESP has no firmware until later

### DIFF
--- a/lib/WUI/espif.h
+++ b/lib/WUI/espif.h
@@ -77,6 +77,8 @@ enum class EspFwState {
     NoEsp,
     /// The ESP is being flashed right now.
     Flashing,
+    /// The state is not currently (yet) known.
+    Unknown,
 };
 
 /// Returns the current state of the ESP's firmware, as guessed by us.


### PR DESCRIPTION
During boot, we don't have the thread running, or it has a low priority.
Also, the ESP might need some time to wake up, boot and send us a
message.

Therefore, introduce some delay before deciding the ESP is there, but
doesn't have a relevant FW.

Still report a recognized firmware of the wrong version as soon as we
know it.