### PR TITLE
Increase GUI task stack size to 5KB

### DIFF
--- a/src/buddy/main.cpp
+++ b/src/buddy/main.cpp
@@ -167,7 +167,7 @@ extern "C" void main_cpp(void) {
     defaultTaskHandle = osThreadCreate(osThread(defaultTask), NULL);
 
     if (HAS_GUI) {
-        osThreadDef(displayTask, StartDisplayTask, osPriorityNormal, 0, 1024);
+        osThreadDef(displayTask, StartDisplayTask, osPriorityNormal, 0, 1024 + 256);
         displayTaskHandle = osThreadCreate(osThread(displayTask), NULL);
     }
 


### PR DESCRIPTION
The GUI task can hit 96% in metrics. With so little reserve, it leaves very little space to do certain operations. This PR increases the stack size by 1KB to give the task room for buffers and such.