### PR TITLE
Add nodiscard to auto restore

### DIFF
--- a/src/common/RAII.hpp
+++ b/src/common/RAII.hpp
@@ -24,7 +24,7 @@ public:
      * @param ref reference to variable to be restored
      * @param set_to change value after construction
      */
-    AutoRestore(T &ref, T set_to)
+    [[nodiscard]] AutoRestore(T &ref, T set_to)
         : ref(ref)
         , val(ref) {
         ref = set_to;
@@ -34,7 +34,7 @@ public:
      *
      * @param ref reference to variable to be restored
      */
-    AutoRestore(T &ref)
+    [[nodiscard]] AutoRestore(T &ref)
         : ref(ref)
         , val(ref) {}
     /**

--- a/src/gui/gui_fsensor_api.hpp
+++ b/src/gui/gui_fsensor_api.hpp
@@ -48,7 +48,7 @@ inline bool validate_for_cyclical_calls() {
     static bool can_run = true;
     if (!can_run)
         return false;
-    AutoRestore(can_run, false);
+    AutoRestore ar(can_run, false);
     validate();
     return true;
 }


### PR DESCRIPTION
There was a bug in a use of `AutoRestore` that didn't properly create the object. This resulted in the object being constructed and destructed right after, missing the point of the `AutoRestore` use.

Also added `[[nodiscard]]` attribute to the constructor of `AutoRestore` to prevent this bug from happening ever again.