### PR TITLE
Connect: LFN support in FILE_INFO

### DIFF
--- a/src/connect/buffer.hpp
+++ b/src/connect/buffer.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 
 namespace connect_client {
@@ -92,6 +93,25 @@ public:
     // Pointing into that borrow.
     const char *path() const {
         return reinterpret_cast<const char *>(borrow->data());
+    }
+    char *path() {
+        return reinterpret_cast<char *>(borrow->data());
+    }
+
+    // Stored just behind the path (maybe!)
+    char *name() {
+        char *path = this->path();
+        size_t plen = strlen(path);
+        // Enough space for the name too.
+        assert(plen < FILE_PATH_BUFFER_LEN);
+        return path + plen + 1;
+    }
+    const char *name() const {
+        const char *path = this->path();
+        size_t plen = strlen(path);
+        // Enough space for the name too.
+        assert(plen < FILE_PATH_BUFFER_LEN);
+        return path + plen + 1;
     }
 };
 

--- a/tests/unit/connect/missing_functions.cpp
+++ b/tests/unit/connect/missing_functions.cpp
@@ -1,9 +1,17 @@
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 
 extern "C" {
+
+size_t strlcpy(char *, const char *, size_t);
 
 uint32_t ticks_ms() {
     // Mock only
     return 0;
+}
+
+void get_LFN(char *lfn, size_t lfn_size, char *path) {
+    strlcpy(lfn, basename(path), lfn_size);
 }
 }

--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -107,7 +107,7 @@ TEST_CASE("Render") {
         // clang-format off
         expected = "{"
             "\"job_id\":42,"
-            "\"data\":{\"path\":\"/usb/box.gco\"},"
+            "\"data\":{\"path_sfn\":\"/usb/box.gco\",\"path\":\"/usb/box.gco\"},"
             "\"state\":\"PRINTING\","
             "\"command_id\":11,"
             "\"event\":\"JOB_INFO\""


### PR DESCRIPTION
Send the name and path_sfn.

For now, the server doesn't implement this yet, therefore we also keep the old path field intact. That might be removed some time in the future when no longer needed.

For the same reason, it doesn't show the long name in UI yet :-(.

BFW-2677.