### PR TITLE
connect: Survive server consistently refusing messages

### DIFF
--- a/lib/WUI/nhttp/headers.cpp
+++ b/lib/WUI/nhttp/headers.cpp
@@ -33,6 +33,7 @@ namespace {
         { Status::Unauthorized, "Unauthorized", authenticate_hdrs },
         { Status::NotFound, "Not Found" },
         { Status::MethodNotAllowed, "Method Not Allowed" },
+        { Status::RequestTimeout, "Request Timeout" },
         { Status::Conflict, "Conflict" },
         { Status::LengthRequired, "Length Required" },
         { Status::UnsupportedMediaType, "Unsupported Media Type" },
@@ -40,10 +41,12 @@ namespace {
         { Status::PayloadTooLarge, "Payload Too Large" },
         { Status::UriTooLong, "URI Too Long" },
         { Status::UnprocessableEntity, "Unprocessable Entity" },
+        { Status::TooManyRequests, "Too Many Requests" },
         { Status::RequestHeaderFieldsTooLarge, "Request Header Fields Too Large" },
         { Status::InternalServerError, "Infernal Server Error" },
         { Status::NotImplemented, "Not Implemented" },
         { Status::ServiceTemporarilyUnavailable, "Service Temporarily Unavailable" },
+        { Status::GatewayTimeout, "Gateway Timeout" },
         { Status::InsufficientStorage, "Insufficient Storage" },
     };
 

--- a/src/common/http/types.h
+++ b/src/common/http/types.h
@@ -47,6 +47,7 @@ enum Status {
     Forbidden = 403,
     NotFound = 404,
     MethodNotAllowed = 405,
+    RequestTimeout = 408,
     Conflict = 409,
     LengthRequired = 411,
     PayloadTooLarge = 413,
@@ -54,10 +55,12 @@ enum Status {
     UnsupportedMediaType = 415,
     IMATeaPot = 418,
     UnprocessableEntity = 422,
+    TooManyRequests = 429,
     RequestHeaderFieldsTooLarge = 431,
     InternalServerError = 500,
     NotImplemented = 501,
     ServiceTemporarilyUnavailable = 503,
+    GatewayTimeout = 504,
     InsufficientStorage = 507,
 };
 


### PR DESCRIPTION
Throw away messages the server doesn't "want". Select only few statuses
that'll be retried ‒ generally, timeout-related and rate-limit ones.
These are expected to go away eventually and deliver the message.

Network failures (eg. no status from server received at all) are still
retried, this is only about server providing some unusual error status
code.

Prevents infinite loop of trying to ram a message into the server's
throat while it consistently refuses to accept it, which effectively
blocked the communication until restart.

BFW-2678.