### PR TITLE
Provide the time function

### DIFF
--- a/include/mbedtls/cipher_config_ece.h
+++ b/include/mbedtls/cipher_config_ece.h
@@ -2,16 +2,14 @@
 
 /* System support */
 #define MBEDTLS_HAVE_ASM
-// FIXME: BFW-2767 Time verification always fails
-// #define MBEDTLS_HAVE_TIME
+#define MBEDTLS_HAVE_TIME
 
 /* mbed TLS feature support */
 #define MBEDTLS_PKCS1_V15
 #define MBEDTLS_SSL_PROTO_TLS1_2
 
 // Needed for certificate expiration checks.
-// FIXME: BFW-2767 Time verification always fails
-// #define MBEDTLS_HAVE_TIME_DATE
+#define MBEDTLS_HAVE_TIME_DATE
 // Don't disable important security checks.
 #define MBEDTLS_X509_CHECK_KEY_USAGE
 #define MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE

--- a/lib/WUI/wui_api.cpp
+++ b/lib/WUI/wui_api.cpp
@@ -36,7 +36,7 @@
 
 extern RTC_HandleTypeDef hrtc;
 
-static bool sntp_time_init = false;
+bool sntp_time_init = false;
 static char wui_media_LFN[FILE_NAME_BUFFER_LEN]; // static buffer for gcode file name
 static char wui_media_SFN_path[FILE_PATH_BUFFER_LEN];
 static std::atomic<uint32_t> uploaded_gcodes;
@@ -301,30 +301,6 @@ void get_MAC_address(mac_address_t *dest, uint32_t netdev_id) {
             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
     } else {
         **dest = '\0';
-    }
-}
-
-time_t sntp_get_system_time(void) {
-
-    if (sntp_time_init) {
-        RTC_TimeTypeDef currTime;
-        RTC_DateTypeDef currDate;
-        HAL_RTC_GetTime(&hrtc, &currTime, RTC_FORMAT_BIN);
-        HAL_RTC_GetDate(&hrtc, &currDate, RTC_FORMAT_BIN);
-        time_t secs;
-        struct tm system_time;
-        system_time.tm_isdst = -1; // Is DST on? 1 = yes, 0 = no, -1 = unknown
-        system_time.tm_hour = currTime.Hours;
-        system_time.tm_min = currTime.Minutes;
-        system_time.tm_sec = currTime.Seconds;
-        system_time.tm_mday = currDate.Date;
-        system_time.tm_mon = currDate.Month;
-        system_time.tm_year = currDate.Year;
-        system_time.tm_wday = currDate.WeekDay;
-        secs = mktime(&system_time);
-        return secs;
-    } else {
-        return 0;
     }
 }
 

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -123,15 +123,6 @@ uint32_t load_ini_file_wifi(ETH_config_t *config, ap_entry_t *ap);
 ******************************************************************************/
 void get_MAC_address(mac_address_t *dest, uint32_t netdev_id);
 
-/*!*********************************************************************************************************************
-* \brief Parses time from device's time storage to seconds. MONTHS are from 0 and YEARS are from 1900
-*
-* \retval number of seconds since epoch start (1.0.1900), if time is initialized by sntp
-*
-* \retval 0 if RTC time have not been initialized
-***********************************************************************************************************************/
-time_t sntp_get_system_time(void);
-
 /*!**********************************************************************************************************
 * \brief Sets time and date in device's RTC on some other time storage
 *

--- a/src/buddy/fatfs.c
+++ b/src/buddy/fatfs.c
@@ -1,5 +1,6 @@
 #include "fatfs.h"
-#include <wui_api.h>
+
+#include <time.h>
 
 uint8_t retUSBH;  /* Return value for USBH */
 char USBHPath[4]; /* USBH logical drive path */
@@ -16,7 +17,7 @@ void MX_FATFS_Init(void) {
  * @retval Time in DWORD
  */
 DWORD get_fattime(void) {
-    time_t timestamp = sntp_get_system_time();
+    time_t timestamp = time(NULL);
     struct tm time;
     localtime_r(&timestamp, &time);
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -69,6 +69,7 @@ if(BOARD MATCHES ".*BUDDY")
             support_utils_lib.cpp
             support_utils.cpp
             sys.cpp
+            sys_time.c
             timing.c
             trinamic.cpp
             uartrxbuff.c

--- a/src/common/sys_time.c
+++ b/src/common/sys_time.c
@@ -1,0 +1,37 @@
+#include <stm32f4xx_hal.h>
+#include <wui_api.h>
+
+#include <time.h>
+
+extern RTC_HandleTypeDef hrtc;
+// In wui_api.cpp
+extern bool sntp_time_init;
+
+time_t time(time_t *timer) {
+    if (sntp_time_init) {
+        RTC_TimeTypeDef currTime;
+        RTC_DateTypeDef currDate;
+        HAL_RTC_GetTime(&hrtc, &currTime, RTC_FORMAT_BIN);
+        HAL_RTC_GetDate(&hrtc, &currDate, RTC_FORMAT_BIN);
+        time_t secs;
+        struct tm system_time;
+        system_time.tm_isdst = -1; // Is DST on? 1 = yes, 0 = no, -1 = unknown
+        system_time.tm_hour = currTime.Hours;
+        system_time.tm_min = currTime.Minutes;
+        system_time.tm_sec = currTime.Seconds;
+        system_time.tm_mday = currDate.Date;
+        system_time.tm_mon = currDate.Month;
+        system_time.tm_year = currDate.Year;
+        system_time.tm_wday = currDate.WeekDay;
+        secs = mktime(&system_time);
+        if (timer != NULL) {
+            *timer = secs;
+        }
+        return secs;
+    } else {
+        if (timer != NULL) {
+            *timer = -1;
+        }
+        return -1;
+    }
+}

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -5,7 +5,6 @@
 #include "ScreenHandler.hpp"
 #include "screen_menus.hpp"
 #include <ctime>
-#include "wui_api.h"
 #include "../lang/format_print_will_end.hpp"
 #include "window_dlg_popup.hpp"
 #include "odometer.hpp"
@@ -254,7 +253,7 @@ void screen_printing_data_t::windowEvent(EventLock /*has private ctor*/, window_
 }
 
 void screen_printing_data_t::change_etime() {
-    time_t sec = sntp_get_system_time();
+    time_t sec = time(nullptr);
     if (sec != 0) {
         // store string_view_utf8 for later use - should be safe, we get some static string from flash, no need to copy it into RAM
         // theoretically it can be removed completely in case the string is constant for the whole run of the screen

--- a/src/gui/screen_sysinf.cpp
+++ b/src/gui/screen_sysinf.cpp
@@ -13,6 +13,7 @@
 #include "../hw/cpu_utils.hpp"
 #include "i18n.h"
 #include "marlin_client.h"
+#include <ctime>
 
 /******************************************************************************************************/
 //variables
@@ -57,7 +58,7 @@ screen_sysinfo_data_t::screen_sysinfo_data_t()
     textCPU_load_val.SetValue(osGetCPUUsage());
 
 #ifdef DEBUG_NTP
-    time_t sec = sntp_get_system_time();
+    time_t sec = time(nullptr);
     struct tm now;
     localtime_r(&sec, &now);
     static char buff[40];


### PR DESCRIPTION
Instead of using our own custom function to get time based on NTP,
provide it as the standard time function.

Besides being a bit cleaner as the solution, this makes mbedTLS work
without too much gymnastics and makes certificate expiration work.

Enabling the expiration checks.

BFW-2767.