### PR TITLE
Fix broken probing with non-zero probe_offset.z. Second variant.

### DIFF
--- a/lib/Marlin/Marlin/src/module/probe.cpp
+++ b/lib/Marlin/Marlin/src/module/probe.cpp
@@ -759,7 +759,7 @@ float probe_at_point(const float &rx, const float &ry, const ProbePtRaise raise_
   if (!DEPLOY_PROBE()) {
     measured_z = run_z_probe() + probe_offset.z;
 
-    float move_away_from = std::isnan(measured_z) ? current_position.z : measured_z;
+    const float move_away_from = std::isnan(measured_z) ? current_position.z : (measured_z - probe_offset.z);
 
     const bool big_raise = raise_after == PROBE_PT_BIG_RAISE;
     if (big_raise || raise_after == PROBE_PT_RAISE) {


### PR DESCRIPTION
Change has no effect if the probe_offset.z == 0.

Change has big impact in case probe_offset.z is non-zero.
In such case move_away_from is set not to have probe clearance but nozzle clearance.
In case negative probe_offset.z it means probe deployed is lower than nozzle.
So probe clearance may become negative so probe can be broken by move
lower than its clearance.