### PR TITLE
Add basic bed leveling screen to Calibration menu

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(
           screen_sysinf.cpp
           screen_temperror.cpp
           screen_watchdog.cpp
+          screen_bed_leveling.cpp
           ScreenFactory.cpp
           ScreenHandler.cpp
           ScreenPrintingModel.cpp

--- a/src/gui/MItem_tools.cpp
+++ b/src/gui/MItem_tools.cpp
@@ -1,4 +1,5 @@
 #include "MItem_tools.hpp"
+#include "screen_bed_leveling.hpp"
 #include "dump.h"
 #include "eeprom.h"
 #include "eeprom_loadsave.h"
@@ -112,28 +113,7 @@ MI_MESH_BED::MI_MESH_BED()
 }
 
 void MI_MESH_BED::click(IWindowMenu & /*window_menu*/) {
-    Response response = Response::No;
-    do {
-        //home if we repeat MBL, nozzle may be in different position than expected
-        if (!marlin_all_axes_homed() || response == Response::Yes) {
-            marlin_event_clr(MARLIN_EVT_CommandBegin);
-            marlin_gcode("G28");
-            while (!marlin_event_clr(MARLIN_EVT_CommandBegin))
-                marlin_client_loop();
-            gui_dlg_wait(gui_marlin_G28_or_G29_in_progress);
-        }
-        response = Response::No;
-        marlin_event_clr(MARLIN_EVT_CommandBegin);
-        marlin_gcode("G29");
-        while (!marlin_event_clr(MARLIN_EVT_CommandBegin))
-            marlin_client_loop();
-        gui_dlg_wait(gui_marlin_G28_or_G29_in_progress);
-
-        if (marlin_error(MARLIN_ERR_ProbingFailed)) {
-            marlin_error_clr(MARLIN_ERR_ProbingFailed);
-            response = MsgBox(_("Bed leveling failed. Try again?"), Responses_YesNo);
-        }
-    } while (response != Response::No);
+    Screens::Access()->Open(ScreenFactory::Screen<ScreenBedLeveling>);
 }
 
 /*****************************************************************************/

--- a/src/gui/screen_bed_leveling.cpp
+++ b/src/gui/screen_bed_leveling.cpp
@@ -1,0 +1,85 @@
+#include "screen_bed_leveling.hpp"
+#include "log.h"
+#include "ScreenHandler.hpp"
+#include "gui.hpp"
+
+ScreenBedLeveling::ScreenBedLeveling()
+    : AddSuperWindow<screen_t>()
+    , m_statusMsg(this, { 10, 128, 220, 80 }, is_multiline::no)
+    , m_progressBar(this, Rect16(10, 70, GuiDefaults::RectScreen.Width() - 2 * 10, 16))
+    , header(this)
+    , footer(this) {
+    header.SetIcon(IDR_PNG_heatbed_16px);
+    header.SetText(_("BED LEVELING"));
+    Screens::Access()->DisableMenuTimeout();
+    const uint8_t *recastPointer = reinterpret_cast<const uint8_t *>((const char *)this->m_statusBuffer);
+    this->m_statusMsg.SetText(string_view_utf8::MakeRAM(recastPointer));
+}
+
+void ScreenBedLeveling::windowEvent(EventLock /*has private ctor*/, window_t *sender, GUI_event_t event, void *param) {
+    if (event == GUI_event_t::LOOP) {
+        switch (this->state) {
+        case state_t::idle: // Start homing
+            // Start by clearing events and homing
+            marlin_error_clr(MARLIN_ERR_ProbingFailed);
+            marlin_event_clr(MARLIN_EVT_CommandBegin);
+            marlin_event_clr(MARLIN_EVT_CommandEnd);
+            marlin_gcode("G28");
+            this->m_statusMsg.SetText(_("Homing..."));
+            while (!marlin_event_clr(MARLIN_EVT_CommandBegin))
+                marlin_client_loop();
+            this->state = state_t::homing;
+            break;
+
+        case state_t::homing:
+            // If homing is finished, start mesh bed leveling
+            if (marlin_event_clr(MARLIN_EVT_CommandEnd)) {
+                marlin_gcode("G29");
+                while (!marlin_event_clr(MARLIN_EVT_CommandBegin))
+                    marlin_client_loop();
+                this->state = state_t::leveling;
+                this->updateStatusMsg();
+            }
+            break;
+
+        case state_t::leveling: {
+            this->updateStatusMsg();
+
+            // If leveling is finished, jump the an end state
+            if (marlin_event_clr(MARLIN_EVT_CommandEnd)) {
+                if (marlin_error(MARLIN_ERR_ProbingFailed) || m_currentLevelingPointNum != m_levelingPointCount) {
+                    this->state = state_t::error;
+                } else {
+                    this->state = state_t::done;
+                }
+            }
+            break;
+        }
+        case state_t::done:
+            Screens::Access()->Close();
+            break;
+        case state_t::error:
+            marlin_error_clr(MARLIN_ERR_ProbingFailed);
+            m_statusMsg.SetText(_("Bed leveling failed"));
+            if (!m_errorSleepCycles--)
+                Screens::Access()->Close();
+            break;
+        default:
+            Screens::Access()->Close();
+            break;
+        }
+    }
+
+    SuperWindowEvent(sender, event, param);
+}
+
+void ScreenBedLeveling::updateStatusMsg() {
+    // Update status message
+    bool gotNewMessage = MsgCircleBuffer().ConsumeLast(this->m_statusBuffer);
+    if (gotNewMessage) {
+        this->m_progressBar.SetProgressPercent((++m_currentLevelingPointNum / (float)m_levelingPointCount) * 100.0f);
+        const uint8_t *recastPointer = reinterpret_cast<const uint8_t *>((const char *)this->m_statusBuffer);
+        this->m_statusMsg.SetText(string_view_utf8::MakeRAM(recastPointer));
+        this->m_statusMsg.Invalidate();
+    }
+}

--- a/src/gui/screen_bed_leveling.hpp
+++ b/src/gui/screen_bed_leveling.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "gui.hpp"
+#include "status_footer.hpp"
+#include "window_text.hpp"
+#include "window_icon.hpp"
+#include "window_term.hpp"
+#include "window_progress.hpp"
+#include "screen.hpp"
+#include "ScreenHandler.hpp"
+
+class ScreenBedLeveling : public AddSuperWindow<screen_t> {
+    enum class state_t {
+        idle = 0,
+        homing,
+        leveling,
+        done,
+        error
+    };
+
+    state_t state { state_t::idle };
+    Message<MSG_MAX_LENGTH> m_statusBuffer;
+    window_text_t m_statusMsg;
+    window_numberless_progress_t m_progressBar;
+    window_header_t header;
+    StatusFooter footer;
+    int m_currentLevelingPointNum { 0 };
+    static constexpr uint8_t m_levelingPointCount { 16 };
+    uint8_t m_errorSleepCycles { 50 };
+    void updateStatusMsg();
+
+public:
+    ScreenBedLeveling();
+    virtual void windowEvent(EventLock /*has private ctor*/, window_t *sender, GUI_event_t event, void *param) override;
+};


### PR DESCRIPTION
 - Use screen_t as ancestor and get the last marlin message localy from the screen
 - Block MenuTimeout when Mesh Bed Leveling is in progress
 - Add progressBar

BFW-2586