### PR TITLE
Gcode upload: Shorten returned paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -700,7 +700,7 @@ target_sources(
           $<$<BOOL:${FILAMENT_SENSOR}>:src/common/thread_measurement.cpp>
           src/common/adc.cpp
           src/common/basename.c
-          src/common/lfn.c
+          src/common/lfn.cpp
           src/common/i2c.cpp
           src/common/hardware_serial.cpp
           src/common/eeprom.cpp

--- a/lib/WUI/nhttp/gcode_upload.cpp
+++ b/lib/WUI/nhttp/gcode_upload.cpp
@@ -266,7 +266,7 @@ UploadHooks::Result GcodeUpload::finish(const char *final_filename, bool start_p
     // Close the file first, otherwise it can't be moved
     ftruncate(fileno(tmp_upload_file.get()), ftell(tmp_upload_file.get()));
     tmp_upload_file.reset();
-    return try_rename(fname, final_filename, [&](const char *filename) -> UploadHooks::Result {
+    return try_rename(fname, final_filename, [&](char *filename) -> UploadHooks::Result {
         if (uploaded_notify != nullptr) {
             if (uploaded_notify(filename, start_print)) {
                 return make_tuple(Status::Ok, nullptr);

--- a/lib/WUI/nhttp/gcode_upload.h
+++ b/lib/WUI/nhttp/gcode_upload.h
@@ -27,7 +27,7 @@ namespace nhttp::printer {
  */
 class GcodeUpload final : private UploadHooks {
 public:
-    typedef bool UploadedNotify(const char *name, bool start_print);
+    typedef bool UploadedNotify(char *name, bool start_print);
 
 private:
     UploadState uploader;

--- a/lib/WUI/wui_api.cpp
+++ b/lib/WUI/wui_api.cpp
@@ -18,6 +18,8 @@
 #include "print_utils.hpp"
 #include "marlin_client.h"
 
+#include <basename.h>
+#include <lfn.h>
 #include <ScreenHandler.hpp>
 #include <screen_home.hpp>
 #include <screen_print_preview.hpp>
@@ -351,7 +353,7 @@ uint32_t wui_gcodes_uploaded() {
     return uploaded_gcodes;
 }
 
-bool wui_start_print(const char *filename) {
+bool wui_start_print(char *filename) {
     // Note: By checking now and starting it later, we are introducing a short
     // race condition. Doing it properly would be kind of hard and the risk is
     // we maybe start the print and don't get the print screen or something
@@ -370,14 +372,17 @@ bool wui_start_print(const char *filename) {
     const bool can_start_print = !marlin_vars()->sd_printing && allowed_screen;
 
     if (can_start_print) {
-        strlcpy(marlin_vars()->media_LFN, filename, FILE_PATH_BUFFER_LEN);
+        strlcpy(marlin_vars()->media_LFN, basename(filename), FILE_NAME_BUFFER_LEN);
+        // Turn it into the short name, to improve buffer length, avoid strange
+        // chars like spaces in it, etc.
+        get_SFN_path(filename);
         print_begin(filename);
     }
 
     return can_start_print;
 }
 
-bool wui_uploaded_gcode(const char *filename, bool start_print) {
+bool wui_uploaded_gcode(char *filename, bool start_print) {
     uploaded_gcodes++;
 
     if (start_print) {

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -183,7 +183,7 @@ void wui_store_api_key(char *, uint32_t);
 ///
 /// Returns false if can't print right now. Note that this doesn't check the
 /// existence of the file.
-bool wui_start_print(const char *filename);
+bool wui_start_print(char *filename);
 
 ////////////////////////////////////////////////////////////////////////////
 /// @brief A new gcode was uploaded, take appropriate actions
@@ -193,7 +193,7 @@ bool wui_start_print(const char *filename);
 ///
 /// @return True if everything went fine. False if start_print was enabled and
 ///   the print was not possible to start.
-bool wui_uploaded_gcode(const char *path, bool start_print);
+bool wui_uploaded_gcode(char *path, bool start_print);
 
 ////////////////////////////////////////////////////////////////////////////
 /// @brief Return the number of gcodes uploaded since boot.

--- a/src/common/lfn.cpp
+++ b/src/common/lfn.cpp
@@ -1,9 +1,13 @@
 #include "lfn.h"
 
-#include <string.h>
+#include <cassert>
+#include <cstring>
 #include <dirent.h>
 
-void get_LFN(char *lfn, size_t lfn_size, char *path) {
+namespace {
+
+template <class C>
+void search_file(char *path, C &&callback) {
     /*
      * This is a bit of a hack. It sees the only place we are able to receive
      * the LFN is by iterating through a directory. So we do so and look for
@@ -14,12 +18,14 @@ void get_LFN(char *lfn, size_t lfn_size, char *path) {
     if (!last) {
         // This is weird. We have no slash in the path, this shouldn't happen.
         // So copy it whole just to have something.
-        strlcpy(lfn, path, lfn_size);
+        callback(path, nullptr);
         return;
     }
 
     char *fname = last + 1;
-    strlcpy(lfn, fname, lfn_size);
+    // For the case where we don't find anything, have a result ready. If we
+    // do, we overwrite it later.
+    callback(fname, nullptr);
 
     *last = '\0';
     DIR *d = opendir(path);
@@ -39,9 +45,33 @@ void get_LFN(char *lfn, size_t lfn_size, char *path) {
          * names and case insensitive (it's FAT, after all).
          */
         if ((strcasecmp(ent->d_name, fname) == 0) || (strcasecmp(ent->lfn, fname) == 0)) {
-            strlcpy(lfn, ent->lfn, lfn_size);
+            callback(fname, ent);
             break;
         }
     }
     closedir(d);
+}
+
+}
+
+void get_LFN(char *lfn, size_t lfn_size, char *path) {
+    search_file(path, [&](char *fname, struct dirent *ent) {
+        if (ent != nullptr) {
+            strlcpy(lfn, ent->lfn, lfn_size);
+        } else {
+            strlcpy(lfn, fname, lfn_size);
+        }
+    });
+}
+
+void get_SFN_path(char *path) {
+    search_file(path, [&](char *fname, struct dirent *ent) {
+        if (ent != nullptr) {
+            // fname is part of the path we passed in, so we can modify it.
+            assert(strlen(fname) >= strlen(ent->d_name));
+            strcpy(fname, ent->d_name);
+        }
+        // We are not interested in the other "fallback" cases like the LFN
+        // one. We just keep path intact.
+    });
 }

--- a/src/common/lfn.h
+++ b/src/common/lfn.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #ifdef __cplusplus
 extern "C" {
 #endif //__cplusplus
-
 /**
  * \brief Get the long file name of a given file.
  *
@@ -20,6 +19,18 @@ extern "C" {
  * internally, the short file name from the path might be returned.
  */
 void get_LFN(char *lfn, size_t lfn_size, char *path);
+
+/**
+ * \brief Get a SFN path for a given path.
+ *
+ * Given a full path to a file (either LFN or SFN, doesn't matter), converts
+ * the last part to SFN, in-place. This assumes LFN is never shorter than SFN,
+ * therefore the result can't overflow the buffer.
+ *
+ * This might fail internally (eg. for files that don't exist), in such case
+ * the path is not modified.
+ */
+void get_SFN_path(char *path);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
After uploading (and starting the print), ensure that the returned paths
are the short ones.

* We want to make sure we fit all the buffers once someone sends them
  back to us.
* We want to get rid of all "weird" characters in the paths (like
  spaces), because we don't do proper percent-decoding yet.

Fix some buffer lengths on the way.