### PR TITLE
Fix memory leak in BufferedSerial

### DIFF
--- a/src/common/uartrxbuff.c
+++ b/src/common/uartrxbuff.c
@@ -36,6 +36,10 @@ void uartrxbuff_init(uartrxbuff_t *prxbuff, UART_HandleTypeDef *phuart, DMA_Hand
     prxbuff->event_group = xEventGroupCreate();
 }
 
+void uartrxbuff_deinit(uartrxbuff_t *prxbuff) {
+    vEventGroupDelete(prxbuff->event_group);
+}
+
 void uartrxbuff_reset(uartrxbuff_t *prxbuff) {
     // Clear all the event flags
     xEventGroupClearBits(prxbuff->event_group,

--- a/src/common/uartrxbuff.h
+++ b/src/common/uartrxbuff.h
@@ -38,6 +38,8 @@ typedef struct _uartrxbuff_t {
 
 extern void uartrxbuff_init(uartrxbuff_t *prxbuff, UART_HandleTypeDef *phuart, DMA_HandleTypeDef *phdma, int size, uint8_t *pdata);
 
+extern void uartrxbuff_deinit(uartrxbuff_t *prxbuff);
+
 extern void uartrxbuff_reset(uartrxbuff_t *prxbuff);
 
 extern int uartrxbuff_getchar(uartrxbuff_t *prxbuff);

--- a/src/hw/buffered_serial.cpp
+++ b/src/hw/buffered_serial.cpp
@@ -61,6 +61,8 @@ void BufferedSerial::Close() {
     // Clear the buffer
     uartrxbuff_reset(&rxBuf);
 
+    uartrxbuff_deinit(&rxBuf);
+
     isOpen = false;
 }
 


### PR DESCRIPTION
Properly cleanup event group on BufferedSerial deinit.