### PR TITLE
connect: Minor code cleanups

### DIFF
--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -15,10 +15,10 @@ using namespace json;
 
 namespace {
 
-constexpr const char *const print_file = "/usb/box.gco";
-constexpr const char *const rejected_event_printing = "{\"reason\":\"Job ID doesn't match\",\"state\":\"PRINTING\",\"command_id\":11,\"event\":\"REJECTED\"}";
-constexpr const char *const rejected_event_idle = "{\"state\":\"IDLE\",\"command_id\":11,\"event\":\"REJECTED\"}";
-constexpr const char *const rejected_event_idle_no_job = "{\"reason\":\"No job in progress\",\"state\":\"IDLE\",\"command_id\":11,\"event\":\"REJECTED\"}";
+constexpr const char *print_file = "/usb/box.gco";
+constexpr const char *rejected_event_printing = R"({"reason":"Job ID doesn't match","state":"PRINTING","command_id":11,"event":"REJECTED"})";
+constexpr const char *rejected_event_idle = R"({"state":"IDLE","command_id":11,"event":"REJECTED"})";
+constexpr const char *rejected_event_idle_no_job = R"({"reason":"No job in progress","state":"IDLE","command_id":11,"event":"REJECTED"})";
 
 constexpr Printer::Params params_printing() {
     Printer::Params params {};
@@ -110,7 +110,7 @@ TEST_CASE("Render") {
         // clang-format off
         expected = "{"
             "\"job_id\":42,"
-            "\"data\":{\"path_sfn\":\"/usb/box.gco\",\"path\":\"/usb/box.gco\"},"
+            R"("data":{"path_sfn":"/usb/box.gco","path":"/usb/box.gco"},)"
             "\"state\":\"PRINTING\","
             "\"command_id\":11,"
             "\"event\":\"JOB_INFO\""


### PR DESCRIPTION
* Remove extra (unneeded) const.
* Use the raw strings to get rid of some escaping in JSON constants. Not everywhere (it's not worth with strings with only few escape sequences).

Followup-on review comments from BFW-2828.