### PR TITLE
Fix crash screen text drawn over separator.

### DIFF
--- a/src/gui/screen_crash_recovery.cpp
+++ b/src/gui/screen_crash_recovery.cpp
@@ -27,7 +27,7 @@ static constexpr size_t row_3 = 205; // line
 static constexpr size_t col_0 = 10;
 static constexpr Rect16 icon_nozzle_rc { 97, row_1 - 5, 48, 48 };
 static constexpr Rect16 icon_nozzle_crash_rc { 97 - 26, row_1, 48, 48 };
-static constexpr size_t row_nok_shift = -70;
+static constexpr size_t row_nok_shift = -31;
     #endif
 
 static constexpr size_t char_h = 24;
@@ -66,6 +66,13 @@ static constexpr const char *en_text_X_axis = N_("X-axis");
 static constexpr const char *en_text_Y_axis = N_("Y-axis");
 
 static constexpr const char *en_text_long_short = N_("Length of an axis is too short.\nThere's an obstacle or bearing issue.\nRetry check, pause or resume the print?");
+/**
+ * There is no known way how this might happen on MINI printer to ordinary user.
+ * If the motor is electrically disconnected, axis is too short.
+ * If the pulley is loose, axis is too long, but the screen is not shown
+ * as there is homing attempt before showing the screen which fails after 45 tries,
+ * printer resets with homing failed red screen.
+ */
 static constexpr const char *en_text_long_long = N_("Length of an axis is too long.\nMotor current is too low, probably.\nRetry check, pause or resume the print?");
 static constexpr const char *en_text_long_repeat = N_("Repeated collision\nhas been detected.\nDo you want to resume\nor pause the print?");
 


### PR DESCRIPTION
Before the fix crash screen text was drawn over separator.
After the fix crash screen text is not drawn over separator.

After the fix with English text it looks like there is too big gap between the last line and separator. I have experimented with moving axis text results little bit up. But as the text is center aligned in both axis it is also negatively affecting space between header and the text. So I am leaving axis results moved as down as possible not interfering with buttons. This doesn't look best with current text, but on the other hand it leaves space for one more line of text, if the translated text becomes longer.

I have no clue why the text is both vertically and horizontally center aligned. Has the fucking Rome risen again? But I'm not gonna touch that.

Before the fix:
![Before](https://user-images.githubusercontent.com/35807926/192008087-92ba87f2-89af-4739-884b-5b4c9669a820.gif)
After the fix:
![After](https://user-images.githubusercontent.com/35807926/192008091-6ac8bc20-f0ca-4348-a5fb-4400af1cfeb6.gif)
After the fix if translation is one line longer:
![After_longer_text](https://user-images.githubusercontent.com/35807926/192008094-6eb561a1-2405-4bf9-b22d-0286c1ceef60.gif)
