### PR TITLE
Do not call fsensor validation while on splash screen.

### DIFF
--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -285,8 +285,6 @@ void gui_run(void) {
     un.pGUIStartupProgress = &progr;
     Screens::Access()->WindowEvent(GUI_event_t::GUI_STARTUP, un.pvoid);
 
-    gui::fsensor::validate_for_cyclical_calls();
-
     redraw_cmd_t redraw;
     // TODO make some kind of registration
     while (1) {


### PR DESCRIPTION
Splash screen does not behave normally.
For example it validates all windows at each draw, than invalidates just selected ones.