### PR TITLE
Add support for loading PHA filament

### DIFF
--- a/src/common/client_response.cpp
+++ b/src/common/client_response.cpp
@@ -38,7 +38,8 @@ const PhaseResponses ClientResponses::LoadUnloadResponses[CountPhases<PhasesLoad
 const PhaseResponses ClientResponses::PreheatResponses[CountPhases<PhasesPreheat>()] = {
     {}, //_first
     { Response::Abort, Response::Cooldown, Response::PLA, Response::PETG,
-        Response::ASA, Response::ABS, Response::PC, Response::FLEX, Response::HIPS, Response::PP, Response::PVB }, //UserTempSelection
+        Response::ASA, Response::ABS, Response::PC, Response::FLEX, Response::HIPS,
+        Response::PP, Response::PVB, Response::PHA }, //UserTempSelection
 };
 
 const PhaseResponses ClientResponses::SelftestResponses[CountPhases<PhasesSelftest>()] = {

--- a/src/common/client_response_texts.cpp
+++ b/src/common/client_response_texts.cpp
@@ -42,7 +42,8 @@ const std::array<std::pair<const char *, ResourceId>, static_cast<size_t>(Respon
     std::make_pair( N_("SKIP"), IDR_PNG_back_32px ),              // Skip
     std::make_pair( N_("STOP"), IDR_PNG_stop_58px  ),             // Stop
     std::make_pair( N_("UNLOAD"), IDR_PNG_spool_58px ),           // Unload
-    std::make_pair( N_("YES"), IDR_NULL )                         // Yes
+    std::make_pair( N_("YES"), IDR_NULL ),                        // Yes
+    std::make_pair( "PHA", IDR_PNG_spool_58px ),                  // PHA filament, do not translate
 };
 // clang-format on
 

--- a/src/common/filament.cpp
+++ b/src/common/filament.cpp
@@ -25,6 +25,7 @@ static constexpr const char *abs_str =   "ABS      255/100";
 static constexpr const char *hips_str =  "HIPS     220/100";
 static constexpr const char *pp_str =    "PP       240/100";
 static constexpr const char *flex_str =  "FLEX     240/ 50";
+static constexpr const char *pha_str =   "PHA      195/  0";
 
 const Filaments::Array filaments = {
     { "---", BtnResponse::GetText(Response::Cooldown),   0,    0,   0, Response::Cooldown }, // Cooldown sets long text instead short, not a bug
@@ -37,6 +38,7 @@ const Filaments::Array filaments = {
     { BtnResponse::GetText(Response::HIPS), hips_str,   220, 170, 100, Response::HIPS },
     { BtnResponse::GetText(Response::PP), pp_str,       240, 170, 100, Response::PP },
     { BtnResponse::GetText(Response::FLEX), flex_str,   240, 170,  50, Response::FLEX },
+    { BtnResponse::GetText(Response::PHA), pha_str,     195, 170,   0, Response::FLEX },
 };
 // clang-format on
 

--- a/src/common/filament.hpp
+++ b/src/common/filament.hpp
@@ -29,7 +29,8 @@ enum class filament_t {
     HIPS,
     PP,
     FLEX,
-    _last = FLEX
+    PHA,
+    _last = PHA
 };
 
 class Filaments {

--- a/src/common/general_response.hpp
+++ b/src/common/general_response.hpp
@@ -41,5 +41,6 @@ enum class Response : uint8_t {
     Stop,
     Unload,
     Yes,
-    _last = Yes
+    PHA,
+    _last = PHA
 };

--- a/src/gui/dialogs/window_dlg_preheat.hpp
+++ b/src/gui/dialogs/window_dlg_preheat.hpp
@@ -53,7 +53,8 @@ protected:
                       MI_Filament<filament_t::ABS>,  \
                       MI_Filament<filament_t::HIPS>, \
                       MI_Filament<filament_t::PP>,   \
-                      MI_Filament<filament_t::FLEX>
+                      MI_Filament<filament_t::FLEX>, \
+                      MI_Filament<filament_t::PHA>
 
 //TODO try to use HIDDEN on return and filament_t::NONE
 //has both return and cooldown


### PR DESCRIPTION
colorFabb has released allPHA, with 190-200C printing temp and a cooled heat bed: https://colorfabb.com/allpha-natural

The code compiles, but this code is not tested; I don't have a mini. I've put an equivalent PR for the i3 so I figured I may as well add PHA support here, too.