### PR TITLE
nhttp: Be more careful about writing headers

### DIFF
--- a/lib/WUI/nhttp/headers.cpp
+++ b/lib/WUI/nhttp/headers.cpp
@@ -81,11 +81,11 @@ size_t write_headers(uint8_t *buffer, size_t buffer_len, Status status, ContentT
         pos += snprintf(buf + pos, buffer_len - pos, "Content-Length: %" PRIu64 "\r\n", *content_length);
         pos = std::min(buffer_len, pos);
     }
-    if (handling == ConnectionHandling::ChunkedKeep) {
+    if (handling == ConnectionHandling::ChunkedKeep && pos < buffer_len) {
         pos += snprintf(buf + pos, buffer_len - pos, "Transfer-Encoding: chunked\r\n");
         pos = std::min(buffer_len, pos);
     }
-    if (etag.has_value()) {
+    if (etag.has_value() && pos < buffer_len) {
         pos += snprintf(buf + pos, buffer_len - pos, "ETag: \"%" PRIu32 "\"\r\n", *etag);
         pos = std::min(buffer_len, pos);
     }
@@ -95,6 +95,7 @@ size_t write_headers(uint8_t *buffer, size_t buffer_len, Status status, ContentT
         pos += copy;
     }
 
+    // That 2 fits, reserved at the top of the function.
     memcpy(buf + pos, "\r\n", 2);
     pos += 2;
     return pos;

--- a/lib/WUI/nhttp/status_page.cpp
+++ b/lib/WUI/nhttp/status_page.cpp
@@ -52,9 +52,8 @@ Step StatusPage::step(std::string_view, bool, uint8_t *output, size_t output_siz
     size_t used_up = write_headers(output, output_size, status, ct, handling, strlen(content_buffer), std::nullopt, text.extra_hdrs);
     size_t rest = output_size - used_up;
     size_t write = std::min(strlen(content_buffer), rest);
-    // If we use up the whole buffer, there's no \0 at the end. We are fine
-    // with that, we work with byte-arrays with lengths here.
-    strncpy(reinterpret_cast<char *>(output + used_up), content_buffer, write);
+    // Copy without the \0, we don't need it.
+    memcpy(output + used_up, content_buffer, write);
 
     Terminating term = close_handling == CloseHandling::ErrorClose ? Terminating::error_termination() : Terminating::for_handling(handling);
     return Step { 0, used_up + write, term };


### PR DESCRIPTION
Prefer more explicit checks for sizes instead of relying on
snprintf/strncpy doing the right thing.