### PR TITLE
log: Unify cpp logging with c logging

### DIFF
--- a/doc/logging.md
+++ b/doc/logging.md
@@ -29,6 +29,14 @@ When recorded, those events can be presented to the user in several ways. They c
 - Such a definition must be in a `.c` or `.cpp` file (not in a header) and appear only once in the project.
 
 
+### Referencing an existing component
+    ```Swift
+    LOG_COMPONENT_REF(MyComponent);
+    ```
+- References an existing component with the name `MyComponent`. This component must have been previously defined in another file with `LOG_COMPONENT_DEF(MyComponent, SEVERITY);`
+- This is required for logging in `.cpp` files because of a difference in logging in `c` and `cpp` files.
+
+
 ### Registration of a custom log destination
     ```C
     static void log_event_custom(log_destination_t *destination, log_event_t *event) {

--- a/src/buddy/filesystem_littlefs_bbf.cpp
+++ b/src/buddy/filesystem_littlefs_bbf.cpp
@@ -5,6 +5,8 @@
 #include "littlefs_bbf.h"
 #include "bbf.hpp"
 
+LOG_COMPONENT_REF(FileSystem);
+
 static filesystem_littlefs_ctx_t bbf_ctx;
 
 static int open_r(struct _reent *r, void *fileStruct, const char *path, int flags, int mode) {

--- a/src/buddy/littlefs_bbf.cpp
+++ b/src/buddy/littlefs_bbf.cpp
@@ -2,6 +2,8 @@
 #include "bbf.hpp"
 #include "log.h"
 
+LOG_COMPONENT_REF(FileSystem);
+
 static lfs_t lfs;
 
 typedef struct {

--- a/src/buddy/main.cpp
+++ b/src/buddy/main.cpp
@@ -38,6 +38,8 @@
     #include "wui.h"
 #endif
 
+LOG_COMPONENT_REF(Buddy);
+
 osThreadId defaultTaskHandle;
 osThreadId displayTaskHandle;
 osThreadId connectTaskHandle;

--- a/src/common/media.cpp
+++ b/src/common/media.cpp
@@ -19,6 +19,9 @@
 #include "metric.h"
 #include <errno.h>
 
+LOG_COMPONENT_REF(USBHost);
+LOG_COMPONENT_REF(MarlinServer);
+
 #ifdef REENUMERATE_USB
 
 extern USBH_HandleTypeDef hUsbHostHS; // UsbHost handle

--- a/src/common/selftest/selftest_esp_update.cpp
+++ b/src/common/selftest/selftest_esp_update.cpp
@@ -31,6 +31,8 @@ extern "C" {
 #include "cmsis_os.h"
 }
 
+LOG_COMPONENT_REF(Network);
+
 #define BOOT_ADDRESS            0x00000ul
 #define APPLICATION_ADDRESS     0x10000ul
 #define PARTITION_TABLE_ADDRESS 0x08000ul

--- a/src/common/selftest/selftest_fan.cpp
+++ b/src/common/selftest/selftest_fan.cpp
@@ -14,6 +14,7 @@
 #define FANTEST_MEASURE_DELAY 7500
 
 using namespace selftest;
+LOG_COMPONENT_REF(Selftest);
 
 CSelftestPart_Fan::CSelftestPart_Fan(IPartHandler &state_machine, const FanConfig_t &config,
     SelftestFan_t &result)
@@ -38,7 +39,7 @@ uint32_t CSelftestPart_Fan::estimate(const FanConfig_t &config) {
 }
 
 LoopResult CSelftestPart_Fan::stateStart() {
-    LogInfo("%s Started", m_config.partname);
+    log_info(Selftest, "%s Started", m_config.partname);
     rResult.state = SelftestSubtestState_t::running;
     SelftestInstance().log_printf("%s Started\n", m_config.partname);
     m_StartTime = SelftestInstance().GetTime();
@@ -57,7 +58,7 @@ LoopResult CSelftestPart_Fan::stateWaitStopped() {
     }
     m_config.fanctl.SelftestSetPWM(m_config.pwm_start);
     m_Step = 0;
-    LogInfo("%s wait stopped, rpm: %d pwm: %d", m_config.partname, m_config.fanctl.getActualRPM(), m_config.fanctl.getPWM());
+    log_info(Selftest, "%s wait stopped, rpm: %d pwm: %d", m_config.partname, m_config.fanctl.getActualRPM(), m_config.fanctl.getPWM());
     return LoopResult::RunNext;
 }
 
@@ -68,7 +69,7 @@ LoopResult CSelftestPart_Fan::stateWaitRpm() {
     }
     m_SampleCount = 0;
     m_SampleSum = 0;
-    LogInfo("%s rpm: %d pwm: %d", m_config.partname, m_config.fanctl.getActualRPM(), m_config.fanctl.getPWM());
+    log_info(Selftest, "%s rpm: %d pwm: %d", m_config.partname, m_config.fanctl.getActualRPM(), m_config.fanctl.getPWM());
     return LoopResult::RunNext;
 }
 
@@ -84,7 +85,7 @@ LoopResult CSelftestPart_Fan::stateMeasureRpm() {
     if ((m_config.rpm_min_table != nullptr) && (m_config.rpm_max_table != nullptr))
         if ((rpm < m_config.rpm_min_table[m_Step]) || (rpm > m_config.rpm_max_table[m_Step])) {
             SelftestInstance().log_printf("%s %u RPM out of range (%u - %u)\n", m_config.partname, rpm, m_config.rpm_min_table[m_Step], m_config.rpm_max_table[m_Step]);
-            LogError("%s measure rpm, rpm: %d pwm: %d", m_config.partname, m_config.fanctl.getActualRPM(), m_config.fanctl.getPWM());
+            log_error(Selftest, "%s measure rpm, rpm: %d pwm: %d", m_config.partname, m_config.fanctl.getActualRPM(), m_config.fanctl.getPWM());
             return LoopResult::Fail;
         }
     if (++m_Step < m_config.steps) {
@@ -92,7 +93,7 @@ LoopResult CSelftestPart_Fan::stateMeasureRpm() {
         return LoopResult::GoToMark;
     }
     //finish
-    LogInfo("%s Finished\n", m_config.partname);
+    log_info(Selftest, "%s Finished\n", m_config.partname);
     return LoopResult::RunNext;
 }
 

--- a/src/common/selftest/selftest_firstlayer.cpp
+++ b/src/common/selftest/selftest_firstlayer.cpp
@@ -18,6 +18,7 @@
 #include <array>
 
 using namespace selftest;
+LOG_COMPONENT_REF(Selftest);
 
 CSelftestPart_FirstLayer::CSelftestPart_FirstLayer(IPartHandler &state_machine, const FirstLayerConfig_t &config,
     SelftestFirstLayer_t &result)
@@ -31,7 +32,7 @@ CSelftestPart_FirstLayer::CSelftestPart_FirstLayer(IPartHandler &state_machine, 
 }
 
 LoopResult CSelftestPart_FirstLayer::stateStart() {
-    LogInfo("%s Started", rConfig.partname);
+    log_info(Selftest, "%s Started", rConfig.partname);
     SelftestInstance().log_printf("%s Started\n", rConfig.partname);
 
     return LoopResult::RunNext;
@@ -78,7 +79,7 @@ LoopResult CSelftestPart_FirstLayer::stateAskFilamentInit() {
         rResult.preselect_response = Response::Load;
         break;
     }
-    LogInfo("%s user asked about filament");
+    log_info(Selftest, "%s user asked about filament");
     return LoopResult::RunNext;
 }
 
@@ -87,15 +88,15 @@ LoopResult CSelftestPart_FirstLayer::stateAskFilament() {
     switch (response) {
     case Response::Next:
         state_selected_by_user = filament_known_but_detected_as_not_inserted ? StateSelectedByUser::Preheat : StateSelectedByUser::Calib;
-        LogInfo("%s user pressed Next", rConfig.partname);
+        log_info(Selftest, "%s user pressed Next", rConfig.partname);
         return LoopResult::RunNext;
     case Response::Load:
         state_selected_by_user = StateSelectedByUser::Load;
-        LogInfo("%s user pressed Load", rConfig.partname);
+        log_info(Selftest, "%s user pressed Load", rConfig.partname);
         return LoopResult::RunNext;
     case Response::Unload:
         state_selected_by_user = StateSelectedByUser::Unload;
-        LogInfo("%s user pressed Unload", rConfig.partname);
+        log_info(Selftest, "%s user pressed Unload", rConfig.partname);
         return LoopResult::RunNext;
 
     default:
@@ -112,7 +113,7 @@ LoopResult CSelftestPart_FirstLayer::statePreheatEnqueueGcode() {
     }
 
     queue.enqueue_one_now("M1700 W0 S"); // preheat, no return no cooldown, set filament
-    LogInfo("%s preheat enqueued", rConfig.partname);
+    log_info(Selftest, "%s preheat enqueued", rConfig.partname);
     return LoopResult::RunNext;
 }
 
@@ -140,7 +141,7 @@ LoopResult CSelftestPart_FirstLayer::stateFilamentLoadEnqueueGcode() {
     }
 
     queue.enqueue_one_now("M701 W0"); // load, no return no cooldown
-    LogInfo("%s load enqueued", rConfig.partname);
+    log_info(Selftest, "%s load enqueued", rConfig.partname);
     return LoopResult::RunNext;
 }
 
@@ -173,7 +174,7 @@ LoopResult CSelftestPart_FirstLayer::stateFilamentUnloadEnqueueGcode() {
     }
 
     queue.enqueue_one_now("M702 W0"); // unload, no return no cooldown
-    LogInfo("%s unload enqueued", rConfig.partname);
+    log_info(Selftest, "%s unload enqueued", rConfig.partname);
     return LoopResult::RunNext;
 }
 
@@ -338,7 +339,7 @@ LoopResult CSelftestPart_FirstLayer::stateCleanSheet() {
 LoopResult CSelftestPart_FirstLayer::stateFinish() {
 
     //finish
-    LogInfo("%s Finished\n", rConfig.partname);
+    log_info(Selftest, "%s Finished\n", rConfig.partname);
     return LoopResult::RunNext;
 }
 

--- a/src/common/selftest/selftest_log.hpp
+++ b/src/common/selftest/selftest_log.hpp
@@ -31,29 +31,23 @@ public:
     void ForceNextLog() { last_log = std::nullopt; }
 };
 
-#define LogInfo(...)     _log_event(LOG_SEVERITY_INFO, log_component_find("Selftest"), __VA_ARGS__);
-#define LogDebug(...)    _log_event(LOG_SEVERITY_DEBUG, log_component_find("Selftest"), __VA_ARGS__);
-#define LogWarning(...)  _log_event(LOG_SEVERITY_WARNING, log_component_find("Selftest"), __VA_ARGS__);
-#define LogError(...)    _log_event(LOG_SEVERITY_ERROR, log_component_find("Selftest"), __VA_ARGS__);
-#define LogCritical(...) _log_event(LOG_SEVERITY_CRITICAL, log_component_find("Selftest"), __VA_ARGS__);
-
 /**
  * @brief Info log which will be skipped if delay requirements are not met
  * first parameter must be LogTimer object
  */
-#define LogInfoTimed(LOG, ...)                                                          \
-    {                                                                                   \
-        if (LOG.CanLog())                                                               \
-            _log_event(LOG_SEVERITY_INFO, log_component_find("Selftest"), __VA_ARGS__); \
+#define LogInfoTimed(LOG, ...)               \
+    {                                        \
+        if (LOG.CanLog())                    \
+            log_info(Selftest, __VA_ARGS__); \
     }
 
 /**
  * @brief Debug log which will be skipped if delay requirements are not met
  * first parameter must be LogTimer object
  */
-#define LogDebugTimed(LOG, ...)                                                          \
-    {                                                                                    \
-        if (LOG.CanLog())                                                                \
-            _log_event(LOG_SEVERITY_DEBUG, log_component_find("Selftest"), __VA_ARGS__); \
+#define LogDebugTimed(LOG, ...)               \
+    {                                         \
+        if (LOG.CanLog())                     \
+            log_debug(Selftest, __VA_ARGS__); \
     }
 }

--- a/src/common/selftest/selftest_netstatus_interface.cpp
+++ b/src/common/selftest/selftest_netstatus_interface.cpp
@@ -7,6 +7,8 @@
 #include "selftest_eeprom.hpp"
 #include "selftest_log.hpp"
 
+LOG_COMPONENT_REF(Selftest);
+
 static TestResultNet_t convert(netdev_status_t status) {
     switch (status) {
     case NETDEV_UNLINKED:
@@ -46,8 +48,8 @@ void phaseNetStatus() {
     eeres.wifi = uint8_t(convert(wifi));
     eeprom_set_var(EEVAR_SELFTEST_RESULT, variant8_ui32(eeres.ui32));
 
-    LogInfo("Eth %s", to_string(eth));
-    LogInfo("Wifi %s", to_string(wifi));
+    log_info(Selftest, "Eth %s", to_string(eth));
+    log_info(Selftest, "Wifi %s", to_string(wifi));
 }
 
 } // namespace selftest

--- a/src/common/selftest/selftest_part.cpp
+++ b/src/common/selftest/selftest_part.cpp
@@ -9,6 +9,7 @@
 #include "selftest_log.hpp"
 
 using namespace selftest;
+LOG_COMPONENT_REF(Selftest);
 
 PhasesSelftest IPartHandler::fsm_phase_index = PhasesSelftest::_none;
 
@@ -106,14 +107,14 @@ void IPartHandler::next() {
 }
 
 void IPartHandler::Pass() {
-    LogDebug("IPartHandler::Pass");
+    log_debug(Selftest, "IPartHandler::Pass");
     current_state = IndexFinished();
     current_state_enter_time = SelftestInstance().GetTime();
     pass();
 }
 
 void IPartHandler::Fail() {
-    LogDebug("IPartHandler::Fail");
+    log_debug(Selftest, "IPartHandler::Fail");
     if (current_state != IndexFailed()) {
         current_state = IndexFailed();
         current_state_enter_time = SelftestInstance().GetTime();
@@ -122,7 +123,7 @@ void IPartHandler::Fail() {
 }
 
 void IPartHandler::Abort() {
-    LogDebug("IPartHandler::Abort");
+    log_debug(Selftest, "IPartHandler::Abort");
     current_state = IndexAborted();
     abort();
 }

--- a/src/common/selftest_result_type.hpp
+++ b/src/common/selftest_result_type.hpp
@@ -10,6 +10,8 @@
 #include "fsm_base_types.hpp"
 #include "selftest_log.hpp"
 
+LOG_COMPONENT_REF(Selftest);
+
 struct SelftestResult_t {
     TestResult_t printFan;
     TestResult_t heatBreakFan;
@@ -69,15 +71,15 @@ struct SelftestResult_t {
     }
 
     void Log() const {
-        LogInfo("Print fan result is %s", ToString(printFan));
-        LogInfo("Heatbreak fan result is %s", ToString(heatBreakFan));
-        LogInfo("X axis result is %s", ToString(xaxis));
-        LogInfo("Y axis result is %s", ToString(yaxis));
-        LogInfo("Z axis result is %s", ToString(zaxis));
-        LogInfo("Nozzle heater result is %s", ToString(nozzle));
-        LogInfo("Bed heater result is %s", ToString(bed));
-        LogInfo("Ethernet result is %s", ToString(eth));
-        LogInfo("Wifi result is %s", ToString(wifi));
+        log_info(Selftest, "Print fan result is %s", ToString(printFan));
+        log_info(Selftest, "Heatbreak fan result is %s", ToString(heatBreakFan));
+        log_info(Selftest, "X axis result is %s", ToString(xaxis));
+        log_info(Selftest, "Y axis result is %s", ToString(yaxis));
+        log_info(Selftest, "Z axis result is %s", ToString(zaxis));
+        log_info(Selftest, "Nozzle heater result is %s", ToString(nozzle));
+        log_info(Selftest, "Bed heater result is %s", ToString(bed));
+        log_info(Selftest, "Ethernet result is %s", ToString(eth));
+        log_info(Selftest, "Wifi result is %s", ToString(wifi));
     }
 
     constexpr void Deserialize(fsm::PhaseData new_data) {

--- a/src/common/sys.cpp
+++ b/src/common/sys.cpp
@@ -8,6 +8,8 @@
 #include "log.h"
 #include "disable_interrupts.h"
 
+LOG_COMPONENT_REF(Buddy);
+
 #define DFU_REQUEST_RTC_BKP_REGISTER RTC->BKP0R
 
 // magic value of RTC->BKP0R for requesting DFU bootloader entry

--- a/src/common/w25x_communication.cpp
+++ b/src/common/w25x_communication.cpp
@@ -6,6 +6,8 @@
 #include "cmsis_os.h"
 #include "stm32f4xx_hal.h"
 
+LOG_COMPONENT_REF(W25X);
+
 /// The SPI used by this module
 static SPI_HandleTypeDef *spi_handle;
 

--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -52,6 +52,8 @@ int guimain_spi_test = 0;
 #include "gui_media_events.hpp"
 #include "main.h"
 #include "bsod.h"
+
+LOG_COMPONENT_REF(Buddy);
 extern void blockISR(); // do not want to include marlin temperature
 
 #ifdef USE_ST7789
@@ -156,7 +158,7 @@ static void finish_update() {
                     bsod("unreachable");
                 }
 
-                _log_event(LOG_SEVERITY_INFO, log_component_find("Buddy"), "Bootloader update progress %s (%i %%)", stage_description, percent_done);
+                log_info(Buddy, "Bootloader update progress %s (%i %%)", stage_description, percent_done);
                 screen_splash_data_t::bootstrap_cb(percent_done, stage_description);
                 gui_redraw();
             });
@@ -180,8 +182,7 @@ static void finish_update() {
                 default:
                     bsod("unreachable");
                 }
-
-                _log_event(LOG_SEVERITY_INFO, log_component_find("Buddy"), "Bootstrap progress %s (%i %%)", stage_description, percent_done);
+                log_info(Buddy, "Bootstrap progress %s (%i %%)", stage_description, percent_done);
                 screen_splash_data_t::bootstrap_cb(percent_done, stage_description);
                 gui_redraw();
             });

--- a/src/gui/screen_filebrowser.cpp
+++ b/src/gui/screen_filebrowser.cpp
@@ -17,6 +17,8 @@
 #include "../Marlin/src/gcode/lcd/M73_PE.h"
 #include "GuiDefaults.hpp"
 
+LOG_COMPONENT_REF(GUI);
+
 #ifndef MAXPATHNAMELENGTH
     #define MAXPATHNAMELENGTH F_MAXPATHNAMELENGTH
 #endif

--- a/src/gui/screen_menu_steel_sheets.cpp
+++ b/src/gui/screen_menu_steel_sheets.cpp
@@ -10,6 +10,8 @@
 #include "WindowItemFormatableLabel.hpp"
 #include "GuiDefaults.hpp"
 
+LOG_COMPONENT_REF(GUI);
+
 #if _DEBUG // todo remove #if _DEBUG after rename is finished
     #include "screen_sheet_rename.hpp"
 #endif

--- a/src/gui/screen_sheet_rename.cpp
+++ b/src/gui/screen_sheet_rename.cpp
@@ -3,6 +3,8 @@
 #include "log.h"
 #include "SteelSheets.hpp"
 
+LOG_COMPONENT_REF(GUI);
+
 static void onclick_ok();
 static void onclick_cancel();
 

--- a/src/gui/test_display.cpp
+++ b/src/gui/test_display.cpp
@@ -10,6 +10,8 @@
 #include "display_helper.h"
 #include "log.h"
 
+LOG_COMPONENT_REF(Buddy);
+
 typedef void(test_display_t)(uint16_t cnt);
 
 void test_display_random_dots(uint16_t cnt);

--- a/src/guiapi/src/window_event.cpp
+++ b/src/guiapi/src/window_event.cpp
@@ -4,6 +4,8 @@
 #include "log.h"
 #include "gui_time.hpp"
 
+LOG_COMPONENT_REF(GUI);
+
 EventLock::EventLock(const char *event_method_name, window_t *sender, GUI_event_t event) {
     //
     // Log Events

--- a/src/guiapi/src/window_icon.cpp
+++ b/src/guiapi/src/window_icon.cpp
@@ -11,6 +11,8 @@
 #include "gui_invalidate.hpp"
 #include "syslog.h"
 
+LOG_COMPONENT_REF(GUI);
+
 void window_icon_t::SetIdRes(ResourceId id) {
     if (dataSource.id_res != id) {
         dataSource.set(id);

--- a/src/logging/log.h
+++ b/src/logging/log.h
@@ -145,11 +145,28 @@ void log_destination_unregister(log_destination_t *destination);
 ///
 ///    log_event(severity_variable, MyComponent, "Something has happened");
 ///
-#define log_event(severity, component, fmt, ...)                                \
-    do {                                                                        \
-        extern log_component_t LOG_COMPONENT(component);                        \
-        _log_event(severity, &__log_component_##component, fmt, ##__VA_ARGS__); \
-    } while (0)
+#ifdef __cplusplus
+    #define log_event(severity, component, fmt, ...)                                \
+        do {                                                                        \
+            _log_event(severity, &__log_component_##component, fmt, ##__VA_ARGS__); \
+        } while (0)
+
+    /// \def LOG_COMPONENT_REF(component)
+    /// References an existing component
+    ///
+    /// To be used when logging to a component defined in another file.
+    ///
+    /// Usage (top of the file):
+    ///    LOG_COMPONENT_REF(MyComponent);
+    ///
+    #define LOG_COMPONENT_REF(component) extern log_component_t LOG_COMPONENT(component)
+#else
+    #define log_event(severity, component, fmt, ...)                                \
+        do {                                                                        \
+            extern log_component_t LOG_COMPONENT(component);                        \
+            _log_event(severity, &__log_component_##component, fmt, ##__VA_ARGS__); \
+        } while (0)
+#endif
 
 /// \def log_debug(component, fmt, ...)
 /// Record a log event with `debug` severity.

--- a/src/resources/fileutils.hpp
+++ b/src/resources/fileutils.hpp
@@ -6,8 +6,6 @@
 #include "filesystem_littlefs_bbf.h"
 #include "bbf.hpp"
 
-#define log(severity, ...) _log_event(severity, log_component_find("Resources"), __VA_ARGS__)
-
 class DIRDeleter {
 public:
     void operator()(DIR *dir) {

--- a/src/resources/hash.cpp
+++ b/src/resources/hash.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 
 using namespace buddy::resources;
+LOG_COMPONENT_REF(Resources);
 
 class HashContext {
 private:
@@ -53,7 +54,7 @@ static bool update_hash_with_file(const char *root, Path &path, HashContext &has
     // filedata
     std::unique_ptr<FILE, FILEDeleter> source(fopen(path.get(), "rb"));
     if (source.get() == nullptr) {
-        log(LOG_SEVERITY_ERROR, "Failed to open file %s", source.get());
+        log_error(Resources, "Failed to open file %s", source.get());
         return false;
     }
     uint8_t buffer[128];
@@ -150,13 +151,13 @@ bool buddy::resources::calculate_directory_hash(Hash &hash, const char *root) {
     const Path root_dir(root);
     Path current_path(root);
 
-    log(LOG_SEVERITY_INFO, "Starting to calculate hash of %s", root);
+    log_info(Resources, "Starting to calculate hash of %s", root);
 
     bool success = update_hash_with_directory(root_dir.get(), current_path, sha_ctx);
 
     if (success) {
         sha_ctx.finish(hash);
-        log(LOG_SEVERITY_INFO, "Hash calculation finished (result %02X%02X%02X%02X%02X%02X...)", hash[0], hash[1], hash[2], hash[3], hash[4], hash[5]);
+        log_info(Resources, "Hash calculation finished (result %02X%02X%02X%02X%02X%02X...)", hash[0], hash[1], hash[2], hash[3], hash[4], hash[5]);
     }
 
     return success;


### PR DESCRIPTION
Logging in c++ always suffered from having to `log_component_find("component")`. This PR adjusts logging so that instead of `log_component_find` logging in c++ has the 'normal' interface (`log_info(component, "text")`, ...), with the addition that the component needs to be referenced at the top of the file with `LOG_COMPONENT_REF(Component)`