### PR TITLE
Fix broken Marlin subrepo.

### DIFF
--- a/lib/Marlin/.gitrepo
+++ b/lib/Marlin/.gitrepo
@@ -7,6 +7,6 @@
 	remote = git@github.com:prusa3d/Marlin.git
 	branch = buddy
 	commit = f00b48f9a8da77d0d603b74c843359b82ee306e3
-	parent = fecd28dd2c559ed32253c0c65841ad3eadce953c
+	parent = fd46d65e36d3ef556d6adc483994126aac5b1248
 	method = merge
 	cmdver = 0.4.1


### PR DESCRIPTION
Parent pointed to commit which was not predecessor commit in this branch.
This was broken by rebasing original commit.
Original commit fecd28dd2c559ed32253c0c65841ad3eadce953c became
fd46d65e36d3ef556d6adc483994126aac5b1248 after rebase.

Before this fix git subrepo pull lib/Marlin -M rebase -b 2.1.x
failed with error:
fatal: Not a valid object name: ''.