### PR TITLE
connect: Fine-tune Forbidden reporting

### DIFF
--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -373,9 +373,9 @@ optional<OnlineStatus> connect::communicate(CachedFactory &conn_factory) {
         // Switch just to provide proper error message
         switch (resp.status) {
         case Status::BadRequest:
+        case Status::Forbidden:
             return OnlineStatus::InternalError;
         case Status::Unauthorized:
-        case Status::Forbidden:
             return OnlineStatus::Auth;
         default:
             return OnlineStatus::ServerError;


### PR DESCRIPTION
Forbidden is reported by the server if we do something it doesn't like, but we have the right password. Report it accordingly (there's no "functional" change).