### PR TITLE
Connect: Controlling the job

### DIFF
--- a/src/connect/command.cpp
+++ b/src/connect/command.cpp
@@ -63,14 +63,17 @@ Command Command::parse_json_command(CommandId id, const string_view &body, Share
     // Error from jsmn_parse will lead to -1 -> converted to 0, refused by json::search as Broken.
     const bool success = json::search(body.data(), tokens, std::max(parse_result, 0), [&](const Event &event) {
         if (event.depth == 1 && event.type == Type::String && event.key == "command") {
-            if (event.value == "SEND_INFO") {
-                data = SendInfo {};
-            } else if (event.value == "SEND_JOB_INFO") {
-                // We'll set the job ID later, we may or may not have parset it yet.
-                data = SendJobInfo {};
-            } else if (event.value == "SEND_FILE_INFO") {
-                data = SendFileInfo {};
-            }
+            // Will fill in all the insides later on, if needed
+#define T(NAME, TYPE)          \
+    if (event.value == NAME) { \
+        data = TYPE {};        \
+    } else
+            T("SEND_INFO", SendInfo)
+            T("SEND_JOB_INFO", SendJobInfo)
+            T("SEND_FILE_INFO", SendFileInfo)
+            T("PAUSE_PRINT", PausePrint)
+            T("STOP_PRINT", StopPrint)
+            T("RESUME_PRINT", ResumePrint)
             return;
         }
 

--- a/src/connect/command.hpp
+++ b/src/connect/command.hpp
@@ -23,8 +23,11 @@ struct SendJobInfo {
 struct SendFileInfo {
     SharedPath path;
 };
+struct PausePrint {};
+struct ResumePrint {};
+struct StopPrint {};
 
-using CommandData = std::variant<UnknownCommand, BrokenCommand, ProcessingOtherCommand, Gcode, SendInfo, SendJobInfo, SendFileInfo>;
+using CommandData = std::variant<UnknownCommand, BrokenCommand, ProcessingOtherCommand, Gcode, SendInfo, SendJobInfo, SendFileInfo, PausePrint, ResumePrint, StopPrint>;
 
 struct Command {
     CommandId id;

--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -387,7 +387,8 @@ void connect::run() {
 }
 
 connect::connect(Printer &printer, SharedBuffer &buffer)
-    : printer(printer)
+    : planner(printer)
+    , printer(printer)
     , buffer(buffer) {}
 
 OnlineStatus last_status() {

--- a/src/connect/marlin_printer.hpp
+++ b/src/connect/marlin_printer.hpp
@@ -26,6 +26,7 @@ public:
     virtual Params params() const override;
     virtual std::optional<NetInfo> net_info(Iface iface) const override;
     virtual NetCreds net_creds() const override;
+    virtual bool job_control(JobControl) override;
 
     static bool load_cfg_from_ini();
 };

--- a/src/connect/planner.cpp
+++ b/src/connect/planner.cpp
@@ -67,6 +67,8 @@ const char *to_str(EventType event) {
         return "JOB_INFO";
     case EventType::FileInfo:
         return "FILE_INFO";
+    case EventType::Finished:
+        return "FINISHED";
     default:
         assert(false);
         return "???";
@@ -163,6 +165,19 @@ void Planner::command(const Command &command, const Gcode &) {
     // TODO: Implement
     planned_event = Event { EventType::Rejected, command.id };
 }
+
+#define JC(CMD)                                                         \
+    void Planner::command(const Command &command, const CMD##Print &) { \
+        if (printer.job_control(Printer::JobControl::CMD)) {            \
+            planned_event = Event { EventType::Finished, command.id };  \
+        } else {                                                        \
+            planned_event = Event { EventType::Rejected, command.id };  \
+        }                                                               \
+    }
+
+JC(Pause)
+JC(Resume)
+JC(Stop)
 
 void Planner::command(const Command &command, const SendInfo &) {
     planned_event = Event {

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -2,6 +2,7 @@
 
 #include "buffer.hpp"
 #include "command.hpp"
+#include "printer.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -28,6 +29,7 @@ enum class EventType {
     FileInfo,
     Rejected,
     Accepted,
+    Finished,
 };
 
 const char *to_str(EventType event);
@@ -61,6 +63,8 @@ enum class ActionResult {
 /// similar after something bad happens.
 class Planner {
 private:
+    Printer &printer;
+
     /// The next (or current) event we want to send out.
     std::optional<Event> planned_event;
     /// Last time we've successfully sent a telemetry to the server.
@@ -87,9 +91,13 @@ private:
     void command(const Command &, const SendInfo &);
     void command(const Command &, const SendJobInfo &);
     void command(const Command &, const SendFileInfo &);
+    void command(const Command &, const PausePrint &);
+    void command(const Command &, const ResumePrint &);
+    void command(const Command &, const StopPrint &);
 
 public:
-    Planner() {
+    Planner(Printer &printer)
+        : printer(printer) {
         reset();
     }
     /// Reset the state.

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -30,6 +30,7 @@ public:
         Paused,
         Finished,
         Ready,
+        Busy,
         Error,
     };
 
@@ -94,6 +95,12 @@ public:
         char api_key[KEY_BUF];
     };
 
+    enum class JobControl {
+        Pause,
+        Resume,
+        Stop,
+    };
+
 protected:
     PrinterInfo info;
     virtual Config load_config() = 0;
@@ -111,6 +118,7 @@ public:
     virtual Params params() const = 0;
     virtual std::optional<NetInfo> net_info(Iface iface) const = 0;
     virtual NetCreds net_creds() const = 0;
+    virtual bool job_control(JobControl) = 0;
 
     // Returns a newly reloaded config and a flag if it changed since last load.
     std::tuple<Config, bool> config();

--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -32,6 +32,8 @@ namespace {
             return "READY";
         case Printer::DeviceState::Error:
             return "ERROR";
+        case Printer::DeviceState::Busy:
+            return "BUSY";
         case Printer::DeviceState::Unknown:
         default:
             return "UNKNOWN";

--- a/tests/unit/connect/command.cpp
+++ b/tests/unit/connect/command.cpp
@@ -60,3 +60,15 @@ TEST_CASE("Send file info") {
 TEST_CASE("Send file info - missing args") {
     command_test<BrokenCommand>("{\"command\": \"SEND_FILE_INFO\", \"args\": [], \"kwargs\": {}}");
 }
+
+TEST_CASE("Pause print") {
+    command_test<PausePrint>("{\"command\": \"PAUSE_PRINT\", \"args\": [], \"kwargs\": {}}");
+}
+
+TEST_CASE("Resume print") {
+    command_test<ResumePrint>("{\"command\": \"RESUME_PRINT\", \"args\": [], \"kwargs\": {}}");
+}
+
+TEST_CASE("Stop print") {
+    command_test<StopPrint>("{\"command\": \"STOP_PRINT\", \"args\": [], \"kwargs\": {}}");
+}

--- a/tests/unit/connect/mock_printer.h
+++ b/tests/unit/connect/mock_printer.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <connect/printer.hpp>
+
+#include <cstring>
+#include <optional>
+
+namespace connect {
+
+constexpr Printer::Params params_idle() {
+    Printer::Params params {};
+
+    params.job_id = 13;
+    params.state = Printer::DeviceState::Idle;
+
+    return params;
+}
+
+class MockPrinter final : public Printer {
+private:
+    const Params &p;
+
+public:
+    MockPrinter(const Params &params)
+        : p(params) {
+        info.appendix = false;
+        strcpy(info.fingerprint, "DEADBEEF");
+        info.firmware_version = "TST-1234";
+        strcpy(info.serial_number, "FAKE-1234");
+    }
+
+    virtual void renew() override {}
+    virtual Config load_config() override {
+        return Config();
+    }
+
+    virtual Params params() const override {
+        return p;
+    }
+
+    virtual std::optional<NetInfo> net_info(Iface iface) const override {
+        return std::nullopt;
+    }
+
+    virtual NetCreds net_creds() const override {
+        return {};
+    }
+
+    virtual bool job_control(JobControl) override {
+        return false;
+    }
+};
+
+}

--- a/tests/unit/connect/planner.cpp
+++ b/tests/unit/connect/planner.cpp
@@ -1,4 +1,5 @@
 #include "time_mock.h"
+#include "mock_printer.h"
 
 #include <planner.hpp>
 
@@ -35,7 +36,9 @@ void event_info(Planner &planner) {
 }
 
 TEST_CASE("Success scenario") {
-    Planner planner;
+    Printer::Params params(params_idle());
+    MockPrinter printer(params);
+    Planner planner(printer);
 
     event_info(planner);
     planner.action_done(ActionResult::Ok);
@@ -50,7 +53,9 @@ TEST_CASE("Success scenario") {
 }
 
 TEST_CASE("Retries early") {
-    Planner planner;
+    Printer::Params params(params_idle());
+    MockPrinter printer(params);
+    Planner planner(printer);
 
     event_info(planner);
     planner.action_done(ActionResult::Failed);
@@ -73,7 +78,9 @@ TEST_CASE("Retries early") {
 }
 
 TEST_CASE("Reinit after several failures") {
-    Planner planner;
+    Printer::Params params(params_idle());
+    MockPrinter printer(params);
+    Planner planner(printer);
 
     event_info(planner);
     planner.action_done(ActionResult::Ok);
@@ -99,7 +106,9 @@ TEST_CASE("Reinit after several failures") {
 }
 
 TEST_CASE("Unknown / broken command refused") {
-    Planner planner;
+    Printer::Params params(params_idle());
+    MockPrinter printer(params);
+    Planner planner(printer);
 
     event_info(planner);
     planner.action_done(ActionResult::Ok);
@@ -130,7 +139,9 @@ TEST_CASE("Unknown / broken command refused") {
 }
 
 TEST_CASE("Send info request") {
-    Planner planner;
+    Printer::Params params(params_idle());
+    MockPrinter printer(params);
+    Planner planner(printer);
 
     event_info(planner);
     planner.action_done(ActionResult::Ok);

--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -1,5 +1,7 @@
 #include <render.hpp>
 
+#include "mock_printer.h"
+
 #include <catch2/catch.hpp>
 
 #include <cstring>
@@ -30,46 +32,6 @@ constexpr Printer::Params params_printing() {
     params.state = Printer::DeviceState::Printing;
 
     return params;
-};
-
-constexpr Printer::Params params_idle() {
-    Printer::Params params {};
-
-    params.job_id = 13;
-    params.state = Printer::DeviceState::Idle;
-
-    return params;
-}
-
-class MockPrinter final : public Printer {
-private:
-    const Params &p;
-
-public:
-    MockPrinter(const Params &params)
-        : p(params) {
-        info.appendix = false;
-        strcpy(info.fingerprint, "DEADBEEF");
-        info.firmware_version = "TST-1234";
-        strcpy(info.serial_number, "FAKE-1234");
-    }
-
-    virtual void renew() override {}
-    virtual Config load_config() override {
-        return Config();
-    }
-
-    virtual Params params() const override {
-        return p;
-    }
-
-    virtual optional<NetInfo> net_info(Iface iface) const override {
-        return nullopt;
-    }
-
-    virtual NetCreds net_creds() const override {
-        return {};
-    }
 };
 
 }


### PR DESCRIPTION
Pause/Resume/Stop commands.

Few downsides to this implementation:

* Due to races, it is possible this could cancel or pause the wrong job.
  Like, if the user clicks to stop a print in Connect, it is delayed
  somewhere (network issues?), cancels locally, starts a new print and
  then the original cancel arrives. This is a protocol design problem,
  there's no job_id in the cancel command to check against.

BFW-2804.