### PR TITLE
Enable additional languages in their selection menus

### DIFF
--- a/src/gui/screen_menu_languages.cpp
+++ b/src/gui/screen_menu_languages.cpp
@@ -128,7 +128,7 @@ protected:
 #ifdef _DEBUG
 using Screen = ScreenMenu<EFooter::Off, MI_RETURN, MI_ENGLISH, MI_CZECH, MI_GERMAN, MI_SPANISH, MI_FRENCH, MI_ITALIAN, MI_POLISH, MI_TEST_LANG>;
 #else
-using Screen = ScreenMenu<EFooter::Off, MI_RETURN, MI_ENGLISH>;
+using Screen = ScreenMenu<EFooter::Off, MI_RETURN, MI_ENGLISH, MI_CZECH, MI_GERMAN, MI_SPANISH, MI_FRENCH, MI_ITALIAN, MI_POLISH>;
 #endif
 
 class ScreenMenuLanguages : public Screen {
@@ -146,7 +146,7 @@ ScreenFactory::UniquePtr GetScreenMenuLanguages() {
 
 /*****************************************************************************/
 //parent alias
-using Screen_noReturn = ScreenMenu<EFooter::Off, MI_ENGLISH>;
+using Screen_noReturn = ScreenMenu<EFooter::Off, MI_ENGLISH, MI_CZECH, MI_GERMAN, MI_SPANISH, MI_FRENCH, MI_ITALIAN, MI_POLISH>;
 
 class ScreenMenuLanguagesNoRet : public Screen_noReturn {
 public:


### PR DESCRIPTION
For some reason language selection menus were disabled. Probably some remains from the development builds.