### PR TITLE
Connect: START_PRINT command

### DIFF
--- a/src/connect/command.cpp
+++ b/src/connect/command.cpp
@@ -74,6 +74,7 @@ Command Command::parse_json_command(CommandId id, const string_view &body, Share
             T("PAUSE_PRINT", PausePrint)
             T("STOP_PRINT", StopPrint)
             T("RESUME_PRINT", ResumePrint)
+            T("START_PRINT", StartPrint)
             return;
         }
 
@@ -112,6 +113,13 @@ Command Command::parse_json_command(CommandId id, const string_view &body, Share
     } else if (auto *info = get_if<SendFileInfo>(&data); info != nullptr) {
         if (has_path) {
             info->path = SharedPath(move(buff));
+        } else {
+            // Missing parameters
+            data = BrokenCommand {};
+        }
+    } else if (auto *start = get_if<StartPrint>(&data); start != nullptr) {
+        if (has_path) {
+            start->path = SharedPath(move(buff));
         } else {
             // Missing parameters
             data = BrokenCommand {};

--- a/src/connect/command.hpp
+++ b/src/connect/command.hpp
@@ -26,8 +26,11 @@ struct SendFileInfo {
 struct PausePrint {};
 struct ResumePrint {};
 struct StopPrint {};
+struct StartPrint {
+    SharedPath path;
+};
 
-using CommandData = std::variant<UnknownCommand, BrokenCommand, ProcessingOtherCommand, Gcode, SendInfo, SendJobInfo, SendFileInfo, PausePrint, ResumePrint, StopPrint>;
+using CommandData = std::variant<UnknownCommand, BrokenCommand, ProcessingOtherCommand, Gcode, SendInfo, SendJobInfo, SendFileInfo, PausePrint, ResumePrint, StopPrint, StartPrint>;
 
 struct Command {
     CommandId id;

--- a/src/connect/marlin_printer.cpp
+++ b/src/connect/marlin_printer.cpp
@@ -7,6 +7,7 @@
 #include <otp.h>
 #include <odometer.hpp>
 #include <netdev.h>
+#include <print_utils.hpp>
 
 #include <cassert>
 #include <cstdlib>
@@ -332,6 +333,20 @@ bool MarlinPrinter::job_control(JobControl control) {
     }
     assert(0);
     return false;
+}
+
+bool MarlinPrinter::start_print(const char *path) {
+    // Renew was presumably called before short, it's up-to-date-ish
+    if (marlin_is_printing()) {
+        return false;
+    }
+
+    // TODO: We _had_ checks for certain screens in which printing is allowed
+    // (and not allow it in others). But they seem to be gone now, so we can't reuse them.
+    // BFW-2855.
+
+    print_begin(path, true);
+    return true;
 }
 
 }

--- a/src/connect/marlin_printer.hpp
+++ b/src/connect/marlin_printer.hpp
@@ -27,6 +27,7 @@ public:
     virtual std::optional<NetInfo> net_info(Iface iface) const override;
     virtual NetCreds net_creds() const override;
     virtual bool job_control(JobControl) override;
+    virtual bool start_print(const char *path) override;
 
     static bool load_cfg_from_ini();
 };

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -94,6 +94,7 @@ private:
     void command(const Command &, const PausePrint &);
     void command(const Command &, const ResumePrint &);
     void command(const Command &, const StopPrint &);
+    void command(const Command &, const StartPrint &);
 
 public:
     Planner(Printer &printer)

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -119,6 +119,7 @@ public:
     virtual std::optional<NetInfo> net_info(Iface iface) const = 0;
     virtual NetCreds net_creds() const = 0;
     virtual bool job_control(JobControl) = 0;
+    virtual bool start_print(const char *path) = 0;
 
     // Returns a newly reloaded config and a flag if it changed since last load.
     std::tuple<Config, bool> config();

--- a/tests/unit/connect/command.cpp
+++ b/tests/unit/connect/command.cpp
@@ -72,3 +72,11 @@ TEST_CASE("Resume print") {
 TEST_CASE("Stop print") {
     command_test<StopPrint>("{\"command\": \"STOP_PRINT\", \"args\": [], \"kwargs\": {}}");
 }
+
+TEST_CASE("Start print") {
+    REQUIRE(strcmp(command_test<StartPrint>("{\"command\": \"START_PRINT\", \"args\": [\"/usb/x.gcode\"], \"kwargs\": {\"path\": \"/usb/x.gcode\"}}").path.path(), "/usb/x.gcode") == 0);
+}
+
+TEST_CASE("Start print - missing args") {
+    command_test<BrokenCommand>("{\"command\": \"START_PRINT\", \"args\": [], \"kwargs\": {}}");
+}

--- a/tests/unit/connect/mock_printer.h
+++ b/tests/unit/connect/mock_printer.h
@@ -49,6 +49,10 @@ public:
     virtual bool job_control(JobControl) override {
         return false;
     }
+
+    virtual bool start_print(const char *) override {
+        return false;
+    }
 };
 
 }


### PR DESCRIPTION
Unfortunately, we don't have file list synchronization yet. Therefore,
the Connect UI doesn't show projects to print (simply because it doesn't
know there are some) and it can be used only through a manual command
and typing in the path.

Piggy-backing validation for the path on SEND_FILE_INFO too (as we added
the validation for START_PRINT).

Note that the print now can be started even during times when we don't
want it to start. Relates to BFW-2855.

BFW-2805, BFW-2826.