### PR TITLE
Bump to cpp20 and disable volatile warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,10 @@ set(unused "${CMAKE_VERBOSE_MAKEFILE} ${CMAKE_RULE_MESSAGES}")
 
 # enable all warnings (well, not all, but some)
 add_compile_options(-Wall -Wsign-compare)
-add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-register> $<$<COMPILE_LANGUAGE:CXX>:-std=c++1z>)
+add_compile_options(
+  $<$<COMPILE_LANGUAGE:CXX>:-Wno-register> $<$<COMPILE_LANGUAGE:CXX>:-std=c++20>
+  $<$<COMPILE_LANGUAGE:CXX>:-Wno-volatile>
+  )
 
 # append custom C/C++ flags
 if(CUSTOM_COMPILE_OPTIONS)


### PR DESCRIPTION
Bumps c++17 to c++20. Also disables volatile warning, because c++20 deprecated compound operations on volatile variables. 

However, this warning will be removable with c++23 which will (hopefully) de-deprecate compound operations on volatile variables. (from the paper [p2327r0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2327r0.pdf): "The argument against compound operations on volatile variables is that it leads the programmer to believe that the operation itself becomes compounded and therefore atomic")

Tested on Mini to ensure nothing broke.