### PR TITLE
Auto-format missed CMakeLists

### DIFF
--- a/tests/unit/lang/eeprom/CMakeLists.txt
+++ b/tests/unit/lang/eeprom/CMakeLists.txt
@@ -1,10 +1,8 @@
 # define the test executable
-add_executable(language_eeprom_tests
-../../../../src/lang/translator.cpp
-../../../../src/common/language_eeprom.cpp
-../../test_main.cpp
-tests.cpp
-)
+add_executable(
+  language_eeprom_tests ../../../../src/common/language_eeprom.cpp
+                        ../../../../src/lang/translator.cpp ../../test_main.cpp tests.cpp
+  )
 
 # define required search paths
 target_include_directories(language_eeprom_tests PUBLIC . ${CMAKE_SOURCE_DIR}/src/lang)

--- a/tests/unit/lang/format_print_will_end/CMakeLists.txt
+++ b/tests/unit/lang/format_print_will_end/CMakeLists.txt
@@ -1,11 +1,14 @@
-
 # define the test executable
-add_executable(format_print_will_end_tests tests.cpp ../../../../src/lang/format_print_will_end.cpp ../../../../src/lang/translator.cpp)
+add_executable(
+  format_print_will_end_tests ../../../../src/lang/format_print_will_end.cpp
+                              ../../../../src/lang/translator.cpp tests.cpp
+  )
 
 # define required search paths
 target_include_directories(format_print_will_end_tests PUBLIC . ${CMAKE_SOURCE_DIR}/src/lang)
 
 # define custom macros
+
 # target_compile_definitions(format_print_will_end_tests PUBLIC)
 
 # tell build system about the test case

--- a/tests/unit/lang/string_view_utf8/CMakeLists.txt
+++ b/tests/unit/lang/string_view_utf8/CMakeLists.txt
@@ -1,13 +1,11 @@
-
 # define the test executable
 add_executable(string_view_utf8_tests tests.cpp)
 
 # define required search paths
-target_include_directories(string_view_utf8_tests PUBLIC
-    ${CMAKE_SOURCE_DIR}/src/lang
-)
+target_include_directories(string_view_utf8_tests PUBLIC ${CMAKE_SOURCE_DIR}/src/lang)
 
 # define custom macros
+
 # target_compile_definitions(string_view_utf8_tests PUBLIC LAZYFILELIST_UNITTEST)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zluty_kun.bin ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)


### PR DESCRIPTION
Autoformating not formatted CMakeLists. These changes are a part of https://github.com/prusa3d/Prusa-Firmware-Buddy/pull/2197 that seems to be 'postponed', but forwarding them in this PR would help with `pre-commit run cmake-format --all-files` which keeps hitting these files every time.