### PR TITLE
nhttp: Reset timers after a step

### DIFF
--- a/lib/WUI/nhttp/server.cpp
+++ b/lib/WUI/nhttp/server.cpp
@@ -245,6 +245,11 @@ bool Server::Slot::step() {
     if (!input.empty() || invoke_client_close || output) {
         server->activity(conn, this);
         step(input, output, output_size);
+        // Note: The step can take extensive amount of time - specifically, it
+        // can take a long time to write data to USB (several seconds!). We
+        // therefore want to reset the timer after that too, because it's not
+        // inactivity of the other side.
+        server->activity(conn, this);
         return true;
     }
 


### PR DESCRIPTION
Because the step can take a long time (due to USB write) and could
trigger false "inactivity" timeout.