### PR TITLE
connect: Accept `path_sfn` parameters.

### DIFF
--- a/src/connect/command.cpp
+++ b/src/connect/command.cpp
@@ -103,7 +103,7 @@ Command Command::parse_json_command(CommandId id, const string_view &body, Share
             if (err && *err) {
                 job_id = nullopt;
             }
-        } else if (event.depth == 2 && in_kwargs && event.type == Type::String && event.key == "path") {
+        } else if (event.depth == 2 && in_kwargs && event.type == Type::String && (event.key == "path" || event.key == "path_sfn")) {
             const size_t len = min(event.value->size() + 1, buff.size());
             strlcpy(reinterpret_cast<char *>(buff.data()), event.value->data(), len);
             has_path = true;

--- a/tests/unit/connect/command.cpp
+++ b/tests/unit/connect/command.cpp
@@ -77,6 +77,10 @@ TEST_CASE("Start print") {
     REQUIRE(strcmp(command_test<StartPrint>("{\"command\": \"START_PRINT\", \"args\": [\"/usb/x.gcode\"], \"kwargs\": {\"path\": \"/usb/x.gcode\"}}").path.path(), "/usb/x.gcode") == 0);
 }
 
+TEST_CASE("Start print - SFN") {
+    REQUIRE(strcmp(command_test<StartPrint>("{\"command\": \"START_PRINT\", \"args\": [\"/usb/x.gcode\"], \"kwargs\": {\"path_sfn\": \"/usb/x.gcode\"}}").path.path(), "/usb/x.gcode") == 0);
+}
+
 TEST_CASE("Start print - missing args") {
     command_test<BrokenCommand>("{\"command\": \"START_PRINT\", \"args\": [], \"kwargs\": {}}");
 }


### PR DESCRIPTION
Connect insists on making distinction between short and long paths for us. We don't care, but we need to be able to accept either.