### PR TITLE
ESP: Show wifi link status on dev

### DIFF
--- a/lib/WUI/espif.cpp
+++ b/lib/WUI/espif.cpp
@@ -758,3 +758,34 @@ EspFwState esp_fw_state() {
     assert(0);
     return EspFwState::NoEsp;
 }
+
+EspLinkState esp_link_state() {
+    ESPIFOperatingMode mode = esp_operating_mode.load();
+    switch (mode) {
+    case ESPIF_WAIT_INIT:
+    case ESPIF_WRONG_FW:
+    case ESPIF_FLASHING_MODE:
+    case ESPIF_UNINITIALIZED_MODE:
+        return EspLinkState::Init;
+    case ESPIF_NEED_AP:
+        return EspLinkState::NoAp;
+        return EspLinkState::Down;
+    case ESPIF_RUNNING_MODE: {
+        if (delayed_down == NO_DELAYED_DOWN) {
+            if (espif_link()) {
+                if (seen_intron) {
+                    return EspLinkState::Up;
+                } else {
+                    return EspLinkState::Silent;
+                }
+            } else {
+                return EspLinkState::Down;
+            }
+        } else {
+            return EspLinkState::Cooldown;
+        }
+    }
+    }
+    assert(0);
+    return EspLinkState::Init;
+}

--- a/lib/WUI/espif.h
+++ b/lib/WUI/espif.h
@@ -89,4 +89,23 @@ enum class EspFwState {
 /// transition to NoEsp and then again reach Ok, or (due to flashing) go
 /// WrongVersion -> Flashing -> NoEsp -> Ok.
 EspFwState esp_fw_state();
+
+enum class EspLinkState {
+    /// Being initialized, flashed, wrong FW version... see esp_fw_state.
+    Init,
+    /// Not connected to an AP.
+    NoAp,
+    /// Up and running.
+    Up,
+    /// Connected to AP, but not brought up (missing IP?)
+    Down,
+    /// Lost signal for a while, waiting to see if it stays down.
+    Cooldown,
+    /// No communication from ESP for a while.
+    ///
+    /// Broken UART? ESP crashed?
+    Silent,
+};
+
+EspLinkState esp_link_state();
 #endif

--- a/src/gui/MItem_lan.cpp
+++ b/src/gui/MItem_lan.cpp
@@ -11,7 +11,7 @@
 #include "marlin_client.h"
 
 MI_WIFI_STATUS_t::MI_WIFI_STATUS_t()
-    : WI_INFO_t(_(label), IDR_NULL, is_enabled_t::yes, is_hidden_t::yes) {
+    : WI_INFO_t(_(label), IDR_NULL, is_enabled_t::yes, is_hidden_t::dev) {
 }
 
 MI_WIFI_INIT_t::MI_WIFI_INIT_t()

--- a/src/gui/screen_menu_lan_settings.cpp
+++ b/src/gui/screen_menu_lan_settings.cpp
@@ -14,6 +14,7 @@
 #include "network_gui_tools.hpp"
 #include "MItem_lan.hpp"
 #include <http_lifetime.h>
+#include <espif.h>
 
 // Container for this base class contains all MI from both ETH and WIFI screen
 // There can be MI, that will not be used in derived class (MI_WIFI_... won't be used in ETH Screen)
@@ -64,6 +65,8 @@ void ScreenMenuConnectionBase::refresh_addresses() {
 
         stringify_address_for_screen(str, sizeof(str), ethconfig, ETHVAR_MSK(ETHVAR_LAN_GW_IP4));
         Item<MI_IP4_GWAY>().ChangeInformation(str);
+
+        Item<MI_WIFI_STATUS_t>().ChangeInformation("UP");
     } else {
         const char *msg = UNKNOWN_ADDR;
         Item<MI_IP4_ADDR>().ChangeInformation(msg);
@@ -73,6 +76,42 @@ void ScreenMenuConnectionBase::refresh_addresses() {
 
         msg = UNKNOWN_ADDR;
         Item<MI_IP4_GWAY>().ChangeInformation(msg);
+
+        switch (esp_link_state()) {
+        case EspLinkState::Init:
+            switch (esp_fw_state()) {
+            case EspFwState::Flashing:
+            case EspFwState::NoFirmware:
+            case EspFwState::WrongVersion:
+                Item<MI_WIFI_STATUS_t>().ChangeInformation("!FW");
+                break;
+            case EspFwState::NoEsp:
+                Item<MI_WIFI_STATUS_t>().ChangeInformation("Gone");
+                break;
+            case EspFwState::Ok:
+                Item<MI_WIFI_STATUS_t>().ChangeInformation("Down");
+                break;
+            case EspFwState::Unknown:
+                Item<MI_WIFI_STATUS_t>().ChangeInformation("???");
+                break;
+            }
+            break;
+        case EspLinkState::Cooldown:
+            Item<MI_WIFI_STATUS_t>().ChangeInformation("SIGN");
+            break;
+        case EspLinkState::NoAp:
+            Item<MI_WIFI_STATUS_t>().ChangeInformation("NO AP");
+            break;
+        case EspLinkState::Down:
+            Item<MI_WIFI_STATUS_t>().ChangeInformation("Down");
+            break;
+        case EspLinkState::Up:
+            Item<MI_WIFI_STATUS_t>().ChangeInformation("Up");
+            break;
+        case EspLinkState::Silent:
+            Item<MI_WIFI_STATUS_t>().ChangeInformation("Silent");
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
Show some more info about the internal / link state of the wifi in the
menu. Only accessible in dev builds („green“ menu).