### PR TITLE
Don't link the whole mbedTLS to tests

### DIFF
--- a/lib/WUI/nhttp/headers.cpp
+++ b/lib/WUI/nhttp/headers.cpp
@@ -7,7 +7,7 @@
 
 #include <sys/stat.h>
 #include <inttypes.h> // PRIu* macros (not available in <cinttypes>)
-#include <sha256.h>
+#include <mbedtls/sha256.h>
 
 using http::ConnectionHandling;
 using http::ContentType;

--- a/tests/unit/lib/WUI/nhttp/CMakeLists.txt
+++ b/tests/unit/lib/WUI/nhttp/CMakeLists.txt
@@ -80,6 +80,7 @@ target_include_directories(
           ${CMAKE_SOURCE_DIR}/lib/WUI/nhttp
           ${CMAKE_SOURCE_DIR}/src/gui
           ${CMAKE_SOURCE_DIR}/src/common
+          ${CMAKE_SOURCE_DIR}/lib/Middlewares/Third_Party/mbedtls/include
           ${CMAKE_SOURCE_DIR}/lib/Middlewares/Third_Party/LwIP/src/include
           ${CMAKE_SOURCE_DIR}/lib/Middlewares/Third_Party/LwIP/system
           ${CMAKE_SOURCE_DIR}/lib/jsmn
@@ -101,7 +102,6 @@ add_custom_target(
                                        ${CMAKE_CURRENT_BINARY_DIR}/http_req_automaton.h
   )
 add_dependencies(nhttp_tests generate-http-automata-tests)
-target_link_libraries(nhttp_tests mbedTLS)
 # target_link_libraries(http_tests LwIP)
 set_target_properties(nhttp_tests PROPERTIES CXX_STANDARD 17)
 

--- a/tests/unit/lib/WUI/nhttp/missing_functions.c
+++ b/tests/unit/lib/WUI/nhttp/missing_functions.c
@@ -65,3 +65,7 @@ err_t tcpip_try_callback(tcpip_callback_fn fn, void *ctx) {
 void get_LFN(char *lfn, size_t lfn_size, char *path) {
     strlcpy(lfn, basename(path), lfn_size);
 }
+
+void mbedtls_platform_zeroize(void *b, size_t size) {
+    memset(b, 0, size);
+}


### PR DESCRIPTION
It's not used (much), and gives us trouble when compiling on Windows.