### PR TITLE
build: Change GENERATE_BBF option to BOOL

### DIFF
--- a/ProjectOptions.cmake
+++ b/ProjectOptions.cmake
@@ -39,7 +39,7 @@ set(MCU
     )
 set(GENERATE_BBF
     "NO"
-    CACHE STRING "Whether a .bbf version should be generated."
+    CACHE BOOL "Whether a .bbf version should be generated."
     )
 set(GENERATE_DFU
     "NO"


### PR DESCRIPTION
I see no reason GENERATE_BBF should be a STRING