### PR TITLE
Expand and optimize OutputPin for performance

### DIFF
--- a/src/common/Pin.hpp
+++ b/src/common/Pin.hpp
@@ -110,7 +110,7 @@ protected:
         : m_halPortBase(IoPortToHalBase(ioPort))
         , m_halPin(IoPinToHal(ioPin)) {}
 
-    GPIO_TypeDef *getHalPort() const {
+    __attribute__((always_inline)) inline GPIO_TypeDef *getHalPort() const {
         return reinterpret_cast<GPIO_TypeDef *>(m_halPortBase);
     }
 
@@ -275,6 +275,15 @@ public:
             getHalPort()->BSRR = static_cast<uint32_t>(m_halPin) << 16U;
         }
     }
+
+    __attribute__((always_inline)) inline void set() const {
+        getHalPort()->BSRR = m_halPin;
+    }
+
+    __attribute__((always_inline)) inline void reset() const {
+        getHalPort()->BSRR = static_cast<uint32_t>(m_halPin) << 16U;
+    }
+
     void configure() const;
 
 public:


### PR DESCRIPTION
Making the function `getHalPort()` always inline allows it to be optimized when called from a function with `#pragma GCC optimize()`. Functions `set` and `reset` are added to skip the branch in `OutputPin::write(PinState)`. 

These changes are needed for time sensitive protocols that require writing to be faster than with debug mode.