### PR TITLE
Ask for filament when nozzle is preheated and not inserted

### DIFF
--- a/src/marlin_stubs/pause/M70X_preheat.cpp
+++ b/src/marlin_stubs/pause/M70X_preheat.cpp
@@ -37,7 +37,7 @@ static Response evaluate_preheat_conditions(PreheatData preheat_data) {
     bool canKnowTemp = preheat_data.Mode() == PreheatMode::Unload || preheat_data.Mode() == PreheatMode::Change_phase1 || preheat_data.Mode() == PreheatMode::Purge || preheat_data.Mode() == PreheatMode::Unload_askUnloaded;
 
     // Check if we are using operation which can get temp from printer and check if it can get the temp from available info (inserted filament or set temperature in temperature menu and no filament inserted)
-    if (canKnowTemp && ((Filaments::CurrentIndex() != filament_t::NONE) || (Filaments::CurrentIndex() == filament_t::NONE && !thermalManager.targetTooColdToExtrude(0)))) {
+    if (canKnowTemp && ((Filaments::CurrentIndex() != filament_t::NONE))) {
         // We can get temperature without user telling us
         response = preheatTempKnown();
     } else {


### PR DESCRIPTION
This eliminates the posibility of returning `filament::NONE` from
`evaluate_preheat_condition` when we have preheated after filament unload.
This caused unintentional cooldown and need for second press of unload
or change buttons