### PR TITLE
GUI: Possibility of vertical icon-button alignment

### DIFF
--- a/src/gui/dialogs/DialogRadioButton.hpp
+++ b/src/gui/dialogs/DialogRadioButton.hpp
@@ -36,7 +36,11 @@ private:
     static size_t cnt_responses(Responses_t resp);
     static size_t cnt_buttons(const PhaseTexts *labels, Responses_t resp);
     Rect16 getIconRect(uint8_t idx) const;
+    Rect16 getHorizontalIconRect(uint8_t idx) const;
+    Rect16 getVerticalIconRect(uint8_t idx) const;
     Rect16 getLabelRect(uint8_t idx) const;
+    Rect16 getHorizontalLabelRect(uint8_t idx) const;
+    Rect16 getVerticalLabelRect(uint8_t idx) const;
 
 public:
     /**

--- a/src/gui/screen_print_preview.cpp
+++ b/src/gui/screen_print_preview.cpp
@@ -25,11 +25,11 @@ static GCodeInfo &gcode_init() {
 }
 
 ScreenPrintPreview::ScreenPrintPreview()
-    : title_text(this, Rect16(PADDING, PADDING, SCREEN_WIDTH - 2 * PADDING, TITLE_HEIGHT))
+    : title_text(this, Rect16(PADDING, PADDING, display::GetW() - 2 * PADDING, TITLE_HEIGHT))
+    , radio(this, GuiDefaults::GetIconnedButtonRect(GetRect()), ClientResponses::GetResponses(PhasesPrintPreview::main_dialog))
     , gcode(gcode_init())
     , gcode_description(this, gcode)
     , thumbnail(this, GuiDefaults::PreviewThumbnailRect)
-    , radio(this, GuiDefaults::GetIconnedButtonRect(GetRect()), ClientResponses::GetResponses(PhasesPrintPreview::main_dialog))
     , phase(PhasesPrintPreview::_first) {
 
     super::ClrMenuTimeoutClose();

--- a/src/gui/screen_print_preview.hpp
+++ b/src/gui/screen_print_preview.hpp
@@ -21,12 +21,11 @@ class ScreenPrintPreview : public AddSuperWindow<screen_t> {
     static ScreenPrintPreview *ths; // to be accessible in dialog handler
 
     window_roll_text_t title_text;
+    RadioButton radio; // shows 2 mutually exclusive buttons Print and Back
 
     GCodeInfo &gcode;
     GCodeInfoWithDescription gcode_description; // cannot be first
     WindowPreviewThumbnail thumbnail;           // draws preview png
-
-    RadioButton radio; // shows 2 mutually exclusive buttons Print and Back
 
     PhasesPrintPreview phase;
 

--- a/src/guiapi/include/GuiDefaults.hpp
+++ b/src/guiapi/include/GuiDefaults.hpp
@@ -116,4 +116,4 @@ struct GuiDefaults {
     static constexpr Rect16 MsgBoxLayoutRect = { 0, 0, 0, 0 }; // TODO: Connect with dialogs
     static constexpr Rect16 DialogFrameRect = RectScreenBody;
     static constexpr uint16_t RadioButtonCornerRadius = 0;
-};
+    static constexpr uint8_t IconButtonSize = 64;

--- a/src/guiapi/include/GuiDefaults.hpp
+++ b/src/guiapi/include/GuiDefaults.hpp
@@ -117,3 +117,4 @@ struct GuiDefaults {
     static constexpr Rect16 DialogFrameRect = RectScreenBody;
     static constexpr uint16_t RadioButtonCornerRadius = 0;
     static constexpr uint8_t IconButtonSize = 64;
+};


### PR DESCRIPTION
Radiobutton determines which alignment is used (horizontal x vertical) based on which side of rectangle is longer.

There is a possibility of up to 3 buttons in both vertical and horizontal layout, but it does not check if there is enough space.
This is a good thing imo, because you will see right away, where is the problem when you use smaller rectangle than is needed for selected button option (They will try to draw over themselves).

Different options have different layouts:

1 icon button (when rects height is bigger than width): Icon with it's label are centered (both axis)
2 icon buttons: first icon starts on the upper edge and second icon's label ends at bottom edge
3 icon buttons: combination of both above