### PR TITLE
Connect: hostname compression

### DIFF
--- a/src/connect/CMakeLists.txt
+++ b/src/connect/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
           printer.cpp
           marlin_printer.cpp
           run.cpp
+          hostname.cpp
           ${CMAKE_CURRENT_BINARY_DIR}/http_resp_automaton.cpp
   )
 

--- a/src/connect/hostname.cpp
+++ b/src/connect/hostname.cpp
@@ -1,0 +1,83 @@
+#include "hostname.hpp"
+
+#include <cstring>
+#include <cstdint>
+
+namespace connect_client {
+
+namespace {
+
+    const constexpr char *suffixes[] = {
+        "connect.prusa3d.com",
+        "prusa3d.com",
+    };
+
+    constexpr uint8_t compress_mark = 1;
+}
+
+bool compress_host(const char *host, char *buffer, size_t buffer_len) {
+    size_t len = strlen(host);
+    for (size_t i = 0; i < (sizeof suffixes / sizeof *suffixes); i++) {
+        size_t suf_len = strlen(suffixes[i]);
+
+        if (suf_len > len) {
+            // Hostname shorter than suffix - suffix is for sure not there.
+            continue;
+        }
+
+        if (len - suf_len + 2 >= buffer_len) {
+            // The result would be longer even if it was shortened by the suffix, so no need to check.
+            continue;
+        }
+
+        if (strcasecmp(suffixes[i], host + len - suf_len) == 0) {
+            size_t l_prefix = len - suf_len;
+            memcpy(buffer, host, l_prefix);
+            buffer[l_prefix] = compress_mark;
+            // Avoid 0 index for strlen to work on that string.
+            buffer[l_prefix + 1] = i + 1;
+            buffer[l_prefix + 2] = '\0';
+            return true;
+        }
+    }
+
+    if (len >= buffer_len) {
+        return false;
+    }
+
+    // Just checked the size, strcpy is fine
+    strcpy(buffer, host);
+    return true;
+}
+
+void decompress_host(char *host, size_t host_buffer) {
+    size_t len = strlen(host);
+    if (len < 2) {
+        return;
+    }
+
+    if (host[len - 2] != compress_mark) {
+        return;
+    }
+
+    // Re-adjust back to 0-based indices
+    size_t idx = host[len - 1] - 1;
+
+    if (idx >= (sizeof suffixes / sizeof *suffixes)) {
+        // idx out of range
+        return;
+    }
+
+    size_t suffix_len = strlen(suffixes[idx]);
+    size_t new_len = len - 2 + suffix_len;
+
+    if (new_len + 1 > host_buffer) {
+        // The result wouldn't fit, so don't expand.
+        // (That shouldn't happen)
+        return;
+    }
+
+    strcpy(host + len - 2, suffixes[idx]);
+}
+
+}

--- a/src/connect/hostname.hpp
+++ b/src/connect/hostname.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdlib>
+
+// Hostname compression. We don't want to allocate bigger chunk of eeprom, but
+// still need to store some testing domains that are longer. Therefore, we
+// compress the "known suffix" of it. There's a possibility to have more such
+// known suffixes in the future.
+//
+// (It is still possible to have non-compressed custom ones as before, they
+// still need to fit into the eeprom variable though).
+
+namespace connect_client {
+
+// Copies the host into the provided buffer, applying compression if possible.
+//
+// Returns false if it doesn't fit into the buffer (after any applicable
+// compression).
+//
+// The resulting value is \0-terminated.
+bool compress_host(const char *host, char *buffer, size_t buffer_len);
+
+// The reverse of compress_host. Expands it in-place.
+//
+// In case the value is not compressed, is invalid or the expanded value
+// wouldn't fit, it leaves the original intact.
+void decompress_host(char *host, size_t host_buffer);
+
+}

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -65,7 +65,7 @@ public:
     };
 
     struct Config {
-        static constexpr size_t CONNECT_URL_LEN = 30;
+        static constexpr size_t CONNECT_URL_LEN = 35;
         static constexpr size_t CONNECT_URL_BUF_LEN = (CONNECT_URL_LEN + 1);
         static constexpr size_t CONNECT_TOKEN_LEN = 20;
         static constexpr size_t CONNECT_TOKEN_BUF_LEN = (CONNECT_TOKEN_LEN + 1);

--- a/tests/unit/connect/CMakeLists.txt
+++ b/tests/unit/connect/CMakeLists.txt
@@ -11,9 +11,11 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/connect/render.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/command.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/planner.cpp
+  ${CMAKE_SOURCE_DIR}/src/connect/hostname.cpp
   command.cpp
   missing_functions.cpp
   render.cpp
+  hostname.cpp
   ${CMAKE_SOURCE_DIR}/tests/stubs/jsmn_impl.c
   ${CMAKE_SOURCE_DIR}/tests/stubs/strlcpy.c
   )

--- a/tests/unit/connect/hostname.cpp
+++ b/tests/unit/connect/hostname.cpp
@@ -1,0 +1,62 @@
+#include <hostname.hpp>
+
+#include <catch2/catch.hpp>
+#include <cstring>
+
+using namespace connect_client;
+
+constexpr const char *uncompressed = "uncompressed.example.com";
+constexpr const char *compressed = "whatever.connect.prusa3d.com";
+
+TEST_CASE("Host not compressed") {
+    char buffer[30];
+
+    REQUIRE(compress_host(uncompressed, buffer, sizeof buffer));
+    REQUIRE(strcmp(uncompressed, buffer) == 0);
+
+    decompress_host(buffer, sizeof buffer);
+    REQUIRE(strcmp(uncompressed, buffer) == 0);
+}
+
+TEST_CASE("Host doesn't fit, not compressed") {
+    char buffer[10];
+
+    REQUIRE_FALSE(compress_host(uncompressed, buffer, sizeof buffer));
+}
+
+TEST_CASE("Host doesn't fit after compression") {
+    // The compressed shall be 11 chars + \0, so this overflows by exactly 1
+    char buffer[11];
+    REQUIRE_FALSE(compress_host(compressed, buffer, sizeof buffer));
+}
+
+TEST_CASE("Host compressed") {
+    // This shall be an exact fit.
+    char buffer[12];
+
+    REQUIRE(compress_host(compressed, buffer, sizeof buffer));
+    // The compressed representation is "valid" string, with \0 at the end.
+    REQUIRE(strlen(buffer) < sizeof buffer);
+
+    char decompress_buffer[30];
+    memcpy(decompress_buffer, buffer, sizeof buffer);
+
+    // An attempt to decompress without giving it space to expand shall fail (silently, shall do nothing).
+    decompress_host(decompress_buffer, sizeof buffer);
+    REQUIRE(memcmp(decompress_buffer, buffer, sizeof buffer) == 0);
+
+    // When we give it enough space, it'll expand
+    decompress_host(decompress_buffer, sizeof decompress_buffer);
+    REQUIRE(strcmp(compressed, decompress_buffer) == 0);
+}
+
+TEST_CASE("Looks like compressed") {
+    // This things looks like a compressed thing, but isn't (index out of range).
+    const char *impostor = "impostor.\x01X";
+
+    char buffer[30];
+    strcpy(buffer, impostor);
+    decompress_host(buffer, sizeof buffer);
+    // Nothing changed.
+    REQUIRE(strcmp(buffer, impostor) == 0);
+}


### PR DESCRIPTION
* We have several test domains that don't fit the current 20 character limit.
* Increasing the size in eeprom doesn't sound like it's worth it (mostly just for testing purposes), we don't have an agreement on the right size after increasing it, etc.
* This is an interim solution to allow testing with minimal risk of backfiring (technically, the value into which it is compressed is still valid DNS, but nobody is going to use it in practice).

BFW-2918.