### PR TITLE
Closing „error“ HTTP

### DIFF
--- a/lib/WUI/link_content/previews.cpp
+++ b/lib/WUI/link_content/previews.cpp
@@ -25,7 +25,7 @@ optional<ConnectionState> Previews::accept(const RequestParser &parser) const {
 
     // Content of the USB drive is only for authenticated, don't ever try anything without it.
     if (!parser.authenticated()) {
-        return StatusPage(Status::Unauthorized, parser.can_keep_alive(), parser.accepts_json);
+        return StatusPage(Status::Unauthorized, parser.status_page_handling(), parser.accepts_json);
     }
 
     uint16_t width;
@@ -39,12 +39,12 @@ optional<ConnectionState> Previews::accept(const RequestParser &parser) const {
         width = 220;
         height = 140;
     } else {
-        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json, "Thumbnail size specification not recognized");
+        return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json, "Thumbnail size specification not recognized");
     }
 
     char fname[FILE_PATH_BUFFER_LEN + extra_size];
     if (!parser.uri_filename(fname, sizeof(fname))) {
-        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json, "This doesn't look like file name");
+        return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json, "This doesn't look like file name");
     }
 
     // Strip the extra prefix (without the last /)
@@ -55,7 +55,7 @@ optional<ConnectionState> Previews::accept(const RequestParser &parser) const {
     if (f) {
         return GCodePreview(f, fname, parser.can_keep_alive(), parser.accepts_json, width, height, parser.if_none_match);
     } else {
-        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json);
+        return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json);
     }
 }
 

--- a/lib/WUI/link_content/prusa_link_api.cpp
+++ b/lib/WUI/link_content/prusa_link_api.cpp
@@ -47,7 +47,7 @@ optional<ConnectionState> PrusaLinkApi::accept(const RequestParser &parser) cons
     const auto suffix = *suffix_opt;
 
     if (!parser.authenticated()) {
-        return StatusPage(Status::Unauthorized, parser.can_keep_alive(), parser.accepts_json);
+        return StatusPage(Status::Unauthorized, parser.status_page_handling(), parser.accepts_json);
     }
 
     const auto get_only = [parser](ConnectionState state) -> ConnectionState {
@@ -55,13 +55,13 @@ optional<ConnectionState> PrusaLinkApi::accept(const RequestParser &parser) cons
             return state;
         } else {
             // Drop the connection in fear there might be a body we don't know about.
-            return StatusPage(Status::MethodNotAllowed, false, parser.accepts_json);
+            return StatusPage(Status::MethodNotAllowed, StatusPage::CloseHandling::ErrorClose, parser.accepts_json);
         }
     };
 
     // Some stubs for now, to make more clients (including the web page) happier.
     if (suffix == "download") {
-        return get_only(StatusPage(Status::NoContent, parser.can_keep_alive(), parser.accepts_json));
+        return get_only(StatusPage(Status::NoContent, parser.status_page_handling(), parser.accepts_json));
     } else if (suffix == "settings") {
         return get_only(SendStaticMemory("{\"printer\": {}}", http::ContentType::ApplicationJson, parser.can_keep_alive()));
     } else if (remove_prefix(suffix, "files").has_value()) {
@@ -103,7 +103,7 @@ optional<ConnectionState> PrusaLinkApi::accept(const RequestParser &parser) cons
             if (parser.uri_filename(fname, sizeof fname)) {
                 size_t len = strlen(fname);
                 if (prefix_len > len) {
-                    return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json);
+                    return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json);
                 }
 
                 const char *fname_real = fname + prefix_len;
@@ -135,7 +135,7 @@ optional<ConnectionState> PrusaLinkApi::accept(const RequestParser &parser) cons
                  * on the USB drive (eg. our xflash).
                  */
                 if (strncmp(fname_real, "/usb/", 5) != 0) {
-                    StatusPage(Status::Forbidden, parser.can_keep_alive(), parser.accepts_json);
+                    StatusPage(Status::Forbidden, parser.status_page_handling(), parser.accepts_json);
                 }
 
                 switch (parser.method) {
@@ -146,12 +146,12 @@ optional<ConnectionState> PrusaLinkApi::accept(const RequestParser &parser) cons
                     if (result == -1) {
                         switch (errno) {
                         case EBUSY:
-                            return StatusPage(Status::Conflict, parser.can_keep_alive(), parser.accepts_json, "File is busy");
+                            return StatusPage(Status::Conflict, parser.status_page_handling(), parser.accepts_json, "File is busy");
                         default:
-                            return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json);
+                            return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json);
                         }
                     } else {
-                        return StatusPage(Status::NoContent, parser.can_keep_alive(), parser.accepts_json);
+                        return StatusPage(Status::NoContent, parser.status_page_handling(), parser.accepts_json);
                     }
                 }
                 case Method::Post:
@@ -159,14 +159,14 @@ optional<ConnectionState> PrusaLinkApi::accept(const RequestParser &parser) cons
                         return FileCommand(fname_real, *parser.content_length, parser.can_keep_alive(), parser.accepts_json);
                     } else {
                         // Drop the connection (and the body there).
-                        return StatusPage(Status::LengthRequired, false, parser.accepts_json);
+                        return StatusPage(Status::LengthRequired, StatusPage::CloseHandling::ErrorClose, parser.accepts_json);
                     }
                 default:
                     // Drop the connection in fear there might be a body we don't know about.
-                    return StatusPage(Status::MethodNotAllowed, false, parser.accepts_json);
+                    return StatusPage(Status::MethodNotAllowed, StatusPage::CloseHandling::ErrorClose, parser.accepts_json);
                 }
             } else {
-                return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json);
+                return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json);
             }
         }
         // The real API endpoints
@@ -181,16 +181,16 @@ optional<ConnectionState> PrusaLinkApi::accept(const RequestParser &parser) cons
                 return JobCommand(*parser.content_length, parser.can_keep_alive(), parser.accepts_json);
             } else {
                 // Drop the connection (and the body there).
-                return StatusPage(Status::LengthRequired, false, parser.accepts_json);
+                return StatusPage(Status::LengthRequired, StatusPage::CloseHandling::ErrorClose, parser.accepts_json);
             }
         }
         default:
-            return StatusPage(Status::MethodNotAllowed, false, parser.accepts_json);
+            return StatusPage(Status::MethodNotAllowed, StatusPage::CloseHandling::ErrorClose, parser.accepts_json);
         }
     } else if (suffix == "printer") {
         return get_only(StatelessJson(get_printer, parser.can_keep_alive()));
     } else {
-        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json);
+        return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json);
     }
 }
 

--- a/lib/WUI/link_content/usb_files.cpp
+++ b/lib/WUI/link_content/usb_files.cpp
@@ -24,12 +24,12 @@ optional<ConnectionState> UsbFiles::accept(const RequestParser &parser) const {
 
     // Content of the USB drive is only for authenticated, don't ever try anything without it.
     if (!parser.authenticated()) {
-        return StatusPage(Status::Unauthorized, parser.can_keep_alive(), parser.accepts_json);
+        return StatusPage(Status::Unauthorized, parser.status_page_handling(), parser.accepts_json);
     }
 
     char fname[FILE_PATH_BUFFER_LEN];
     if (!parser.uri_filename(fname, sizeof(fname))) {
-        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json, "This doesn't look like file name");
+        return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json, "This doesn't look like file name");
     }
 
     if (parser.method == Method::Get) {
@@ -55,9 +55,9 @@ optional<ConnectionState> UsbFiles::accept(const RequestParser &parser) const {
             return std::move(step);
         }
 
-        return StatusPage(Status::NotFound, parser.can_keep_alive(), parser.accepts_json);
+        return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json);
     } else {
-        return StatusPage(Status::MethodNotAllowed, parser.can_keep_alive(), parser.accepts_json);
+        return StatusPage(Status::MethodNotAllowed, parser.status_page_handling(), parser.accepts_json);
     }
 }
 

--- a/lib/WUI/nhttp/common_selectors.cpp
+++ b/lib/WUI/nhttp/common_selectors.cpp
@@ -9,7 +9,7 @@ namespace nhttp::handler::selectors {
 
 optional<ConnectionState> ValidateRequest::accept(const RequestParser &request) const {
     if (request.method == Method::UnknownMethod) {
-        return StatusPage(Status::MethodNotAllowed, request.can_keep_alive(), request.accepts_json, "Unrecognized method");
+        return StatusPage(Status::MethodNotAllowed, request.status_page_handling(), request.accepts_json, "Unrecognized method");
     }
 
     if (request.error_code != Status::UnknownStatus) {
@@ -18,7 +18,7 @@ optional<ConnectionState> ValidateRequest::accept(const RequestParser &request) 
          * that case since there might be leftovers of the unrecognized request
          * lying around.
          */
-        return StatusPage(request.error_code, request.error_code == Status::BadRequest ? false : request.can_keep_alive(), request.accepts_json);
+        return StatusPage(request.error_code, request.error_code == Status::BadRequest ? StatusPage::CloseHandling::ErrorClose : request.status_page_handling(), request.accepts_json);
     }
 
     return nullopt;
@@ -27,7 +27,7 @@ optional<ConnectionState> ValidateRequest::accept(const RequestParser &request) 
 const ValidateRequest validate_request;
 
 optional<ConnectionState> UnknownRequest::accept(const RequestParser &request) const {
-    return StatusPage(Status::NotFound, request.can_keep_alive(), request.accepts_json);
+    return StatusPage(Status::NotFound, request.status_page_handling(), request.accepts_json);
 }
 
 const UnknownRequest unknown_request;

--- a/lib/WUI/nhttp/file_command.cpp
+++ b/lib/WUI/nhttp/file_command.cpp
@@ -46,9 +46,9 @@ handler::StatusPage FileCommand::process() {
 
     switch (parse_result) {
     case JsonParseResult::ErrMem:
-        return StatusPage(Status::PayloadTooLarge, can_keep_alive, json_errors, "Too many JSON tokens");
+        return StatusPage(Status::PayloadTooLarge, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, "Too many JSON tokens");
     case JsonParseResult::ErrReq:
-        return StatusPage(Status::BadRequest, can_keep_alive, json_errors, "Couldn't parse JSON");
+        return StatusPage(Status::BadRequest, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, "Couldn't parse JSON");
     case JsonParseResult::Ok:
         break;
     }
@@ -56,26 +56,26 @@ handler::StatusPage FileCommand::process() {
     switch (command) {
     case Command::Unknown:
         // Any idea for better status than the very generic 400? 404?
-        return StatusPage(Status::BadRequest, can_keep_alive, "Unknown file command");
+        return StatusPage(Status::BadRequest, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, "Unknown file command");
     case Command::Start:
         switch (start()) {
         case StartResult::NotReady:
-            return StatusPage(Status::Conflict, can_keep_alive, json_errors, "Can't start print now");
+            return StatusPage(Status::Conflict, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, "Can't start print now");
         case StartResult::NotFound:
-            return StatusPage(Status::NotFound, can_keep_alive, json_errors, "Gcode doesn't exist");
+            return StatusPage(Status::NotFound, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, "Gcode doesn't exist");
         case StartResult::Started:
-            return StatusPage(Status::NoContent, can_keep_alive, json_errors);
+            return StatusPage(Status::NoContent, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
         }
     default:
         assert(0);
-        return StatusPage(Status::InternalServerError, can_keep_alive, json_errors, "Invalid command");
+        return StatusPage(Status::InternalServerError, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, "Invalid command");
     }
 }
 
 handler::Step FileCommand::step(string_view input, bool terminated_by_client, uint8_t *, size_t) {
     if (content_length > buffer.size()) {
         // Refuse early, without reading the body -> drop the connection too.
-        return Step { 0, 0, StatusPage(Status::PayloadTooLarge, false, json_errors) };
+        return Step { 0, 0, StatusPage(Status::PayloadTooLarge, StatusPage::CloseHandling::ErrorClose, json_errors) };
     }
 
     const size_t rest = content_length - buffer_used;
@@ -90,7 +90,7 @@ handler::Step FileCommand::step(string_view input, bool terminated_by_client, ui
     if (content_length > buffer_used) {
         // Still waiting for more data.
         if (terminated_by_client) {
-            return Step { to_read, 0, StatusPage(Status::BadRequest, false, json_errors, "Truncated request") };
+            return Step { to_read, 0, StatusPage(Status::BadRequest, StatusPage::CloseHandling::ErrorClose, json_errors, "Truncated request") };
         } else {
             return Step { to_read, 0, Continue() };
         }

--- a/lib/WUI/nhttp/file_info.cpp
+++ b/lib/WUI/nhttp/file_info.cpp
@@ -144,7 +144,7 @@ Step FileInfo::step(std::string_view, bool, uint8_t *output, size_t output_size)
             // Special case it, we return empty list of files.
             renderer = DirRenderer(); // Produces empty file list
         } else {
-            return Step { 0, 0, StatusPage(Status::NotFound, can_keep_alive, json_errors) };
+            return Step { 0, 0, StatusPage(Status::NotFound, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors) };
         }
         written = write_headers(output, output_size, after_upload ? Status::Created : Status::Ok, ContentType::ApplicationJson, handling);
 
@@ -182,7 +182,7 @@ Step FileInfo::step(std::string_view, bool, uint8_t *output, size_t output_size)
             // return a 500 error, we have sent the headers out already
             // (possibly), so the best we can do is to abort the
             // connection.
-            return { 0, 0, Terminating { Done::CloseFast } };
+            return { 0, 0, Terminating { 0, Done::CloseFast } };
         }
     }
 
@@ -202,7 +202,7 @@ Step FileInfo::step(std::string_view, bool, uint8_t *output, size_t output_size)
 
     // This place should be unreachable!
     assert(0);
-    return { 0, 0, Terminating { Done::CloseFast } };
+    return { 0, 0, Terminating { 0, Done::CloseFast } };
 }
 
 }

--- a/lib/WUI/nhttp/gcode_preview.cpp
+++ b/lib/WUI/nhttp/gcode_preview.cpp
@@ -36,7 +36,7 @@ GCodePreview::GCodePreview(FILE *f, const char *path, bool can_keep_alive, bool 
 Step GCodePreview::step(string_view, bool, uint8_t *buffer, size_t buffer_size) {
     if (etag_matches) {
         // No need to pass the json_errors, NotModified has no content anyway.
-        return { 0, 0, StatusPage(Status::NotModified, can_keep_alive, false) };
+        return { 0, 0, StatusPage(Status::NotModified, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, false) };
     }
     ConnectionHandling handling = can_keep_alive ? ConnectionHandling::ChunkedKeep : ConnectionHandling::Close;
 
@@ -63,7 +63,7 @@ Step GCodePreview::step(string_view, bool, uint8_t *buffer, size_t buffer_size) 
              * Something is wrong. We don't care about exactly what, we simply
              * don't have the preview -> 404.
              */
-            return { 0, 0, StatusPage(Status::NotFound, can_keep_alive, json_errors, "File doesn't contain preview") };
+            return { 0, 0, StatusPage(Status::NotFound, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, "File doesn't contain preview") };
         }
     } else {
         NextInstruction instruction = Continue();

--- a/lib/WUI/nhttp/gcode_upload.cpp
+++ b/lib/WUI/nhttp/gcode_upload.cpp
@@ -67,12 +67,12 @@ GcodeUpload::UploadResult GcodeUpload::start(const RequestParser &parser, Upload
 
     const auto boundary = parser.boundary();
     if (boundary.empty()) {
-        return StatusPage(Status::BadRequest, false, json_errors, "Missing boundary");
+        return StatusPage(Status::BadRequest, StatusPage::CloseHandling::ErrorClose, json_errors, "Missing boundary");
     }
 
     // One day we may want to support chunked and connection-close, but we are not there yet.
     if (!parser.content_length.has_value()) {
-        return StatusPage(Status::LengthRequired, json_errors, false);
+        return StatusPage(Status::LengthRequired, StatusPage::CloseHandling::ErrorClose, json_errors);
     }
 
     static size_t upload_idx = 0;
@@ -82,7 +82,7 @@ GcodeUpload::UploadResult GcodeUpload::start(const RequestParser &parser, Upload
     unique_file_ptr file(fopen(fname, "wb"));
     if (!file) {
         // Missing USB -> Insufficient storage.
-        return StatusPage(Status::InsufficientStorage, false, json_errors, "Missing USB drive");
+        return StatusPage(Status::InsufficientStorage, StatusPage::CloseHandling::ErrorClose, json_errors, "Missing USB drive");
     }
 
     char boundary_cstr[boundary.size() + 1];
@@ -91,7 +91,7 @@ GcodeUpload::UploadResult GcodeUpload::start(const RequestParser &parser, Upload
     UploadState uploader(boundary_cstr);
 
     if (const auto err = uploader.get_error(); get<0>(err) != Status::Ok) {
-        return StatusPage(get<0>(err), false, json_errors, get<1>(err));
+        return StatusPage(get<0>(err), StatusPage::CloseHandling::ErrorClose, json_errors, get<1>(err));
     }
 
     return GcodeUpload(move(uploader), json_errors, *parser.content_length, file_idx, move(file), uploaded);
@@ -100,7 +100,7 @@ GcodeUpload::UploadResult GcodeUpload::start(const RequestParser &parser, Upload
 Step GcodeUpload::step(string_view input, bool terminated_by_client, uint8_t *, size_t) {
     uploader.setup(this);
     if (terminated_by_client && size_rest > 0) {
-        return { 0, 0, StatusPage(Status::BadRequest, false, json_errors, "Truncated body") };
+        return { 0, 0, StatusPage(Status::BadRequest, StatusPage::CloseHandling::ErrorClose, json_errors, "Truncated body") };
     }
 
     const size_t read = std::min(input.size(), size_rest);
@@ -109,7 +109,7 @@ Step GcodeUpload::step(string_view input, bool terminated_by_client, uint8_t *, 
     size_rest -= read;
 
     if (const auto err = uploader.get_error(); get<0>(err) != Status::Ok) {
-        return { read, 0, StatusPage(get<0>(err), false, json_errors, get<1>(err)) };
+        return { read, 0, StatusPage(get<0>(err), StatusPage::CloseHandling::ErrorClose, json_errors, get<1>(err)) };
     }
 
     if (size_rest == 0) {
@@ -123,7 +123,7 @@ Step GcodeUpload::step(string_view input, bool terminated_by_client, uint8_t *, 
             strlcpy(filename + USB_MOUNT_POINT_LENGTH, orig_filename, sizeof(filename) - USB_MOUNT_POINT_LENGTH);
             return { read, 0, FileInfo(filename, false, json_errors, true) };
         } else {
-            return { read, 0, StatusPage(Status::BadRequest, false, json_errors, "Missing file") };
+            return { read, 0, StatusPage(Status::BadRequest, StatusPage::CloseHandling::ErrorClose, json_errors, "Missing file") };
         }
     } else {
         return { read, 0, Continue() };

--- a/lib/WUI/nhttp/handler.cpp
+++ b/lib/WUI/nhttp/handler.cpp
@@ -6,16 +6,21 @@ namespace nhttp::handler {
 
 Step Idle::step(string_view, bool terminated_by_client, uint8_t *, size_t) {
     if (terminated_by_client) {
-        return { 0, 0, Terminating { Done::Close } };
+        return { 0, 0, Terminating { 0, Done::Close } };
     } else {
         return { 0, 0, Continue() };
     }
 }
 
-Step Terminating::step(string_view, bool, uint8_t *, size_t) {
-    return { 0, 0, Continue() };
+Step Terminating::step(string_view input, bool client_closed, uint8_t *, size_t) {
+    if (client_closed) {
+        eat_input = 0;
+    }
+    if (!input.empty() && eat_input) {
+        return { input.size(), 0, Continue() };
+    } else {
+        return { 0, 0, Continue() };
+    }
 }
-
-Selector::~Selector() {}
 
 }

--- a/lib/WUI/nhttp/handler.h
+++ b/lib/WUI/nhttp/handler.h
@@ -96,12 +96,21 @@ public:
  * connection or transition to Idle on its own.
  */
 struct Terminating {
+    bool eat_input;
     Done how;
-    bool want_read() const { return false; }
+    /*
+     * Request to shut down the send direction early, even during the eating of
+     * input.
+     */
+    bool shutdown_send = false;
+    bool want_read() const { return eat_input > 0; }
     bool want_write() const { return false; }
     Step step(std::string_view input, bool terminated_by_client, uint8_t *output, size_t output_size);
     static Terminating for_handling(http::ConnectionHandling handling) {
-        return Terminating { handling == http::ConnectionHandling::Close ? Done::Close : Done::KeepAlive };
+        return Terminating { false, handling == http::ConnectionHandling::Close ? Done::Close : Done::KeepAlive, false };
+    }
+    static Terminating error_termination() {
+        return Terminating { true, Done::Close, true };
     }
 };
 
@@ -183,7 +192,7 @@ struct Step {
  */
 class Selector {
 public:
-    virtual ~Selector();
+    virtual ~Selector() = default;
     virtual std::optional<ConnectionState> accept(const RequestParser &request) const = 0;
 };
 

--- a/lib/WUI/nhttp/job_command.cpp
+++ b/lib/WUI/nhttp/job_command.cpp
@@ -33,7 +33,7 @@ JobCommand::JobCommand(size_t content_length, bool can_keep_alive, bool json_err
 Step JobCommand::step(std::string_view input, bool terminated_by_client, uint8_t *, size_t) {
     if (content_length > buffer.size()) {
         // Refuse early, without reading the body -> drop the connection too.
-        return Step { 0, 0, StatusPage(Status::PayloadTooLarge, false, json_errors) };
+        return Step { 0, 0, StatusPage(Status::PayloadTooLarge, StatusPage::CloseHandling::ErrorClose, json_errors) };
     }
 
     const size_t rest = content_length - buffer_used;
@@ -48,7 +48,7 @@ Step JobCommand::step(std::string_view input, bool terminated_by_client, uint8_t
     if (content_length > buffer_used) {
         // Still waiting for more data.
         if (terminated_by_client) {
-            return Step { to_read, 0, StatusPage(Status::BadRequest, false, json_errors, "Truncated request") };
+            return Step { to_read, 0, StatusPage(Status::BadRequest, StatusPage::CloseHandling::ErrorClose, json_errors, "Truncated request") };
         } else {
             return Step { to_read, 0, Continue() };
         }
@@ -81,9 +81,9 @@ StatusPage JobCommand::process() {
 
     switch (parse_result) {
     case JsonParseResult::ErrMem:
-        return StatusPage(Status::PayloadTooLarge, can_keep_alive, json_errors, "Too many JSON tokens");
+        return StatusPage(Status::PayloadTooLarge, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, "Too many JSON tokens");
     case JsonParseResult::ErrReq:
-        return StatusPage(Status::BadRequest, can_keep_alive, json_errors, "Couldn't parse JSON");
+        return StatusPage(Status::BadRequest, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, "Couldn't parse JSON");
     case JsonParseResult::Ok:
         break;
     }
@@ -95,34 +95,34 @@ StatusPage JobCommand::process() {
     switch (top_command) {
     case Command::ErrUnknownCommand:
         // Any idea for better status than the very generic 400? 404?
-        return StatusPage(Status::BadRequest, can_keep_alive, "Unknown job command");
+        return StatusPage(Status::BadRequest, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, "Unknown job command");
     case Command::Pause:
         if (pause()) {
-            return StatusPage(Status::NoContent, can_keep_alive, json_errors);
+            return StatusPage(Status::NoContent, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
         } else {
-            return StatusPage(Status::Conflict, can_keep_alive, json_errors);
+            return StatusPage(Status::Conflict, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
         }
     case Command::Resume:
         if (resume()) {
-            return StatusPage(Status::NoContent, can_keep_alive, json_errors);
+            return StatusPage(Status::NoContent, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
         } else {
-            return StatusPage(Status::Conflict, can_keep_alive, json_errors);
+            return StatusPage(Status::Conflict, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
         }
     case Command::PauseToggle:
         if (pause_toggle()) {
-            return StatusPage(Status::NoContent, can_keep_alive, json_errors);
+            return StatusPage(Status::NoContent, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
         } else {
-            return StatusPage(Status::Conflict, can_keep_alive, json_errors);
+            return StatusPage(Status::Conflict, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
         }
     case Command::Stop:
         if (stop()) {
-            return StatusPage(Status::NoContent, can_keep_alive, json_errors);
+            return StatusPage(Status::NoContent, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
         } else {
-            return StatusPage(Status::Conflict, can_keep_alive, json_errors);
+            return StatusPage(Status::Conflict, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
         }
     default:
         assert(0);
-        return StatusPage(Status::InternalServerError, can_keep_alive, json_errors, "Invalid command");
+        return StatusPage(Status::InternalServerError, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, "Invalid command");
     }
 }
 

--- a/lib/WUI/nhttp/req_parser.cpp
+++ b/lib/WUI/nhttp/req_parser.cpp
@@ -191,6 +191,10 @@ bool RequestParser::can_keep_alive() const {
     return (connection == Connection::KeepAlive) || (version_major == 1 && version_minor >= 1 && connection != Connection::Close);
 }
 
+StatusPage::CloseHandling RequestParser::status_page_handling() const {
+    return can_keep_alive() ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close;
+}
+
 bool RequestParser::uri_filename(char *buffer, size_t buffer_size) const {
     // Only up to ?, which are query params
     size_t len = url_size;

--- a/lib/WUI/nhttp/req_parser.h
+++ b/lib/WUI/nhttp/req_parser.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "step.h"
+#include "status_page.h"
 #include <http/types.h>
 
 #include <automata/core.h>
@@ -116,6 +117,8 @@ public:
      * * Connection header, if present.
      */
     bool can_keep_alive() const;
+    // Status page close handling for the current can_keep_alive.
+    StatusPage::CloseHandling status_page_handling() const;
     /**
      * \brief Is the request authenticated by a valid api key?
      */

--- a/lib/WUI/nhttp/send_file.cpp
+++ b/lib/WUI/nhttp/send_file.cpp
@@ -43,7 +43,7 @@ void SendFile::disable_caching() {
 Step SendFile::step(std::string_view, bool, uint8_t *buffer, size_t buffer_size) {
     if (etag_matches) {
         // Note: json_errors are not enabled, because NotModified has no content anyway.
-        return Step { 0, 0, StatusPage(Status::NotModified, connection_handling != ConnectionHandling::Close, false) };
+        return Step { 0, 0, StatusPage(Status::NotModified, (connection_handling != ConnectionHandling::Close) ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, false) };
     }
 
     if (!buffer) {

--- a/lib/WUI/nhttp/server.cpp
+++ b/lib/WUI/nhttp/server.cpp
@@ -234,6 +234,14 @@ bool Server::Slot::step() {
         return true;
     }
 
+    if (!wr) {
+        if (Terminating *t = get_if<Terminating>(&state); t && t->shutdown_send) {
+            t->shutdown_send = false;
+            // Ignoring errors, no way to handle anyway and we'll close it soon.
+            altcp_shutdown(conn, 0, 1);
+            return true;
+        }
+    }
     if (!re && !wr) {
         /*
          * The current phase doesn't want to do anything. Check for special

--- a/lib/WUI/nhttp/stateless_json.cpp
+++ b/lib/WUI/nhttp/stateless_json.cpp
@@ -56,7 +56,7 @@ Step StatelessJson::step(std::string_view, bool, uint8_t *buffer, size_t buffer_
             // return a 500 error, we have sent the headers out already
             // (possibly), so the best we can do is to abort the
             // connection.
-            return { 0, 0, Terminating { Done::CloseFast } };
+            return { 0, 0, Terminating { 0, Done::CloseFast } };
         }
 
         // Fall through: the last chunk may fit

--- a/lib/WUI/nhttp/status_page.cpp
+++ b/lib/WUI/nhttp/status_page.cpp
@@ -40,7 +40,7 @@ Step StatusPage::step(std::string_view, bool, uint8_t *output, size_t output_siz
         ct = ContentType::TextPlain;
     }
 
-    ConnectionHandling handling = can_keep_alive ? ConnectionHandling::ContentLengthKeep : ConnectionHandling::Close;
+    ConnectionHandling handling = close_handling == CloseHandling::KeepAlive ? ConnectionHandling::ContentLengthKeep : ConnectionHandling::Close;
 
     /*
      * TODO: We might also want to include the Content-Location header with a
@@ -56,7 +56,8 @@ Step StatusPage::step(std::string_view, bool, uint8_t *output, size_t output_siz
     // with that, we work with byte-arrays with lengths here.
     strncpy(reinterpret_cast<char *>(output + used_up), content_buffer, write);
 
-    return Step { 0, used_up + write, Terminating::for_handling(handling) };
+    Terminating term = close_handling == CloseHandling::ErrorClose ? Terminating::error_termination() : Terminating::for_handling(handling);
+    return Step { 0, used_up + write, term };
 }
 
 }

--- a/lib/WUI/nhttp/status_page.h
+++ b/lib/WUI/nhttp/status_page.h
@@ -10,17 +10,29 @@
 namespace nhttp::handler {
 
 class StatusPage {
+public:
+    enum class CloseHandling {
+        Close,
+        /*
+         * Close for error states.
+         *
+         * First closes the outward side, then eats all the data.
+         */
+        ErrorClose,
+        KeepAlive,
+    };
+
 private:
     const char *extra_content;
     http::Status status;
-    bool can_keep_alive;
+    CloseHandling close_handling;
     bool json_content;
 
 public:
-    StatusPage(http::Status status, bool can_keep_alive, bool json_content, const char *extra_content = "")
+    StatusPage(http::Status status, CloseHandling close_handling, bool json_content, const char *extra_content = "")
         : extra_content(extra_content)
         , status(status)
-        , can_keep_alive(can_keep_alive)
+        , close_handling(close_handling)
         , json_content(json_content) {}
     bool want_read() const { return false; }
     bool want_write() const { return true; }

--- a/tests/unit/lib/WUI/nhttp/server_tests.cpp
+++ b/tests/unit/lib/WUI/nhttp/server_tests.cpp
@@ -203,7 +203,7 @@ public:
                 static const char *extra_hdrs[] = { "Fake: YesOfCourse\r\n", nullptr };
                 return SendStaticMemory("<html><body><h1>Don't tell anyone!</h1>", guess_content_by_ext(filename), parser.can_keep_alive(), extra_hdrs);
             } else {
-                return StatusPage(Status::Unauthorized, parser.can_keep_alive(), false);
+                return StatusPage(Status::Unauthorized, parser.status_page_handling(), false);
             }
         }
 


### PR DESCRIPTION
When there's an error on HTTP (usually, early in HTTP upload), we send
the response ASAP, close our side of connection and then continue
accepting the data until the other side is satisfied (not closing their
side forcefully).

This is to deal with browsers that don't deal well with the connection
being closed on them. Now, we have to accept the whole transfer (which
takes time), but gives the correct error description.