### PR TITLE
Sound mode [Assist] at filebrowsing

### DIFF
--- a/src/gui/window_file_list.cpp
+++ b/src/gui/window_file_list.cpp
@@ -169,9 +169,10 @@ void window_file_list_t::inc(int dif) {
 
     if (!middle) {
         Sound_Play(eSOUND_TYPE::BlindAlert);
-    } else if (repaint) {
+    } else {
         Sound_Play(eSOUND_TYPE::EncoderMove);
     }
+
     if (!repaint) {
         if (index != old_index) {
             invalidateItem(index);


### PR DESCRIPTION
BFW-2735
Adjust sound playing during file browsing to play correctly in Assist mode.