### PR TITLE
ESP: Disable delay down

### DIFF
--- a/lib/WUI/espif.h
+++ b/lib/WUI/espif.h
@@ -99,8 +99,6 @@ enum class EspLinkState {
     Up,
     /// Connected to AP, but not brought up (missing IP?)
     Down,
-    /// Lost signal for a while, waiting to see if it stays down.
-    Cooldown,
     /// No communication from ESP for a while.
     ///
     /// Broken UART? ESP crashed?

--- a/src/gui/screen_menu_lan_settings.cpp
+++ b/src/gui/screen_menu_lan_settings.cpp
@@ -96,9 +96,6 @@ void ScreenMenuConnectionBase::refresh_addresses() {
                 break;
             }
             break;
-        case EspLinkState::Cooldown:
-            Item<MI_WIFI_STATUS_t>().ChangeInformation("SIGN");
-            break;
         case EspLinkState::NoAp:
             Item<MI_WIFI_STATUS_t>().ChangeInformation("NO AP");
             break;


### PR DESCRIPTION
Disable the delayed bringing of the wifi interface down. This was
implemented in an effort to not re-request DHCP on short glitch in
signal. Nevertheless, there are APs that block access to the network
until the DHCP exchange is completed. Therefore, the optimization
actually killed connectivity after the glitch on such APs and we can't
use it.

Relates to BFW-2646.