### PR TITLE
network: HeaderOut use variant value

### DIFF
--- a/src/common/http/httpc.hpp
+++ b/src/common/http/httpc.hpp
@@ -10,7 +10,7 @@ namespace http {
 
 struct HeaderOut {
     const char *name = nullptr;
-    const char *value = nullptr;
+    const std::variant<const char *, size_t> value = nullptr;
     const std::optional<size_t> size_limit = std::nullopt;
 };
 

--- a/src/common/http/post_file_request.cpp
+++ b/src/common/http/post_file_request.cpp
@@ -1,7 +1,7 @@
 #include "post_file_request.hpp"
 
 namespace http {
-PostFile::PostFile(const char *file_path, const char *url_string, const char *file_size)
+PostFile::PostFile(const char *file_path, const char *url_string, size_t file_size)
     : hdrs {
         { "Content-Length", file_size, std::nullopt },
         { nullptr, nullptr, std::nullopt },

--- a/src/common/http/post_file_request.hpp
+++ b/src/common/http/post_file_request.hpp
@@ -5,7 +5,7 @@
 namespace http {
 class PostFile : public Request {
 public:
-    PostFile(const char *file_path, const char *url_string, const char *file_size);
+    PostFile(const char *file_path, const char *url_string, size_t file_size);
     virtual ~PostFile() = default;
     const char *url() const override;
     ContentType content_type() const override;

--- a/src/common/utils/overloaded_visitor.hpp
+++ b/src/common/utils/overloaded_visitor.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+/**
+ * @brief Used to overload std::visit with multiple lambdas, usage: std::visit(Overloaded { lambda1, lambda2, ...}, variant);
+ *
+ * @tparam Ts
+ */
+template <typename... Ts>
+struct Overloaded : Ts... {
+    using Ts::operator()...;
+};
+template <class... Ts>
+Overloaded(Ts...)->Overloaded<Ts...>; // CTAD


### PR DESCRIPTION
Continuation of https://github.com/prusa3d/Prusa-Firmware-Buddy/pull/2531

This PR changes HeaderOut to allow parameter to take either a `const char *` string or a `size_t` parameter, for ease of use and cleaniness.