### PR TITLE
Bootloader: remove dependency on iostream

### DIFF
--- a/src/bootloader/bootloader.cpp
+++ b/src/bootloader/bootloader.cpp
@@ -1,6 +1,5 @@
 #include "log.h"
 #include "bsod.h"
-#include <iostream>
 #include <tuple>
 #include <memory>
 #include "cmsis_os.h"


### PR DESCRIPTION
iostream was linked with bootloader.cpp. It was unused, but it was consuming 5.5kB of memory in .bss section.

Edit: Also a lot of space in .rodata and .text sections (~120kB).