### PR TITLE
network: Add PostLambda request

### DIFF
--- a/src/common/http/CMakeLists.txt
+++ b/src/common/http/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(
   PRIVATE httpc.cpp
           os_porting.cpp
           post_file_request.cpp
+          post_lambda_request.cpp
           resp_parser.cpp
           socket.cpp
           socket_connection_factory.cpp

--- a/src/common/http/post_lambda_request.cpp
+++ b/src/common/http/post_lambda_request.cpp
@@ -1,0 +1,27 @@
+#include "post_lambda_request.hpp"
+
+namespace http {
+PostLambda::PostLambda(LambdaT lam, const char *url_string)
+    : url_string(url_string)
+    , lamb(lam) {
+}
+const char *PostLambda::url() const {
+    return url_string;
+}
+ContentType PostLambda::content_type() const {
+    return ContentType::ApplicationOctetStream;
+}
+Method PostLambda::method() const {
+    return Method::Post;
+}
+
+std::variant<size_t, Error> PostLambda::write_body_chunk(char *data, size_t size) {
+    assert(size && lamb);
+    if (!size || !lamb) {
+        return Error::InternalError;
+    }
+
+    return lamb(data, size);
+}
+
+};

--- a/src/common/http/post_lambda_request.hpp
+++ b/src/common/http/post_lambda_request.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include "httpc.hpp"
+#include <functional>
+
+namespace http {
+/**
+* @brief Post Request with 'write_body_chunk' given by user via a (potentially stateful) lambda
+*
+*/
+class PostLambda : public Request {
+public:
+    using LambdaT = std::function<std::variant<size_t, Error>(char *, size_t)>;
+
+    PostLambda(LambdaT lambda, const char *url_string);
+    virtual ~PostLambda() = default;
+    const char *url() const override;
+    ContentType content_type() const override;
+    Method method() const override;
+    std::variant<size_t, Error> write_body_chunk(char *data, size_t size) override;
+
+private:
+    const char *url_string;
+    LambdaT lamb;
+};
+};


### PR DESCRIPTION
This PR adds a PostLambda request, which allows "write_body_chunk" to be given by user via a stateful lambda. 