### PR TITLE
Connect: Reasons in Rejected events

### DIFF
--- a/src/connect/command.hpp
+++ b/src/connect/command.hpp
@@ -11,7 +11,9 @@ namespace connect_client {
 using CommandId = uint32_t;
 
 struct UnknownCommand {};
-struct BrokenCommand {};
+struct BrokenCommand {
+    const char *reason = nullptr;
+};
 struct ProcessingOtherCommand {};
 struct ProcessingThisCommand {};
 struct GcodeTooLarge {};

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -40,6 +40,11 @@ struct Event {
     std::optional<CommandId> command_id;
     std::optional<uint16_t> job_id;
     std::optional<SharedPath> path;
+    /// Reason for the event. May be null.
+    ///
+    /// Reasons are constant strings, therefore the non-owned const char * ‒
+    /// they are not supposed to get "constructed" or interpolated.
+    const char *reason = nullptr;
 };
 
 using Action = std::variant<

--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -16,8 +16,9 @@ using namespace json;
 namespace {
 
 constexpr const char *const print_file = "/usb/box.gco";
-constexpr const char *const rejected_event_printing = "{\"state\":\"PRINTING\",\"command_id\":11,\"event\":\"REJECTED\"}";
+constexpr const char *const rejected_event_printing = "{\"reason\":\"Job ID doesn't match\",\"state\":\"PRINTING\",\"command_id\":11,\"event\":\"REJECTED\"}";
 constexpr const char *const rejected_event_idle = "{\"state\":\"IDLE\",\"command_id\":11,\"event\":\"REJECTED\"}";
+constexpr const char *const rejected_event_idle_no_job = "{\"reason\":\"No job in progress\",\"state\":\"IDLE\",\"command_id\":11,\"event\":\"REJECTED\"}";
 
 constexpr Printer::Params params_printing() {
     Printer::Params params {};
@@ -124,7 +125,7 @@ TEST_CASE("Render") {
             42,
         };
         params = params_idle();
-        expected = rejected_event_idle;
+        expected = rejected_event_idle_no_job;
     }
 
     SECTION("Even - job info - invalid job ID") {


### PR DESCRIPTION
Provide the (debug) reason for rejected events when complaining to the server about something.

BFW-2828.