### PR TITLE
Enable Link Time Optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,6 @@ add_subdirectory(lib)
 #
 
 add_executable(firmware)
-
 add_subdirectory(src)
 
 if(WUI)
@@ -315,6 +314,13 @@ objcopy(firmware "binary" ".bin")
 
 # generate linker map file
 target_link_options(firmware PUBLIC -Wl,-Map=firmware.map)
+
+# link time optimizations
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  if(MCU MATCHES "STM32F40")
+    set_target_properties(firmware PROPERTIES INTERPROCEDURAL_OPTIMIZATION True)
+  endif()
+endif() # "Release"
 
 # inform about the firmware's size in terminal
 report_size(firmware)

--- a/src/common/crash_dump/dump.h
+++ b/src/common/crash_dump/dump.h
@@ -73,6 +73,7 @@ static const uint32_t DUMP_INFO_SIZE = 0x00000010;
 #define DUMP_REGS_GEN_EXC_TO_CCRAM()                                                    \
     asm volatile(                                                                       \
         "    ldr r1, =0x1000ff00    \n" /* hardcoded ccram addres - todo: use macro  */ \
+        "    .ltorg                 \n" /* put the immediate constant 0x1000ff00 here*/ \
         "    ldr r2, [r0, #0x00]    \n" /* load r0 from stack frame  */                 \
         "    str r2, [r1, #0x00]    \n" /* store r0 to ccram  */                        \
         "    ldr r2, [r0, #0x04]    \n" /* r1  */                                       \


### PR DESCRIPTION
Proof of concept - code size drops by ~31KB

Placement of `set_target_properties(firmware PROPERTIES INTERPROCEDURAL_OPTIMIZATION True)` in CMakeLists.txt is a matter of further discussion.