### PR TITLE
Define STOPPED printing state

### DIFF
--- a/src/gui/screen_printing.hpp
+++ b/src/gui/screen_printing.hpp
@@ -19,6 +19,7 @@ enum class printing_state_t : uint8_t {
     REHEATING,
     REHEATING_DONE,
     MBL_FAILED,
+    STOPPED,
     PRINTED,
     COUNT //setting this state == forced update
 };


### PR DESCRIPTION
BFW-2414
printing screen now differentiate between states PRINTED and STOPPED. This will come in handy in GUI.