### PR TITLE
vscode: Add plugin OutputColorizer to recommended

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,11 @@
 {
-    "recommendations": ["ccls-project.ccls", "twxs.cmake", "ms-vscode.cmake-tools", "marus25.cortex-debug", "marus25.cortex-debug-dp-stm32f4"],
+    "recommendations": [
+        "ccls-project.ccls",
+        "twxs.cmake",
+        "ms-vscode.cmake-tools",
+        "marus25.cortex-debug",
+        "marus25.cortex-debug-dp-stm32f4",
+        "IBM.output-colorizer"
+    ],
     "unwantedRecommendations": ["ms-vscode.cpptools-extension-pack"]
 }


### PR DESCRIPTION
This plugin colorizes build output. It's not perfect coloring (ie the same as it would be if built from command line), since the plugin 'blindly parses the text and adds colours based on patterns', but it is at least something. And something is a lot better than nothing when it comes to reading compiler output.

Added screenshots with sample error:

- Current:
![image](https://user-images.githubusercontent.com/68755280/193565088-4515141d-119c-448f-b68f-ece1f598147c.png)

- Colorized:
![image](https://user-images.githubusercontent.com/68755280/193564154-92793638-b04e-41e2-b905-2b6189e2ed38.png)
