### PR TITLE
Fix template syntax error

### DIFF
--- a/lib/Marlin/Marlin/src/libs/circularqueue.h
+++ b/lib/Marlin/Marlin/src/libs/circularqueue.h
@@ -51,7 +51,7 @@ class CircularQueue {
      *          of item this queue will handle and N defines the maximum number of
      *          items that can be stored on the queue.
      */
-    CircularQueue<T, N>() {
+    CircularQueue() {
       buffer.size = N;
       buffer.count = buffer.head = buffer.tail = 0;
     }


### PR DESCRIPTION
No idea why it is accepted in some circumstances, but local test
compilation fails on it.