### PR TITLE
Connect: Printer ready support (lightweight)

### DIFF
--- a/src/connect/command.cpp
+++ b/src/connect/command.cpp
@@ -75,6 +75,8 @@ Command Command::parse_json_command(CommandId id, const string_view &body, Share
             T("STOP_PRINT", StopPrint)
             T("RESUME_PRINT", ResumePrint)
             T("START_PRINT", StartPrint)
+            T("SET_PRINTER_READY", SetPrinterReady)
+            T("CANCEL_PRINTER_READY", CancelPrinterReady)
             return;
         }
 

--- a/src/connect/command.hpp
+++ b/src/connect/command.hpp
@@ -29,8 +29,10 @@ struct StopPrint {};
 struct StartPrint {
     SharedPath path;
 };
+struct SetPrinterReady {};
+struct CancelPrinterReady {};
 
-using CommandData = std::variant<UnknownCommand, BrokenCommand, ProcessingOtherCommand, Gcode, SendInfo, SendJobInfo, SendFileInfo, PausePrint, ResumePrint, StopPrint, StartPrint>;
+using CommandData = std::variant<UnknownCommand, BrokenCommand, ProcessingOtherCommand, Gcode, SendInfo, SendJobInfo, SendFileInfo, PausePrint, ResumePrint, StopPrint, StartPrint, SetPrinterReady, CancelPrinterReady>;
 
 struct Command {
     CommandId id;

--- a/src/connect/marlin_printer.hpp
+++ b/src/connect/marlin_printer.hpp
@@ -11,6 +11,9 @@ class MarlinPrinter final : public Printer {
 private:
     marlin_vars_t *marlin_vars;
     SharedBuffer &buffer;
+    // The SET_PRINTER_READY & friends support. Eventually, this shall sync
+    // with GUI and other places somehow. For now, only Connect-internal flag.
+    bool ready = false;
 
 protected:
     virtual Config load_config() override;
@@ -28,6 +31,7 @@ public:
     virtual NetCreds net_creds() const override;
     virtual bool job_control(JobControl) override;
     virtual bool start_print(const char *path) override;
+    virtual bool set_ready(bool ready) override;
 
     static bool load_cfg_from_ini();
 };

--- a/src/connect/planner.cpp
+++ b/src/connect/planner.cpp
@@ -231,6 +231,19 @@ void Planner::command(const Command &command, const SendFileInfo &params) {
     }
 }
 
+void Planner::command(const Command &command, const SetPrinterReady &) {
+    auto result = printer.set_ready(true) ? EventType::Finished : EventType::Rejected;
+    planned_event = Event { result, command.id };
+}
+
+void Planner::command(const Command &command, const CancelPrinterReady &) {
+    bool ok = printer.set_ready(false);
+    // Setting _not_ ready can't fail.
+    assert(ok);
+    (void)ok; // Avoid warnging when asserts are disabled.
+    planned_event = Event { EventType::Finished, command.id };
+}
+
 void Planner::command(Command command) {
     // We can get commands only as result of telemetry, not of other things.
     // TODO: We probably want to have some more graceful way to deal with the

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -95,6 +95,8 @@ private:
     void command(const Command &, const ResumePrint &);
     void command(const Command &, const StopPrint &);
     void command(const Command &, const StartPrint &);
+    void command(const Command &, const CancelPrinterReady &);
+    void command(const Command &, const SetPrinterReady &);
 
 public:
     Planner(Printer &printer)

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -120,6 +120,7 @@ public:
     virtual NetCreds net_creds() const = 0;
     virtual bool job_control(JobControl) = 0;
     virtual bool start_print(const char *path) = 0;
+    virtual bool set_ready(bool ready) = 0;
 
     // Returns a newly reloaded config and a flag if it changed since last load.
     std::tuple<Config, bool> config();

--- a/tests/unit/connect/command.cpp
+++ b/tests/unit/connect/command.cpp
@@ -80,3 +80,7 @@ TEST_CASE("Start print") {
 TEST_CASE("Start print - missing args") {
     command_test<BrokenCommand>("{\"command\": \"START_PRINT\", \"args\": [], \"kwargs\": {}}");
 }
+
+TEST_CASE("Set printer ready") {
+    command_test<SetPrinterReady>("{\"command\": \"SET_PRINTER_READY\", \"args\": [], \"kwargs\": {}}");
+}

--- a/tests/unit/connect/mock_printer.h
+++ b/tests/unit/connect/mock_printer.h
@@ -53,6 +53,10 @@ public:
     virtual bool start_print(const char *) override {
         return false;
     }
+
+    virtual bool set_ready(bool) override {
+        return true;
+    }
 };
 
 }


### PR DESCRIPTION
The SET_PRINTER_READY and CANCEL_PRINTER_READY commands and the Ready state.

This is the lightweight version, when the flag is stored on the Connect client side and doesn't integrate into the rest of the printer (eg. UI).

BFW-2871.