### PR TITLE
PrusaLink: Avoid unnecessary calls to remove

### DIFF
--- a/lib/WUI/nhttp/gcode_upload.h
+++ b/lib/WUI/nhttp/gcode_upload.h
@@ -34,7 +34,10 @@ private:
     UploadedNotify *uploaded_notify;
     size_t size_rest;
     bool json_errors;
-    GcodeUpload(UploadState uploader, size_t size_rest);
+    // Shall we remove/delete the temp file?
+    // Turns to false in move constructor/assignment in the old instance (it
+    // relinquishes ownership)
+    bool cleanup_temp_file;
     unique_file_ptr tmp_upload_file;
     // A way how to reconstruct the name of the temporary file.
     size_t file_idx;
@@ -43,7 +46,6 @@ private:
     virtual Result finish(const char *final_filename, bool start_print) override;
     virtual Result check_filename(const char *filename) const override;
 
-    void delete_file();
     GcodeUpload(UploadState uploader, bool json_errors, size_t length, size_t upload_idx, unique_file_ptr file, UploadedNotify *uploaded);
 
 public:
@@ -53,9 +55,9 @@ public:
     using UploadResult = std::variant<handler::StatusPage, GcodeUpload>;
     static UploadResult start(const handler::RequestParser &parser, UploadedNotify *uploaded, bool json_errors);
     GcodeUpload(const GcodeUpload &other) = delete;
-    GcodeUpload(GcodeUpload &&other) = default;
+    GcodeUpload(GcodeUpload &&other);
     GcodeUpload &operator=(const GcodeUpload &other) = delete;
-    GcodeUpload &operator=(GcodeUpload &&other) = default;
+    GcodeUpload &operator=(GcodeUpload &&other);
     ~GcodeUpload();
 };
 


### PR DESCRIPTION
Previously, every instance in a move-chain of GcodeUpload attempted to
remove() the temporary file. That failed, because it was held open and
alive by the newer (moved-to) instance, but it was still bothering the
USB storage, trying to delete the (still open) file.

Track if we are the "living" instance or just an empty shell we moved
from and try to close or delete things only in the last instance that
really dies, not moves.