### PR TITLE
fix: cmake 20 property, Marlin _OX macros, LWIP socket write

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,12 @@ endif()
 # eclipse sets those variables, so lets just use them so we don't get a warning about unused
 # variables
 set(unused "${CMAKE_VERBOSE_MAKEFILE} ${CMAKE_RULE_MESSAGES}")
+set(CMAKE_CXX_STANDARD 20)
 
 # enable all warnings (well, not all, but some)
 add_compile_options(-Wall -Wsign-compare)
 add_compile_options(
-  $<$<COMPILE_LANGUAGE:CXX>:-Wno-register> $<$<COMPILE_LANGUAGE:CXX>:-std=c++20>
-  $<$<COMPILE_LANGUAGE:CXX>:-Wno-volatile>
+  $<$<COMPILE_LANGUAGE:CXX>:-Wno-register> $<$<COMPILE_LANGUAGE:CXX>:-Wno-volatile>
   )
 
 # append custom C/C++ flags
@@ -306,8 +306,6 @@ add_subdirectory(lib)
 add_executable(firmware)
 
 add_subdirectory(src)
-
-set_target_properties(firmware PROPERTIES CXX_STANDARD 17)
 
 if(WUI)
   target_compile_definitions(firmware PRIVATE BUDDY_ENABLE_WUI)

--- a/include/buddy/lwipopts.h
+++ b/include/buddy/lwipopts.h
@@ -69,7 +69,7 @@ extern "C" {
 #define LWIP_SINGLE_NETIF            0
 #define LWIP_NETIF_HOSTNAME          1
 #define LWIP_HTTPD_SUPPORT_POST      0
-#define LWIP_COMPAT_SOCKETS          1
+#define LWIP_COMPAT_SOCKETS          2
 #define LWIP_ALTCP                   0
 #define LWIP_HTTPD_DYNAMIC_FILE_READ 0
 #define LWIP_TIMERS                  1

--- a/lib/Marlin/Marlin/src/core/macros.h
+++ b/lib/Marlin/Marlin/src/core/macros.h
@@ -39,11 +39,11 @@
 #define _FORCE_INLINE_ __attribute__((__always_inline__)) __inline__
 #define  FORCE_INLINE  __attribute__((always_inline)) inline
 #define _UNUSED      __attribute__((unused))
-#define _O0          __attribute__((optimize("O0")))
-#define _Os          __attribute__((optimize("Os")))
-#define _O1          __attribute__((optimize("O1")))
-#define _O2          __attribute__((optimize("O2")))
-#define _O3          __attribute__((optimize("O3")))
+#define __O0         __attribute__((optimize("O0")))
+#define __Os         __attribute__((optimize("Os")))
+#define __O1         __attribute__((optimize("O1")))
+#define __O2         __attribute__((optimize("O2")))
+#define __O3         __attribute__((optimize("O3")))
 
 #ifndef UNUSED
   #if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)

--- a/lib/Marlin/Marlin/src/core/types.h
+++ b/lib/Marlin/Marlin/src/core/types.h
@@ -263,15 +263,9 @@ struct XYval {
   FI XYval<T>& operator*=(const int &v)                 { x *= v;    y *= v;    return *this; }
   FI XYval<T>& operator>>=(const int &v)                { _RS(x);    _RS(y);    return *this; }
   FI XYval<T>& operator<<=(const int &v)                { _LS(x);    _LS(y);    return *this; }
-  FI bool      operator==(const XYval<T>   &rs)         { return x == rs.x && y == rs.y; }
-  FI bool      operator==(const XYZval<T>  &rs)         { return x == rs.x && y == rs.y; }
-  FI bool      operator==(const XYZEval<T> &rs)         { return x == rs.x && y == rs.y; }
   FI bool      operator==(const XYval<T>   &rs)   const { return x == rs.x && y == rs.y; }
   FI bool      operator==(const XYZval<T>  &rs)   const { return x == rs.x && y == rs.y; }
   FI bool      operator==(const XYZEval<T> &rs)   const { return x == rs.x && y == rs.y; }
-  FI bool      operator!=(const XYval<T>   &rs)         { return !operator==(rs); }
-  FI bool      operator!=(const XYZval<T>  &rs)         { return !operator==(rs); }
-  FI bool      operator!=(const XYZEval<T> &rs)         { return !operator==(rs); }
   FI bool      operator!=(const XYval<T>   &rs)   const { return !operator==(rs); }
   FI bool      operator!=(const XYZval<T>  &rs)   const { return !operator==(rs); }
   FI bool      operator!=(const XYZEval<T> &rs)   const { return !operator==(rs); }
@@ -471,8 +465,6 @@ struct XYZEval {
   FI XYZEval<T>& operator*=(const T &v)                       { x *= v;    y *= v;    z *= v;    e *= v;    return *this; }
   FI XYZEval<T>& operator>>=(const int &v)                    { _RS(x);    _RS(y);    _RS(z);    _RS(e);    return *this; }
   FI XYZEval<T>& operator<<=(const int &v)                    { _LS(x);    _LS(y);    _LS(z);    _LS(e);    return *this; }
-  FI bool        operator==(const XYZval<T>  &rs)             { return x == rs.x && y == rs.y && z == rs.z; }
-  FI bool        operator!=(const XYZval<T>  &rs)             { return !operator==(rs); }
   FI bool        operator==(const XYZval<T>  &rs)       const { return x == rs.x && y == rs.y && z == rs.z; }
   FI bool        operator!=(const XYZval<T>  &rs)       const { return !operator==(rs); }
   FI       XYZEval<T> operator-()                             { return { -x, -y, -z, -e }; }

--- a/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -63,13 +63,13 @@ class unified_bed_leveling {
       static void move_z_with_encoder(const float &multiplier);
       static float measure_point_with_encoder();
       static float measure_business_card_thickness(float in_height);
-      static void manually_probe_remaining_mesh(const xy_pos_t&, const float&, const float&, const bool) _O0;
-      static void fine_tune_mesh(const xy_pos_t &pos, const bool do_ubl_mesh_map) _O0;
+      static void manually_probe_remaining_mesh(const xy_pos_t&, const float&, const float&, const bool) __O0;
+      static void fine_tune_mesh(const xy_pos_t &pos, const bool do_ubl_mesh_map) __O0;
     #endif
 
-    static bool g29_parameter_parsing() _O0;
+    static bool g29_parameter_parsing() __O0;
     static void shift_mesh_height();
-    static void probe_entire_mesh(const xy_pos_t &near, const bool do_ubl_mesh_map, const bool stow_probe, const bool do_furthest) _O0;
+    static void probe_entire_mesh(const xy_pos_t &near, const bool do_ubl_mesh_map, const bool stow_probe, const bool do_furthest) __O0;
     static void tilt_mesh_based_on_3pts(const float &z1, const float &z2, const float &z3);
     static void tilt_mesh_based_on_probed_grid(const bool do_ubl_mesh_map);
     static bool smart_fill_one(const uint8_t x, const uint8_t y, const int8_t xdir, const int8_t ydir);
@@ -91,17 +91,17 @@ class unified_bed_leveling {
     static void report_state();
     static void save_ubl_active_state_and_disable();
     static void restore_ubl_active_state_and_leave();
-    static void display_map(const int) _O0;
-    static mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const xy_pos_t&, const bool=false, MeshFlags *done_flags=nullptr) _O0;
-    static mesh_index_pair find_furthest_invalid_mesh_point() _O0;
+    static void display_map(const int) __O0;
+    static mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const xy_pos_t&, const bool=false, MeshFlags *done_flags=nullptr) __O0;
+    static mesh_index_pair find_furthest_invalid_mesh_point() __O0;
     static void reset();
     static void invalidate();
     static void set_all_mesh_points_to_value(const float value);
     static void adjust_mesh_to_mean(const bool cflag, const float value);
     static bool sanity_check();
 
-    static void G29() _O0;                          // O0 for no optimization
-    static void smart_fill_wlsf(const float &) _O2; // O2 gives smaller code than Os on A2560
+    static void G29() __O0;                          // O0 for no optimization
+    static void smart_fill_wlsf(const float &) __O2; // O2 gives smaller code than Os on A2560
 
     static int8_t storage_slot;
 

--- a/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
+++ b/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
@@ -332,7 +332,7 @@
    * Returns true if did NOT move, false if moved (requires current_position update).
    */
 
-  bool _O2 unified_bed_leveling::line_to_destination_segmented(const feedRate_t &scaled_fr_mm_s) {
+  bool __O2 unified_bed_leveling::line_to_destination_segmented(const feedRate_t &scaled_fr_mm_s) {
 
     if (!position_is_reachable(destination))  // fail if moving outside reachable boundary
       return true;                            // did not move, so current_position still accurate

--- a/lib/Marlin/Marlin/src/libs/bresenham.h
+++ b/lib/Marlin/Marlin/src/libs/bresenham.h
@@ -30,7 +30,7 @@
  */
 
 #define FORCE_INLINE  __attribute__((always_inline)) inline
-#define _O3           __attribute__((optimize("O3")))
+#define __O3          __attribute__((optimize("O3")))
 
 template <uint8_t uid, uint8_t size>
 struct BresenhamCfg { static constexpr uint8_t UID = uid, SIZE = size; };
@@ -114,9 +114,9 @@ public:
     if (tick1(index)) { value[index] += dir[index]; back(index); }
   }
 
-  FORCE_INLINE static void tick1() _O3 { for (uint8_t i = 0; i < Cfg::SIZE; i++) (void)tick1(i); }
+  FORCE_INLINE static void tick1() __O3 { for (uint8_t i = 0; i < Cfg::SIZE; i++) (void)tick1(i); }
 
-  FORCE_INLINE static void tick() _O3 { for (uint8_t i = 0; i < Cfg::SIZE; i++) (void)tick(i); }
+  FORCE_INLINE static void tick() __O3 { for (uint8_t i = 0; i < Cfg::SIZE; i++) (void)tick(i); }
 
   static void report(const uint8_t index) {
     if (index < Cfg::SIZE) {

--- a/lib/Marlin/Marlin/src/libs/nozzle.h
+++ b/lib/Marlin/Marlin/src/libs/nozzle.h
@@ -41,7 +41,7 @@ class Nozzle {
      * @param end xyz_pos_t defining the ending point
      * @param strokes number of strokes to execute
      */
-    static void stroke(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t &strokes) _Os;
+    static void stroke(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t &strokes) __Os;
 
     /**
      * @brief Zig-zag clean pattern
@@ -52,7 +52,7 @@ class Nozzle {
      * @param strokes number of strokes to execute
      * @param objects number of objects to create
      */
-    static void zigzag(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t &strokes, const uint8_t &objects) _Os;
+    static void zigzag(const xyz_pos_t &start, const xyz_pos_t &end, const uint8_t &strokes, const uint8_t &objects) __Os;
 
     /**
      * @brief Circular clean pattern
@@ -62,7 +62,7 @@ class Nozzle {
      * @param strokes number of strokes to execute
      * @param radius radius of circle
      */
-    static void circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t &strokes, const float &radius) _Os;
+    static void circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t &strokes, const float &radius) __Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 
@@ -77,13 +77,13 @@ class Nozzle {
      * @param pattern one of the available patterns
      * @param argument depends on the cleaning pattern
      */
-    static void clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const uint8_t cleans) _Os;
+    static void clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const uint8_t cleans) __Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 
   #if ENABLED(NOZZLE_PARK_FEATURE)
 
-    static void park(const uint8_t z_action, const xyz_pos_t &park=NOZZLE_PARK_POINT) _Os;
+    static void park(const uint8_t z_action, const xyz_pos_t &park=NOZZLE_PARK_POINT) __Os;
 
   #endif
 };

--- a/lib/Marlin/Marlin/src/module/endstops.cpp
+++ b/lib/Marlin/Marlin/src/module/endstops.cpp
@@ -396,7 +396,7 @@ static void print_es_state(const bool is_hit, PGM_P const label=nullptr) {
   SERIAL_EOL();
 }
 
-void _O2 Endstops::M119() {
+void __O2 Endstops::M119() {
   #if ENABLED(BLTOUCH)
     bltouch._set_SW_mode();
   #endif

--- a/lib/Marlin/Marlin/src/module/temperature.h
+++ b/lib/Marlin/Marlin/src/module/temperature.h
@@ -542,7 +542,7 @@ class Temperature {
     /**
      * Call periodically to manage heaters
      */
-    static void manage_heater() _O2; // Added _O2 to work around a compiler error
+    static void manage_heater() __O2; // __O2 added to work around a compiler error
 
     // Return true if the temperatures have been sampled at least once
     static bool temperatures_ready();

--- a/src/buddy/main.cpp
+++ b/src/buddy/main.cpp
@@ -263,7 +263,7 @@ void StartDisplayTask(void const *argument) {
 
 #ifdef BUDDY_ENABLE_CONNECT
 void StartConnectTask(void const *argument) {
-    connect::run();
+    connect_client::run();
 }
 #endif
 

--- a/src/connect/buffer.hpp
+++ b/src/connect/buffer.hpp
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <memory>
 
-namespace connect {
+namespace connect_client {
 
 template <size_t S>
 class Buffer {

--- a/src/connect/command.cpp
+++ b/src/connect/command.cpp
@@ -20,7 +20,7 @@ extern "C" {
 size_t strlcpy(char *, const char *, size_t);
 }
 
-namespace connect {
+namespace connect_client {
 
 namespace {
 

--- a/src/connect/command.hpp
+++ b/src/connect/command.hpp
@@ -6,7 +6,7 @@
 #include <string_view>
 #include <variant>
 
-namespace connect {
+namespace connect_client {
 
 using CommandId = uint32_t;
 

--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -36,7 +36,7 @@ using std::visit;
 
 LOG_COMPONENT_DEF(connect, LOG_SEVERITY_DEBUG);
 
-namespace connect {
+namespace connect_client {
 
 namespace {
 

--- a/src/connect/connect.hpp
+++ b/src/connect/connect.hpp
@@ -5,7 +5,7 @@
 #include "planner.hpp"
 #include "printer.hpp"
 
-namespace connect {
+namespace connect_client {
 
 enum class OnlineStatus {
     Unknown,

--- a/src/connect/connect_error.h
+++ b/src/connect/connect_error.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace connect {
+namespace connect_client {
 
 enum class Error {
     Timeout,

--- a/src/connect/connection.hpp
+++ b/src/connect/connection.hpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include "connect_error.h"
 
-namespace connect {
+namespace connect_client {
 
 constexpr uint8_t SOCKET_TIMEOUT_SEC = 3;
 

--- a/src/connect/httpc.cpp
+++ b/src/connect/httpc.cpp
@@ -11,7 +11,7 @@
 #include <http/chunked.h>
 
 using automata::ExecutionControl;
-using connect::parser::ResponseParser;
+using connect_client::parser::ResponseParser;
 using http::ConnectionHandling;
 using http::ContentType;
 using std::get;
@@ -23,7 +23,7 @@ using std::optional;
 using std::string_view;
 using std::variant;
 
-namespace connect {
+namespace connect_client {
 
 namespace {
     const char *to_str(Method method) {

--- a/src/connect/httpc.hpp
+++ b/src/connect/httpc.hpp
@@ -6,7 +6,7 @@
 #include <variant>
 #include <http/types.h>
 
-namespace connect {
+namespace connect_client {
 
 enum class Method {
     Post

--- a/src/connect/marlin_printer.cpp
+++ b/src/connect/marlin_printer.cpp
@@ -17,7 +17,7 @@
 
 using std::nullopt;
 
-namespace connect {
+namespace connect_client {
 
 namespace {
 

--- a/src/connect/marlin_printer.hpp
+++ b/src/connect/marlin_printer.hpp
@@ -5,7 +5,7 @@
 
 #include <marlin_client.h>
 
-namespace connect {
+namespace connect_client {
 
 class MarlinPrinter final : public Printer {
 private:

--- a/src/connect/planner.cpp
+++ b/src/connect/planner.cpp
@@ -11,7 +11,7 @@ using std::nullopt;
 using std::optional;
 using std::visit;
 
-namespace connect {
+namespace connect_client {
 
 namespace {
 

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -8,7 +8,7 @@
 #include <optional>
 #include <variant>
 
-namespace connect {
+namespace connect_client {
 
 // Just make the code a bit more readable by making this distinction.
 // Unfortunately, not checked at compile time.

--- a/src/connect/printer.cpp
+++ b/src/connect/printer.cpp
@@ -7,7 +7,7 @@
 using std::make_tuple;
 using std::tuple;
 
-namespace connect {
+namespace connect_client {
 
 uint32_t Printer::Config::crc() const {
     uint32_t crc = 0;

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -5,7 +5,7 @@
 #include <tuple>
 #include <optional>
 
-namespace connect {
+namespace connect_client {
 
 class Printer {
 public:

--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -14,7 +14,7 @@ using std::visit;
 #define JSON_MAC(NAME, VAL) JSON_FIELD_STR_FORMAT(NAME, "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX", VAL[0], VAL[1], VAL[2], VAL[3], VAL[4], VAL[5])
 #define JSON_IP(NAME, VAL)  JSON_FIELD_STR_FORMAT(NAME, "%hhu.%hhu.%hhu.%hhu", VAL[0], VAL[1], VAL[2], VAL[3])
 
-namespace connect {
+namespace connect_client {
 
 namespace {
 

--- a/src/connect/render.hpp
+++ b/src/connect/render.hpp
@@ -7,7 +7,7 @@
 
 #include <sys/stat.h>
 
-namespace connect {
+namespace connect_client {
 
 struct RenderState {
     const Printer &printer;

--- a/src/connect/resp_parser.cpp
+++ b/src/connect/resp_parser.cpp
@@ -16,7 +16,7 @@ const automata::Automaton http_response(con::parser::response::paths, con::parse
 
 }
 
-namespace connect::parser {
+namespace connect_client::parser {
 
 ResponseParser::ResponseParser()
     : Execution(&http_response)

--- a/src/connect/resp_parser.h
+++ b/src/connect/resp_parser.h
@@ -3,7 +3,7 @@
 #include <automata/core.h>
 #include <http/types.h>
 
-namespace connect::parser {
+namespace connect_client::parser {
 
 class ResponseParser final : public automata::Execution {
 private:

--- a/src/connect/run.cpp
+++ b/src/connect/run.cpp
@@ -2,7 +2,7 @@
 #include "marlin_printer.hpp"
 #include "connect.hpp"
 
-namespace connect {
+namespace connect_client {
 
 void run() {
     SharedBuffer buffer;

--- a/src/connect/run.hpp
+++ b/src/connect/run.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace connect {
+namespace connect_client {
 
 /// The "main" loop for connect.
 ///

--- a/src/connect/socket.cpp
+++ b/src/connect/socket.cpp
@@ -38,7 +38,7 @@ public:
 
 }
 
-namespace connect {
+namespace connect_client {
 
 socket_con::socket_con() {
     fd = -1;

--- a/src/connect/socket.hpp
+++ b/src/connect/socket.hpp
@@ -3,7 +3,7 @@
 #include "connection.hpp"
 #include "connect_error.h"
 
-namespace connect {
+namespace connect_client {
 
 class socket_con final : public Connection {
 

--- a/src/connect/tls/tls.cpp
+++ b/src/connect/tls/tls.cpp
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <stdbool.h>
 
-namespace connect {
+namespace connect_client {
 
 tls::tls() {
     mbedtls_net_init(&net_context);

--- a/src/connect/tls/tls.hpp
+++ b/src/connect/tls/tls.hpp
@@ -11,7 +11,7 @@
 #include "mbedtls/certs.h"
 #include "mbedtls/platform.h"
 
-namespace connect {
+namespace connect_client {
 
 class tls final : public Connection {
 

--- a/src/gui/screen_menu_connect.cpp
+++ b/src/gui/screen_menu_connect.cpp
@@ -6,7 +6,7 @@
 #include "printers.h"
 #include <connect/connect.hpp>
 
-using connect::OnlineStatus;
+using connect_client::OnlineStatus;
 
 class MI_CONNECT_ENABLED : public WI_ICON_SWITCH_OFF_ON_t {
     constexpr static const char *label = N_("Enabled");
@@ -46,7 +46,7 @@ public:
     }
     virtual void windowEvent(EventLock /*has private ctor*/, window_t *sender, GUI_event_t event, void *param) override {
         if (event == GUI_event_t::CHILD_CLICK || event == GUI_event_t::LOOP) {
-            switch (connect::last_status()) {
+            switch (connect_client::last_status()) {
                 S(Off, "Off");
                 S(NoConfig, "No Config");
                 S(NoDNS, "DNS");

--- a/src/gui/screen_menu_settings.cpp
+++ b/src/gui/screen_menu_settings.cpp
@@ -31,7 +31,7 @@ public:
 
         // FIXME: Error handling
 #ifdef BUDDY_ENABLE_CONNECT
-        connect::MarlinPrinter::load_cfg_from_ini();
+        connect_client::MarlinPrinter::load_cfg_from_ini();
 #endif
     }
 };

--- a/tests/unit/connect/command.cpp
+++ b/tests/unit/connect/command.cpp
@@ -3,7 +3,7 @@
 #include <cstring>
 #include <catch2/catch.hpp>
 
-using namespace connect;
+using namespace connect_client;
 using std::get;
 using std::holds_alternative;
 using std::string_view;

--- a/tests/unit/connect/http_client.cpp
+++ b/tests/unit/connect/http_client.cpp
@@ -16,7 +16,7 @@ using std::optional;
 using std::string;
 using std::string_view;
 using std::variant;
-using namespace connect;
+using namespace connect_client;
 
 namespace {
 

--- a/tests/unit/connect/mock_printer.h
+++ b/tests/unit/connect/mock_printer.h
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <optional>
 
-namespace connect {
+namespace connect_client {
 
 constexpr Printer::Params params_idle() {
     Printer::Params params {};

--- a/tests/unit/connect/planner.cpp
+++ b/tests/unit/connect/planner.cpp
@@ -5,7 +5,7 @@
 
 #include <catch2/catch.hpp>
 
-using namespace connect;
+using namespace connect_client;
 using std::get;
 using std::get_if;
 using std::holds_alternative;

--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -10,7 +10,7 @@
 using std::nullopt;
 using std::optional;
 using std::string_view;
-using namespace connect;
+using namespace connect_client;
 using namespace json;
 
 namespace {


### PR DESCRIPTION
There is a mistake in a previous PR https://github.com/prusa3d/Prusa-Firmware-Buddy/pull/2403  bumping cpp to 20. There is a property in `CMakeLists.txt` that was forgotten and needed to be set. This PR fixes that.

Fixing the property created compiler errors which can be categorized into these two categories:

1. @mkbel Error related to Marlin's `macro.h` due to `#define _O2 ...` macro, which created collisions with `ranges_algo.h` (std lib, included from `algorithms`). The fix of this error is in accordance to a commit fixing this in Marlin's repository https://github.com/MarlinFirmware/Marlin/commit/659b4172aa49d82e54a08b5ed674b3ba4ad51fb0
2. @vorner Error related to LWIP's `socket.h` due to `#define write...` macro, which created collisions with `ostream.tcc` (std lib, included from `memory`). This error is 'fixed' by commenting the problem macro out, and changing corresponding calls from `write` to `lwip_write`