### PR TITLE
fix: algorithm_range with floats and NAN, added tests

### DIFF
--- a/src/common/algorithm_range.hpp
+++ b/src/common/algorithm_range.hpp
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#include <concepts>
+
 template <typename T>
 constexpr bool IsInOpenRange(const T &value, const T &left, const T &right);
 template <typename T>
@@ -23,7 +26,11 @@ class range__ {
         return (low < value) && (value < high);
     }
     static constexpr bool closed_interval(const T &value, const T &low, const T &high) {
-        return !(value < low) && !(high < value);
+        if constexpr (std::floating_point<T>) {
+            return value >= low && value <= high;
+        } else {
+            return !(value < low) && !(high < value);
+        }
     }
     static constexpr bool left_open_interval(const T &value, const T &low, const T &high) {
         return (low < value) && !(high < value);

--- a/tests/unit/common/algorithm_range_tests.cpp
+++ b/tests/unit/common/algorithm_range_tests.cpp
@@ -12,6 +12,16 @@ TEST_CASE("checking ranges", "[range]") {
         CHECK(IsInClosedRange(0, 0, -1));
         CHECK_FALSE(IsInLeftOpenRange(0, 0, -1));
         CHECK(IsInRightOpenRange(0, 0, -1));
+
+        CHECK_FALSE(IsInOpenRange(0.0, 0.0, 1.0));
+        CHECK(IsInClosedRange(0.0, 0.0, 1.0));
+        CHECK_FALSE(IsInLeftOpenRange(0.0, 0.0, 1.0));
+        CHECK(IsInRightOpenRange(0.0, 0.0, 1.0));
+
+        CHECK_FALSE(IsInOpenRange(0.0, 0.0, -1.0));
+        CHECK(IsInClosedRange(0.0, 0.0, -1.0));
+        CHECK_FALSE(IsInLeftOpenRange(0.0, 0.0, -1.0));
+        CHECK(IsInRightOpenRange(0.0, 0.0, -1.0));
     }
 
     SECTION("too small") {
@@ -24,6 +34,16 @@ TEST_CASE("checking ranges", "[range]") {
         CHECK_FALSE(IsInClosedRange(0, 4, 3));
         CHECK_FALSE(IsInLeftOpenRange(1, 100, 10));
         CHECK_FALSE(IsInRightOpenRange(2, 4, 3));
+
+        CHECK_FALSE(IsInOpenRange(-1.0, 0.0, 1.0));
+        CHECK_FALSE(IsInClosedRange(0.0, 3.0, 5.0));
+        CHECK_FALSE(IsInLeftOpenRange(1.0, 10.0, 100.0));
+        CHECK_FALSE(IsInRightOpenRange(2.0, 3.0, 4.0));
+
+        CHECK_FALSE(IsInOpenRange(-1.0, 1.0, 0.0));
+        CHECK_FALSE(IsInClosedRange(0.0, 4.0, 3.0));
+        CHECK_FALSE(IsInLeftOpenRange(1.0, 100.0, 10.0));
+        CHECK_FALSE(IsInRightOpenRange(2.0, 4.0, 3.0));
     }
 
     SECTION("equal to right") {
@@ -36,6 +56,16 @@ TEST_CASE("checking ranges", "[range]") {
         CHECK(IsInClosedRange(-1, 0, -1));
         CHECK(IsInLeftOpenRange(-1, 0, -1));
         CHECK_FALSE(IsInRightOpenRange(-1, 0, -1));
+
+        CHECK_FALSE(IsInOpenRange(1.0, 0.0, 1.0));
+        CHECK(IsInClosedRange(1.0, 0.0, 1.0));
+        CHECK(IsInLeftOpenRange(1.0, 0.0, 1.0));
+        CHECK_FALSE(IsInRightOpenRange(1.0, 0.0, 1.0));
+
+        CHECK_FALSE(IsInOpenRange(-1.0, 0.0, -1.0));
+        CHECK(IsInClosedRange(-1.0, 0.0, -1.0));
+        CHECK(IsInLeftOpenRange(-1.0, 0.0, -1.0));
+        CHECK_FALSE(IsInRightOpenRange(-1.0, 0.0, -1.0));
     }
 
     SECTION("too big") {
@@ -48,6 +78,16 @@ TEST_CASE("checking ranges", "[range]") {
         CHECK_FALSE(IsInClosedRange(6, 5, 3));
         CHECK_FALSE(IsInLeftOpenRange(1111, 100, 10));
         CHECK_FALSE(IsInRightOpenRange(-2, -3, -4));
+
+        CHECK_FALSE(IsInOpenRange(5.0, 0.0, 1.0));
+        CHECK_FALSE(IsInClosedRange(6.0, 3.0, 5.0));
+        CHECK_FALSE(IsInLeftOpenRange(1111.0, 10.0, 100.0));
+        CHECK_FALSE(IsInRightOpenRange(-2.0, -4.0, -3.0));
+
+        CHECK_FALSE(IsInOpenRange(5.0, 1.0, 0.0));
+        CHECK_FALSE(IsInClosedRange(6.0, 5.0, 3.0));
+        CHECK_FALSE(IsInLeftOpenRange(1111.0, 100.0, 10.0));
+        CHECK_FALSE(IsInRightOpenRange(-2.0, -3.0, -4.0));
     }
 
     SECTION("inside") {
@@ -60,5 +100,27 @@ TEST_CASE("checking ranges", "[range]") {
         CHECK(IsInClosedRange(4, 5, 3));
         CHECK(IsInLeftOpenRange(11, 100, 10));
         CHECK(IsInRightOpenRange(-2, -1, -4));
+
+        CHECK(IsInOpenRange(1.0, 0.0, 2.0));
+        CHECK(IsInClosedRange(4.0, 3.0, 5.0));
+        CHECK(IsInLeftOpenRange(11.0, 10.0, 100.0));
+        CHECK(IsInRightOpenRange(-2.0, -4.0, -1.0));
+
+        CHECK(IsInOpenRange(1.0, 2.0, 0.0));
+        CHECK(IsInClosedRange(4.0, 5.0, 3.0));
+        CHECK(IsInLeftOpenRange(11.0, 100.0, 10.0));
+        CHECK(IsInRightOpenRange(-2.0, -1.0, -4.0));
+    }
+
+    SECTION("special") {
+        CHECK_FALSE(IsInOpenRange<double>(NAN, 0.0, 1.0));
+        CHECK_FALSE(IsInClosedRange<double>(NAN, 0.0, 1.0));
+        CHECK_FALSE(IsInLeftOpenRange<double>(NAN, 0.0, 1.0));
+        CHECK_FALSE(IsInRightOpenRange<double>(NAN, 0.0, 1.0));
+
+        CHECK_FALSE(IsInOpenRange<double>(INFINITY, 0.0, 1.0));
+        CHECK_FALSE(IsInClosedRange<double>(INFINITY, 0.0, 1.0));
+        CHECK_FALSE(IsInLeftOpenRange<double>(INFINITY, 0.0, 1.0));
+        CHECK_FALSE(IsInRightOpenRange<double>(INFINITY, 0.0, 1.0));
     }
 }


### PR DESCRIPTION
Insignificant bugfix since algorithm range isn't used anywhere, but it should be correct in case someone decides to use the class.
The problem was in function `IsInClosedRange` when checking whether 'NAN' is in range. Comparisons with NAN always result in false, so `if !false && !false` ends up being `true`, which is incorrect since NAN should not be considered as 'in range'.

Also added tests to catch this special case.