### PR TITLE
Fix junction deviation

### DIFF
--- a/include/marlin/Configuration_MINI.h
+++ b/include/marlin/Configuration_MINI.h
@@ -713,6 +713,8 @@
 #define CLASSIC_JERK
 #if DISABLED(CLASSIC_JERK)
     #define JUNCTION_DEVIATION_MM 0.02 // (mm) Distance from real junction edge
+    //#define JD_SMALL_SEGMENT_HANDLING // Handle small segments (< 1 mm) with large junction angles (> 135°) based on a local curvature estimate, instead of just the junction angle.
+    //#define JD_DEBUG_OUTPUT           // Output junction_cos_theta and vmax_junction_sqr to serial
 #endif
 
 /**

--- a/lib/Marlin/Marlin/src/module/planner.cpp
+++ b/lib/Marlin/Marlin/src/module/planner.cpp
@@ -2393,17 +2393,20 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
                     sin_theta_d2 = SQRT(0.5f * (1.0f - junction_cos_theta)); // Trig half angle identity. Always positive.
 
         vmax_junction_sqr = (junction_acceleration * junction_deviation_mm * sin_theta_d2) / (1.0f - sin_theta_d2);
-        if (block->millimeters < 1) {
+        #if ENABLED(JD_SMALL_SEGMENT_HANDLING)
+          if (block->millimeters < 1) {
 
-          // Fast acos approximation, minus the error bar to be safe
-          const float junction_theta = (RADIANS(-40) * sq(junction_cos_theta) - RADIANS(50)) * junction_cos_theta + RADIANS(90) - 0.18f;
+            // Fast acos approximation, minus the error bar to be safe
+            const float junction_theta = (RADIANS(-40) * sq(junction_cos_theta) - RADIANS(50)) * junction_cos_theta + RADIANS(90) - 0.18f;
 
-          // If angle is greater than 135 degrees (octagon), find speed for approximate arc
-          if (junction_theta > RADIANS(135)) {
-            const float limit_sqr = block->millimeters / (RADIANS(180) - junction_theta) * junction_acceleration;
-            NOMORE(vmax_junction_sqr, limit_sqr);
+            // If angle is greater than 135 degrees (octagon), find speed for approximate arc
+            if (junction_theta > RADIANS(135)) {
+              const float limit_sqr = block->millimeters / (RADIANS(180) - junction_theta) * junction_acceleration;
+              NOMORE(vmax_junction_sqr, limit_sqr);
+            }
           }
-        }
+        #endif //JD_SMALL_SEGMENT_HANDLING
+
       }
 
       // Get the lowest speed

--- a/lib/Marlin/config/default/Configuration.h
+++ b/lib/Marlin/config/default/Configuration.h
@@ -787,6 +787,7 @@
 #if DISABLED(CLASSIC_JERK)
   #define JUNCTION_DEVIATION_MM 0.013 // (mm) Distance from real junction edge
   #define JD_SMALL_SEGMENT_HANDLING // Handle small segments (< 1 mm) with large junction angles (> 135°) based on a local curvature estimate, instead of just the junction angle.
+  //#define JD_DEBUG_OUTPUT           // Output junction_cos_theta and vmax_junction_sqr to serial
 #endif
 
 /**

--- a/lib/Marlin/config/default/Configuration.h
+++ b/lib/Marlin/config/default/Configuration.h
@@ -786,6 +786,7 @@
  */
 #if DISABLED(CLASSIC_JERK)
   #define JUNCTION_DEVIATION_MM 0.013 // (mm) Distance from real junction edge
+  #define JD_SMALL_SEGMENT_HANDLING // Handle small segments (< 1 mm) with large junction angles (> 135°) based on a local curvature estimate, instead of just the junction angle.
 #endif
 
 /**


### PR DESCRIPTION
When doing update of the Marlin, I noticed some problem workaround feature called JD_SMALL_SEGMENT_HANDLING. I decided to backport this trivial fix to our firmware.

This doesn't fix our problem. That upset me so much I fixed the problem myself.

The problem was in junction angle computation - before the fix junction angle was computed after position was rounded up to whole machine steps. For short segments it resulted in +- 6° angle error. After some debugging and realizing that the problem is in segment angle I tried lot of things to fix it. E.g. use double instead float for computation - this has not fixed the problem. I checked the gcode, if the problem is not already presented there - gcode is not problematic, there are 3 decimal points for position, which is sufficient for angle computation.

And then the final fix - compute the angle from float position from gcode - before it is rounded to machine steps coordinates. - that solved the problem. First video JD enabled - before the fix. Second video JD enabled - after the fix.
[test gcode](https://github.com/prusa3d/Prusa-Firmware-Buddy/files/10270973/valec_JD_0.2mm_PLA_MINI_25m.zip)

[JD_gcode_analysis.ods](https://github.com/prusa3d/Prusa-Firmware-Buddy/files/9586791/JD_gcode_analysis.ods)

https://user-images.githubusercontent.com/35807926/190718132-6eb1c4ab-5534-4db1-8564-9e566f15dd6b.mp4


https://user-images.githubusercontent.com/35807926/190718160-32382076-175f-4f0e-94ca-688930cfb98c.mp4

