### PR TITLE
Connect: Fix job_id handling

### DIFF
--- a/src/Connect/core_interface.cpp
+++ b/src/Connect/core_interface.cpp
@@ -117,7 +117,7 @@ device_params_t core_interface::get_data() {
     memset(&params, 0, sizeof params);
 
     if (marlin_vars) {
-        marlin_client_loop();
+        marlin_update_vars(MARLIN_VAR_MSK_DEF | MARLIN_VAR_MSK_WUI);
         switch (marlin_vars->print_state) {
         case mpsIdle:
         case mpsAborted:

--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -168,6 +168,7 @@ static const eeprom_entry_t eeprom_map[] = {
     { "CONNECT_TLS",     VARIANT8_BOOL,  1, 0 }, // EEVAR_CONNECT_TLS
     { "CONNECT_ENABLED", VARIANT8_BOOL,  1, 0 }, // EEVAR_CONNECT_ENABLED
     { "USB_MSC_ENABLED", VARIANT8_BOOL,  1, 0 }, // EEVAR_USB_MSC_ENABLED
+    { "JOB_ID",          VARIANT8_UI16,  1, 0 }, // EEVAR_JOB_ID
     { "CRASH_ENABLED",   VARIANT8_BOOL,  1, 0 }, // EEVAR_CRASH_ENABLED
     { "CRASH_SENS_X",    VARIANT8_I8,    1, 0 }, // EEVAR_CRASH_SENS_X,
     { "CRASH_SENS_Y",    VARIANT8_I8,    1, 0 }, // EEVAR_CRASH_SENS_Y,

--- a/src/common/marlin_vars.h
+++ b/src/common/marlin_vars.h
@@ -51,13 +51,13 @@ typedef enum {
 } marlin_var_id_t;
 
 // variable masks
-#define MARLIN_VAR_MSK(v_id)                                (((uint64_t)1) << (uint8_t)(v_id))
-#define MARLIN_VAR_MSK2(id1, id2)                           (MARLIN_VAR_MSK(id1) | MARLIN_VAR_MSK(id2))
-#define MARLIN_VAR_MSK3(id1, id2, id3)                      (MARLIN_VAR_MSK2(id1, id2) | MARLIN_VAR_MSK(id3))
-#define MARLIN_VAR_MSK4(id1, id2, id3, id4)                 (MARLIN_VAR_MSK2(id1, id2) | MARLIN_VAR_MSK2(id3, id4))
-#define MARLIN_VAR_MSK6(id1, id2, id3, id4, id5, id6)       (MARLIN_VAR_MSK3(id1, id2, id3) | MARLIN_VAR_MSK3(id4, id5, id6))
-#define MARLIN_VAR_MSK7(id1, id2, id3, id4, id5, id6, id7)  (MARLIN_VAR_MSK4(id1, id2, id3, id4) | MARLIN_VAR_MSK3(id5, id6, id7))
-#define MARLIN_VAR_MSK12(id1, id2, id3, id4, id5, id6, ...) (MARLIN_VAR_MSK6(id1, id2, id3, id4, id5, id6) | MARLIN_VAR_MSK6(__VA_ARGS__))
+#define MARLIN_VAR_MSK(v_id)                                     (((uint64_t)1) << (uint8_t)(v_id))
+#define MARLIN_VAR_MSK2(id1, id2)                                (MARLIN_VAR_MSK(id1) | MARLIN_VAR_MSK(id2))
+#define MARLIN_VAR_MSK3(id1, id2, id3)                           (MARLIN_VAR_MSK2(id1, id2) | MARLIN_VAR_MSK(id3))
+#define MARLIN_VAR_MSK4(id1, id2, id3, id4)                      (MARLIN_VAR_MSK2(id1, id2) | MARLIN_VAR_MSK2(id3, id4))
+#define MARLIN_VAR_MSK6(id1, id2, id3, id4, id5, id6)            (MARLIN_VAR_MSK3(id1, id2, id3) | MARLIN_VAR_MSK3(id4, id5, id6))
+#define MARLIN_VAR_MSK7(id1, id2, id3, id4, id5, id6, id7)       (MARLIN_VAR_MSK4(id1, id2, id3, id4) | MARLIN_VAR_MSK3(id5, id6, id7))
+#define MARLIN_VAR_MSK13(id1, id2, id3, id4, id5, id6, id7, ...) (MARLIN_VAR_MSK7(id1, id2, id3, id4, id5, id6, id7) | MARLIN_VAR_MSK6(__VA_ARGS__))
 
 //maximum number of masks is 64
 //maximum mask index is 63
@@ -84,7 +84,7 @@ static const uint64_t MARLIN_VAR_MSK_TEMP_ALL
 // variables defined in this mask are automaticaly updated every 100ms in _server_update_vars
 static const uint64_t MARLIN_VAR_MSK_DEF = MARLIN_VAR_MSK_ALL & ~MARLIN_VAR_MSK(MARLIN_VAR_PQUEUE) & ~MARLIN_VAR_MSK_IPOS_XYZE & ~MARLIN_VAR_MSK(MARLIN_VAR_WAITHEAT) & ~MARLIN_VAR_MSK(MARLIN_VAR_WAITUSER) & ~MARLIN_VAR_MSK(MARLIN_VAR_FILEPATH);
 
-static const uint64_t MARLIN_VAR_MSK_WUI = MARLIN_VAR_MSK_TEMP_CURR | MARLIN_VAR_MSK12(MARLIN_VAR_POS_X, MARLIN_VAR_POS_Y, MARLIN_VAR_POS_Z, MARLIN_VAR_POS_E, MARLIN_VAR_PRNSPEED, MARLIN_VAR_FLOWFACT, MARLIN_VAR_DURATION, MARLIN_VAR_SD_PDONE, MARLIN_VAR_SD_PRINT, MARLIN_VAR_FILENAME, MARLIN_VAR_ENDSTOPS, MARLIN_VAR_JOB_ID);
+static const uint64_t MARLIN_VAR_MSK_WUI = MARLIN_VAR_MSK_TEMP_ALL | MARLIN_VAR_MSK13(MARLIN_VAR_POS_X, MARLIN_VAR_POS_Y, MARLIN_VAR_POS_Z, MARLIN_VAR_POS_E, MARLIN_VAR_PRNSPEED, MARLIN_VAR_FLOWFACT, MARLIN_VAR_DURATION, MARLIN_VAR_SD_PDONE, MARLIN_VAR_SD_PRINT, MARLIN_VAR_FILENAME, MARLIN_VAR_FILEPATH, MARLIN_VAR_ENDSTOPS, MARLIN_VAR_JOB_ID);
 
 // usr8 in variant8_t message contains id (bit0..6) and variable/event flag (bit7)
 static const uint8_t MARLIN_USR8_VAR_FLG = 0x80; // usr8 - variable flag (bit7 set)


### PR DESCRIPTION
Fixing three observed issues:
* The job_id always starting on 51 after boot, no matter how many things
  were printed previously.
* Sometimes getting a telemetry with previous value of job_id but
  already in the printing state when starting a new print.
* The first "printing" telemetry being delayed by several seconds
  against the start of the print.

* Fix race in starting print vs. incrementing it.
* Use marlin_update_vars instead of marlin_client_loop to force getting
  fresh values.
* Fix the mask of variables.
* Fix eeprom variable definitions.

BFW-2686.