### PR TITLE
Connect: Proper fingerprint computation

### DIFF
--- a/src/Connect/connect.cpp
+++ b/src/Connect/connect.cpp
@@ -76,9 +76,9 @@ namespace {
     public:
         BasicRequest(core_interface &core, const printer_info_t &info, const configuration_t &config, const Action &action)
             : hdrs {
-                { "Fingerprint", info.fingerprint },
-                { "Token", config.token },
-                { nullptr, nullptr }
+                { "Fingerprint", info.fingerprint, FINGERPRINT_HDR_SIZE },
+                { "Token", config.token, nullopt },
+                { nullptr, nullptr, nullopt }
             }
             , renderer(RenderState {
                   info,

--- a/src/Connect/core_interface.cpp
+++ b/src/Connect/core_interface.cpp
@@ -229,13 +229,8 @@ printer_info_t core_interface::get_printer_info() {
         synthetic_serial(info.serial_number);
     }
 
-    // Prusa connect requires 16 long fingerprint. Printer code is 8 characters.
-    // Copy printer code behind itself to make it 16 characters long.
-    //FIXME! This is just a temporary solution!
-    printerCode(info.fingerprint); //Compute hash(8 bytes) from uid, serial and mac
-    assert(strlen(info.fingerprint) == 8);
-    memcpy(info.fingerprint + FINGERPRINT_SIZE / 2, info.fingerprint, FINGERPRINT_SIZE / 2);
-    info.fingerprint[FINGERPRINT_SIZE] = 0;
+    printerHash(info.fingerprint, sizeof(info.fingerprint) - 1, false);
+    info.fingerprint[sizeof(info.fingerprint) - 1] = '\0';
 
     info.appendix = appendix_exist();
     return info;

--- a/src/Connect/core_interface.hpp
+++ b/src/Connect/core_interface.hpp
@@ -11,22 +11,24 @@ using marlin variables.
 #include <otp.h>
 
 #include <variant>
+#include <cstdlib>
 
 namespace con {
 
-constexpr uint8_t FW_VER_STR_LEN = 32;
-constexpr uint8_t FW_VER_BUFR_LEN = (FW_VER_STR_LEN + 1);
+constexpr size_t FW_VER_STR_LEN = 32;
+constexpr size_t FW_VER_BUFR_LEN = FW_VER_STR_LEN + 1;
 
-constexpr uint8_t SER_NUM_STR_LEN = 19;
-constexpr uint8_t SER_NUM_BUFR_LEN = (SER_NUM_STR_LEN + 1);
+constexpr size_t SER_NUM_STR_LEN = 19;
+constexpr size_t SER_NUM_BUFR_LEN = SER_NUM_STR_LEN + 1;
 
-constexpr uint8_t FINGERPRINT_SIZE = 16;
-constexpr uint8_t FINGERPRINT_BUFF_LEN = (FINGERPRINT_SIZE + 1);
+constexpr size_t FINGERPRINT_SIZE = 50;
+constexpr size_t FINGERPRINT_BUFF_LEN = FINGERPRINT_SIZE + 1;
+constexpr size_t FINGERPRINT_HDR_SIZE = 16;
 
-constexpr uint8_t CONNECT_URL_LEN = 30;
-constexpr uint8_t CONNECT_URL_BUF_LEN = (CONNECT_URL_LEN + 1);
-constexpr uint8_t CONNECT_TOKEN_LEN = 20;
-constexpr uint8_t CONNECT_TOKEN_BUF_LEN = (CONNECT_TOKEN_LEN + 1);
+constexpr size_t CONNECT_URL_LEN = 30;
+constexpr size_t CONNECT_URL_BUF_LEN = CONNECT_URL_LEN + 1;
+constexpr size_t CONNECT_TOKEN_LEN = 20;
+constexpr size_t CONNECT_TOKEN_BUF_LEN = CONNECT_TOKEN_LEN + 1;
 
 #define X_AXIS_POS 0
 #define Y_AXIS_POS 1

--- a/src/Connect/httpc.hpp
+++ b/src/Connect/httpc.hpp
@@ -13,8 +13,9 @@ enum class Method {
 };
 
 struct HeaderOut {
-    const char *name;
-    const char *value;
+    const char *name = nullptr;
+    const char *value = nullptr;
+    const std::optional<size_t> size_limit = std::nullopt;
 };
 
 class Request {

--- a/src/common/support_utils.h
+++ b/src/common/support_utils.h
@@ -15,6 +15,13 @@ extern void error_url_long(char *str, const uint32_t str_size, const int error_c
 extern void error_url_short(char *str, const uint32_t str_size, const int error_code);
 
 extern void printerCode(char *str);
+// Similar to printerCode, but more generic.
+//
+// * Does _not_ set the terminating '\0' (if you need it, set it yourself).
+// * Allows setting the number of characters output.
+// * Allows setting if it shall be prefixed by the 2 bits of appendix and
+//   signature of firmware.
+extern void printerHash(char *str_buffer, size_t size, bool state_prefix);
 
 extern bool appendix_exist();
 extern bool signature_exist();

--- a/tests/unit/connect/http_client.cpp
+++ b/tests/unit/connect/http_client.cpp
@@ -53,9 +53,6 @@ public:
     virtual Method method() const {
         return Method::Post;
     }
-    virtual const HeaderOut *extra_headers() const override {
-        return nullptr;
-    }
     virtual std::variant<size_t, Error> write_body_chunk(char *data, size_t size) override {
         if (done) {
             return static_cast<size_t>(0);


### PR DESCRIPTION
* Generalize the printer code to be able to produce other similar
  hashes.
* Compute the long fingerprint (that doesn't contain appendix and
  signature bits).
* Send the long/short variant in INFO and header.

NOTE: We are not 100% sure this is the final version of the fingerprint
computation, we just need something to have in hand for further
discussion.

BFW-2657.