### PR TITLE
Support endpoints for PUT

### DIFF
--- a/lib/WUI/link_content/basic_gets.h
+++ b/lib/WUI/link_content/basic_gets.h
@@ -27,5 +27,6 @@ namespace nhttp::link_content {
 json::JsonResult get_version(size_t resume_point, json::JsonOutput &output);
 json::JsonResult get_printer(size_t resume_point, json::JsonOutput &output);
 json::JsonResult get_job(size_t resume_point, json::JsonOutput &output);
+json::JsonResult get_storage(size_t resume_point, json::JsonOutput &output);
 
 }


### PR DESCRIPTION
Support endpoints needed for uploading gcodes by PUT request, specifically adding /api/v1/storage endpoint and enriching /api/version endpoint with upload-by-put boolean.