### PR TITLE
Enable Bootstrap over Debugger & Optimize its speed

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
             "type": "cortex-debug",
             "servertype": "openocd",
             "armToolchainPath": "${workspaceRoot}/.dependencies/gcc-arm-none-eabi-10.3.1/bin",
+            "openOCDPreConfigLaunchCommands": ["set bbf_over_debugger_path ./build-vscode-buddy/firmware.bbf"],
             "configFiles": ["${workspaceRoot}/utils/debug/00_common.cfg", "${workspaceRoot}/utils/debug/10_custom_config.cfg", "${workspaceRoot}/utils/debug/20_board_buddy.cfg", "${workspaceRoot}/utils/debug/30_rtt_workaround.cfg"],
             "toolchainPrefix": "arm-none-eabi",
             "device": "STM32F429VI",
@@ -40,6 +41,7 @@
             "type": "cortex-debug",
             "servertype": "openocd",
             "armToolchainPath": "${workspaceRoot}/.dependencies/gcc-arm-none-eabi-10.3.1/bin",
+            "openOCDPreConfigLaunchCommands": ["set bbf_over_debugger_path ./build-vscode-buddy/firmware.bbf"],
             "configFiles": ["${workspaceRoot}/utils/debug/00_common.cfg", "${workspaceRoot}/utils/debug/10_custom_config.cfg", "${workspaceRoot}/utils/debug/20_board_buddy.cfg", "${workspaceRoot}/utils/debug/30_rtt_workaround.cfg"],
             "toolchainPrefix": "arm-none-eabi",
             "device": "STM32F429VI",
@@ -78,7 +80,9 @@
                     "-pflash", "${workspaceFolder}/build-vscode-buddy/simulator/eeprom_bank1.bin",
                     "-pflash", "${workspaceFolder}/build-vscode-buddy/simulator/eeprom_bank2.bin",
                     "-nodefaults",
-                    "-chardev", "stdio,id=stm32_itm"
+                    "-chardev", "stdio,id=stm32_itm",
+                    "-append", "4x_flash",
+                    "-semihosting-config", "enable=on,target=gdb,arg=firmware ./build-vscode-buddy/firmware.bbf",
                 ],
             },
             "windows": {
@@ -91,7 +95,9 @@
                     "-pflash", "${workspaceFolder}\\build-vscode-buddy\\simulator\\eeprom_bank1.bin",
                     "-pflash", "${workspaceFolder}\\build-vscode-buddy\\simulator\\eeprom_bank2.bin",
                     "-nodefaults",
-                    "-chardev", "stdio,id=stm32_itm"
+                    "-chardev", "stdio,id=stm32_itm",
+                    "-append", "4x_flash",
+                    "-semihosting-config", "enable=on,target=gdb,arg=firmware ./build-vscode-buddy/firmware.bbf",
                 ],
             },
             "linux": {
@@ -104,11 +110,13 @@
                     "-pflash", "${workspaceFolder}/build-vscode-buddy/simulator/eeprom_bank1.bin",
                     "-pflash", "${workspaceFolder}/build-vscode-buddy/simulator/eeprom_bank2.bin",
                     "-nodefaults",
-                    "-chardev", "stdio,id=stm32_itm"
+                    "-chardev", "stdio,id=stm32_itm",
+                    "-append", "4x_flash",
+                    "-semihosting-config", "enable=on,target=gdb,arg=firmware ./build-vscode-buddy/firmware.bbf",
                 ],
             },
             "preLaunchTask": "Prepare Simulator State Directory",
-            "cwd": "${workspaceRoot}",
+            "cwd": "${workspaceFolder}",
             "executable": "${workspaceRoot}/build-vscode-buddy/firmware",
             "request": "launch",
         },

--- a/include/buddy/filesystem_semihosting.h
+++ b/include/buddy/filesystem_semihosting.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#if defined(__cplusplus)
+extern "C" {
+#endif // defined(__cplusplus)
+
+int filesystem_semihosting_init();
+void filesystem_semihosting_deinit();
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif // defined(__cplusplus)

--- a/include/semihosting/semihosting.hpp
+++ b/include/semihosting/semihosting.hpp
@@ -1,0 +1,108 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+namespace semihosting {
+
+enum {
+    SYS_CLOCK = 0x10,
+    SYS_CLOSE = 0x02,
+    SYS_ELAPSED = 0x30,
+    SYS_ERRNO = 0x13,
+    SYS_EXIT = 0x18,
+    SYS_EXIT_EXTENDED = 0x20,
+    SYS_FLEN = 0x0C,
+    SYS_GET_CMDLINE = 0x15,
+    SYS_HEAPINFO = 0x16,
+    SYS_ISERROR = 0x08,
+    SYS_ISTTY = 0x09,
+    SYS_OPEN = 0x01,
+    SYS_READ = 0x06,
+    SYS_READC = 0x07,
+    SYS_REMOVE = 0x0E,
+    SYS_RENAME = 0x0F,
+    SYS_SEEK = 0x0A,
+    SYS_SYSTEM = 0x12,
+    SYS_TICKFREQ = 0x31,
+    SYS_TIME = 0x11,
+    SYS_TMPNAM = 0x0D,
+    SYS_WRITE = 0x05,
+    SYS_WRITEC = 0x03,
+    SYS_WRITE0 = 0x04,
+};
+
+typedef enum {
+    OPEN_MODE_R = 0,    /// read
+    OPEN_MODE_RB = 1,   /// read binary
+    OPEN_MODE_RP = 2,   /// read plus
+    OPEN_MODE_RPB = 3,  /// read plus binary
+    OPEN_MODE_W = 4,    /// write
+    OPEN_MODE_WB = 5,   /// write binary
+    OPEN_MODE_WP = 6,   /// write plus
+    OPEN_MODE_WPB = 7,  /// write plus binary
+    OPEN_MODE_A = 8,    /// append
+    OPEN_MODE_AB = 9,   /// append binary
+    OPEN_MODE_AP = 10,  /// append plus
+    OPEN_MODE_APB = 11, /// append plus binary
+} open_mode_t;
+
+typedef enum {
+    //
+    // hardware exceptions
+    //
+    ADP_Stopped_BranchThroughZero = 0x20000,
+    ADP_Stopped_UndefinedInstr = 0x20001,
+    ADP_Stopped_SoftwareInterrupt = 0x20002,
+    ADP_Stopped_PrefetchAbort = 0x20003,
+    ADP_Stopped_DataAbort = 0x20004,
+    ADP_Stopped_AddressException = 0x20005,
+    ADP_Stopped_IRQ = 0x20006,
+    ADP_Stopped_FIQ = 0x20007,
+    //
+    // software exceptions
+    //
+    ADP_Stopped_BreakPoint = 0x20020,
+    ADP_Stopped_WatchPoint = 0x20021,
+    ADP_Stopped_StepComplete = 0x20022,
+    ADP_Stopped_RunTimeErrorUnknown = 0x20023,
+    ADP_Stopped_InternalError = 0x20024,
+    ADP_Stopped_UserInterruption = 0x20025,
+    ADP_Stopped_ApplicationExit = 0x20026,
+    ADP_Stopped_StackOverflow = 0x20027,
+    ADP_Stopped_DivisionByZero = 0x20028,
+    ADP_Stopped_OSSpecific = 0x20029,
+} exit_reason_t;
+
+typedef struct heapinfo_block {
+    int32_t heap_base;
+    int32_t heap_limit;
+    int32_t stack_base;
+    int32_t stack_limit;
+} heapinfo_block_t;
+
+int32_t sys_clock();
+int32_t sys_close(int32_t handle);
+int32_t sys_elapsed(uint64_t *);
+int32_t sys_errno();
+void sys_exit(int32_t reason);
+void sys_exit(uint32_t reason, int32_t code);
+int32_t sys_flen(int32_t handle);
+int32_t sys_getcmdline(void *buf, uint32_t size);
+int32_t sys_heapinfo(heapinfo_block_t *block);
+int32_t sys_iserror(int32_t status);
+int32_t sys_istty(int32_t handle);
+int32_t sys_open(const char *path, open_mode_t mode, uint32_t path_len);
+int32_t sys_read(int32_t handle, void *buf, uint32_t count);
+int32_t sys_readc();
+int32_t sys_remove(char *path, uint32_t path_len);
+int32_t sys_rename(char *old_path, uint32_t old_path_len, char *new_path, uint32_t new_path_len);
+int32_t sys_seek(int32_t handle, int32_t pos);
+int32_t sys_system(const char *command, uint32_t length);
+int32_t sys_tickfreq();
+int32_t sys_time();
+int32_t sys_tmpnam(void *buf, int32_t target_id, uint32_t buf_size);
+int32_t sys_write(int32_t handle, void *buf, uint32_t count);
+void sys_writec(char ch);
+void sys_write0(char *str);
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ if(BOARD MATCHES "BUDDY")
   add_subdirectory(lang)
   add_subdirectory(marlin_stubs)
   add_subdirectory(syslog)
+  add_subdirectory(semihosting)
 endif()
 
 target_sources(firmware PRIVATE freertos.c freertos_openocd.c)

--- a/src/buddy/CMakeLists.txt
+++ b/src/buddy/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
           filesystem_littlefs_bbf.cpp
           filesystem_littlefs_internal.c
           filesystem_root.c
+          filesystem_semihosting.cpp
           libsysbase_syscalls.c
           littlefs_bbf.cpp
           littlefs_internal.c

--- a/src/buddy/filesystem.c
+++ b/src/buddy/filesystem.c
@@ -4,8 +4,10 @@
 #include "filesystem_fatfs.h"
 #include "filesystem_littlefs_internal.h"
 #include "filesystem_root.h"
+#include "filesystem_semihosting.h"
 #include "libsysbase_syscalls.h"
 
+#include "stm32f4xx.h"
 #include "log.h"
 
 LOG_COMPONENT_DEF(FileSystem, LOG_SEVERITY_INFO);
@@ -16,6 +18,12 @@ void filesystem_init() {
 #endif
     filesystem_fatfs_init();
     filesystem_littlefs_internal_init();
+
+    // if debugger is attached, prepare semihosting fs
+    if (DBGMCU->CR != 0) {
+        filesystem_semihosting_init();
+    }
+
     int device = filesystem_root_init();
 
     if (device != -1) {

--- a/src/buddy/filesystem_semihosting.cpp
+++ b/src/buddy/filesystem_semihosting.cpp
@@ -1,0 +1,165 @@
+#include "filesystem_semihosting.h"
+
+#include <sys/iosupport.h>
+#include <sys/errno.h>
+#include <sys/unistd.h>
+#include <fcntl.h>
+
+#include "filesystem.h"
+#include <semihosting/semihosting.hpp>
+
+typedef struct {
+    int32_t handle;
+    int32_t length;
+    int32_t pos;
+} FIL_EX;
+
+#define PREPARE_FIL_EX(f, fs)              \
+    FIL_EX *f = static_cast<FIL_EX *>(fs); \
+    if (f == NULL) {                       \
+        r->_errno = EBADF;                 \
+        return -1;                         \
+    }
+
+static int open_r(struct _reent *r, void *fileStruct, const char *path, int flags, __attribute__((unused)) int mode);
+static ssize_t read_r(struct _reent *r, void *fileStruct, char *ptr, size_t len);
+static int close_r(struct _reent *r, void *fileStruct);
+static off_t seek_r(struct _reent *r, void *fileStruct, off_t pos, int dir);
+
+static int device = -1;
+
+static const devoptab_t devoptab_semihosting = {
+    .name = "semihosting",
+    .structSize = sizeof(FIL_EX),
+    .open_r = open_r,
+    .close_r = close_r,
+    .read_r = read_r,
+    .seek_r = seek_r,
+};
+
+static int open_r(struct _reent *r, void *fileStruct, const char *path, int flags, __attribute__((unused)) int mode) {
+    PREPARE_FIL_EX(f, fileStruct);
+
+    if (IS_EMPTY(path)) {
+        r->_errno = EINVAL;
+        return -1;
+    }
+
+    path = process_path(path, devoptab_semihosting.name);
+    int result = semihosting::sys_open(path, semihosting::open_mode_t::OPEN_MODE_RB, strlen(path));
+    if (result > 0) {
+        f->pos = 0;
+        f->handle = result;
+        f->length = semihosting::sys_flen(f->handle);
+        if (f->length == -1) {
+            r->_errno = semihosting::sys_errno();
+            return -1;
+        }
+        return 1;
+    } else {
+        r->_errno = semihosting::sys_errno();
+        return -1;
+    }
+}
+
+static ssize_t read_r(struct _reent *r, void *fileStruct, char *ptr, size_t len) {
+    PREPARE_FIL_EX(f, fileStruct);
+
+    if (!ptr) {
+        r->_errno = EINVAL;
+        return -1;
+    }
+
+    if (len == 0) {
+        r->_errno = 0;
+        return 0;
+    }
+
+    int32_t result = semihosting::sys_read(f->handle, ptr, len);
+    int32_t read_bytes = len - result;
+
+    if (result == 0) {
+        // read all requested bytes and not eof
+        f->pos += read_bytes;
+        return len;
+    } else if (result > 0 && result < static_cast<int32_t>(len)) {
+        // partial success
+        f->pos += read_bytes;
+        return read_bytes;
+    } else if (result == static_cast<int32_t>(len)) {
+        // eof, error
+        r->_errno = semihosting::sys_errno();
+        return -1;
+    } else {
+        r->_errno = semihosting::sys_errno();
+        return -1;
+    }
+}
+
+static off_t seek_r(struct _reent *r, void *fileStruct, off_t pos, int dir) {
+    PREPARE_FIL_EX(f, fileStruct);
+    int32_t ofs = -1;
+
+    if (dir == SEEK_SET) {
+        ofs = pos;
+    } else if (dir == SEEK_CUR) {
+        if (pos == 0) {
+            // No seek needed, just return the current position
+            return f->pos;
+        }
+
+        ofs = f->pos + pos;
+    } else if (dir == SEEK_END) {
+        ofs = f->length + pos;
+    }
+
+    if (ofs < 0) {
+        // Cannot seek before the beginning of a file
+        r->_errno = EINVAL;
+        return -1;
+    }
+
+    // It's safe to cast ofs to unsigned long when we are sure it's not negative
+
+    if (ofs > f->length /* && (f->fil.flag & FA_WRITE) == 0 */) {
+        // Unable to seek behind EOF when writing is not enabled
+        r->_errno = EINVAL;
+        return -1;
+    }
+
+    if (ofs == f->pos) {
+        return ofs;
+    }
+
+    int result = semihosting::sys_seek(f->handle, ofs);
+    if (result == 0) {
+        f->pos = ofs;
+        return ofs;
+    } else {
+        r->_errno = semihosting::sys_errno();
+        return -1;
+    }
+}
+
+static int close_r(struct _reent *r, void *fileStruct) {
+    PREPARE_FIL_EX(f, fileStruct);
+
+    int result = semihosting::sys_close(f->handle);
+    r->_errno = semihosting::sys_errno();
+    return result;
+}
+
+int filesystem_semihosting_init() {
+    if (device != -1) {
+        return device;
+    }
+    device = AddDevice(&devoptab_semihosting);
+    return device;
+}
+
+void filesystem_semihosting_deinit() {
+    if (device != -1) {
+        RemoveDevice(devoptab_semihosting.name);
+        device = -1;
+    }
+}

--- a/src/buddy/littlefs_bbf.cpp
+++ b/src/buddy/littlefs_bbf.cpp
@@ -1,31 +1,156 @@
 #include "littlefs_bbf.h"
+
+#include <unistd.h>
+#include <optional>
+#include <errno.h>
+
 #include "bbf.hpp"
 #include "log.h"
+#include "scratch_buffer.hpp"
+#include "bsod.h"
 
 LOG_COMPONENT_REF(FileSystem);
 
 static lfs_t lfs;
 
+struct LruCache {
+    struct Slot {
+        static constexpr lfs_block_t INVALID_BLOCK_NR = -1;
+
+        lfs_block_t block_nr;
+        Slot *next;
+        Slot *previous;
+        uint8_t data[];
+    };
+
+    int block_size;
+    int used_space;
+    Slot *head;
+    uint8_t *buffer;
+    int buffer_size;
+
+    LruCache(uint8_t *buffer, int buffer_size, int block_size)
+        : block_size(block_size)
+        , used_space(0)
+        , head(nullptr)
+        , buffer(buffer)
+        , buffer_size(buffer_size) {
+    }
+
+    int slot_alloc_size() {
+        return sizeof(Slot) + block_size;
+    }
+
+    Slot &alloc() {
+        Slot *slot;
+        if (used_space + slot_alloc_size() < buffer_size) {
+            slot = reinterpret_cast<Slot *>(buffer + used_space);
+            used_space += slot_alloc_size();
+        } else {
+            Slot *current = head;
+            if (current == nullptr) {
+                fatal_error("could not allocate any block", "littlebbf");
+            }
+            while (current->next) {
+                current = current->next;
+            }
+            unchain(current);
+            slot = current;
+        }
+
+        slot->block_nr = Slot::INVALID_BLOCK_NR;
+        slot->next = nullptr;
+        slot->previous = nullptr;
+        return *slot;
+    }
+
+    std::optional<Slot *> get(lfs_block_t block_nr) {
+        Slot *current = head;
+        while (current) {
+            if (current->block_nr == block_nr) {
+                return current;
+            }
+            current = current->next;
+        }
+        return std::nullopt;
+    }
+
+    bool has(lfs_block_t block_nr) {
+        return get(block_nr).has_value();
+    }
+
+    void move_front(Slot *slot) {
+        unchain(slot);
+        slot->next = head;
+        if (head) {
+            head->previous = slot;
+        }
+        head = slot;
+    }
+
+    void unchain(Slot *slot) {
+        if (head == slot) {
+            head = slot->next;
+        }
+
+        if (slot->previous) {
+            slot->previous->next = slot->next;
+        }
+        if (slot->next) {
+            slot->next->previous = slot->previous;
+        }
+        slot->next = nullptr;
+        slot->previous = nullptr;
+    }
+};
+
 typedef struct {
+    struct lfs_config littlefs_config;
     FILE *bbf;
     long data_offset;
+    std::optional<buddy::scratch_buffer::Ownership> scratch_buffer;
+    std::optional<LruCache> block_cache;
 } bbf_lfs_context_t;
 
 static bbf_lfs_context_t bbf_context;
 
-// configuration of the filesystem is provided by this struct
-static struct lfs_config littlefs_config;
-static int read(const struct lfs_config *c, lfs_block_t block,
-    lfs_off_t off, void *buffer, lfs_size_t size) {
+// We can't use the standard read() directly function, as that is currently
+// shadowed by lwip_read :(
+extern "C" _ssize_t _read_r(struct _reent *r, int fileDesc, void *ptr, size_t len);
+#define read(fd, ptr, len) _read_r(_REENT, fd, ptr, len)
 
-    long offset = bbf_context.data_offset + block * c->block_size + off;
-    if (fseek(bbf_context.bbf, offset, SEEK_SET) != 0) {
-        return LFS_ERR_IO;
+static int _read(const struct lfs_config *c, lfs_block_t block,
+    lfs_off_t off, void *out_buffer, lfs_size_t size) {
+
+    LruCache &cache = bbf_context.block_cache.value();
+
+    if (bbf_context.block_cache.has_value() == false) {
+        fatal_error("init failed", "littlebbf");
     }
 
-    if (fread(buffer, 1, size, bbf_context.bbf) != size) {
-        return LFS_ERR_IO;
+    LruCache::Slot *slot;
+    if (!cache.has(block)) {
+        slot = &cache.alloc();
+
+        long block_offset = bbf_context.data_offset + block * c->block_size;
+        int retval = fseek(bbf_context.bbf, block_offset, SEEK_SET);
+        if (retval != 0) {
+            log_error(FileSystem, "BBF: fseek to block %i failed with retval %i, errno %i", block_offset, retval, errno);
+            return LFS_ERR_IO;
+        }
+        retval = read(fileno(bbf_context.bbf), slot->data, c->block_size);
+        if (static_cast<lfs_size_t>(retval) != c->block_size) {
+            log_error(FileSystem, "BBF: read for block %i failed with retval %i, errno %i", block_offset, retval, errno);
+            return LFS_ERR_IO;
+        }
+
+        slot->block_nr = block;
+    } else {
+        slot = cache.get(block).value();
     }
+
+    memcpy(out_buffer, slot->data + off, size);
+    cache.move_front(slot);
 
     return 0;
 }
@@ -67,11 +192,15 @@ lfs_t *littlefs_bbf_init(FILE *bbf, uint8_t bbf_tlv_entry) {
 
     bbf_context.bbf = bbf;
     bbf_context.data_offset = offset;
+    bbf_context.scratch_buffer.emplace();
+    bbf_context.scratch_buffer->acquire(/*wait=*/true);
+    bbf_context.block_cache.emplace(bbf_context.scratch_buffer->get().buffer, bbf_context.scratch_buffer->get().size(), block_size);
 
+    struct lfs_config &littlefs_config = bbf_context.littlefs_config;
     memset(&littlefs_config, 0, sizeof(littlefs_config));
     littlefs_config.block_count = block_count;
     littlefs_config.block_size = block_size;
-    littlefs_config.read = read;
+    littlefs_config.read = _read;
 
     littlefs_config.read_size = 1;
     littlefs_config.prog_size = 1;
@@ -88,14 +217,16 @@ lfs_t *littlefs_bbf_init(FILE *bbf, uint8_t bbf_tlv_entry) {
     return &lfs;
 }
 
-void littlefs_bbf_deinit(lfs_t *lfs) {
-    lfs_unmount(lfs);
-}
-
 struct lfs_config *littlefs_internal_config_get() {
-    if (littlefs_config.block_count != 0) {
-        return &littlefs_config;
+    if (bbf_context.littlefs_config.block_count != 0) {
+        return &bbf_context.littlefs_config;
     } else {
         return NULL;
     }
+}
+
+void littlefs_bbf_deinit(lfs_t *lfs) {
+    bbf_context.block_cache = std::nullopt;
+    bbf_context.scratch_buffer->release();
+    lfs_unmount(lfs);
 }

--- a/src/buddy/littlefs_internal.c
+++ b/src/buddy/littlefs_internal.c
@@ -42,7 +42,7 @@ static struct lfs_config littlefs_config = {
     .prog_size = 1,
     .block_size = BLOCK_SIZE,
     .block_count = 0, // to be initialized at runtime
-    .cache_size = 16,
+    .cache_size = 128,
     .lookahead_size = 16,
     .block_cycles = 500,
 };

--- a/src/device/stm32f4/linker/stm32f407vg.ld
+++ b/src/device/stm32f4/linker/stm32f407vg.ld
@@ -150,6 +150,7 @@ SECTIONS
   {
     . = ALIGN(4);
     _sccmram = .;       /* create a global symbol at ccmram start */
+    *(.ccmram_beginning)
     *(.ccmram)
     *(.ccmram*)
 

--- a/src/device/stm32f4/linker/stm32f407vg_boot.ld
+++ b/src/device/stm32f4/linker/stm32f407vg_boot.ld
@@ -150,6 +150,7 @@ SECTIONS
   {
     . = ALIGN(4);
     _sccmram = .;       /* create a global symbol at ccmram start */
+    *(.ccmram_beginning)
     *(.ccmram)
     *(.ccmram*)
 

--- a/src/device/stm32f4/linker/stm32f42x.ld
+++ b/src/device/stm32f4/linker/stm32f42x.ld
@@ -157,6 +157,7 @@ SECTIONS
   {
     . = ALIGN(4);
     _sccmram = .;       /* create a global symbol at ccmram start */
+    *(.ccmram_beginning)
     *(.ccmram)
     *(.ccmram*)
 

--- a/src/device/stm32f4/linker/stm32f42x_boot.ld
+++ b/src/device/stm32f4/linker/stm32f42x_boot.ld
@@ -157,6 +157,7 @@ SECTIONS
   {
     . = ALIGN(4);
     _sccmram = .;       /* create a global symbol at ccmram start */
+    *(.ccmram_beginning)
     *(.ccmram)
     *(.ccmram*)
 

--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -52,7 +52,7 @@ target_include_directories(firmware PUBLIC "${resources_include_dir}")
 # Standard Resources Image
 #
 
-add_lfs_image(resources-image BLOCK_SIZE 256 BLOCK_COUNT 3000)
+add_lfs_image(resources-image BLOCK_SIZE 4096 BLOCK_COUNT 256)
 
 # /esp directory
 add_resource("esp/uart_wifi.bin" "/esp/uart_wifi.bin")
@@ -96,7 +96,7 @@ add_header_with_revision(standard resources-image)
 #
 if(BOOTLOADER_UPDATE)
 
-  add_lfs_image(resources-bootloader-image BLOCK_SIZE 256 BLOCK_COUNT 1000)
+  add_lfs_image(resources-bootloader-image BLOCK_SIZE 4096 BLOCK_COUNT 64)
 
   get_dependency_directory("bootloader-${BOOTLOADER_VARIANT}" bootloader_dir)
   get_dependency_version("bootloader-${BOOTLOADER_VARIANT}" bootloader_version_str)

--- a/src/resources/bootstrap.cpp
+++ b/src/resources/bootstrap.cpp
@@ -1,16 +1,20 @@
+#include <stdio.h>
 #include <dirent.h>
 #include <memory>
 #include <string.h>
 #include <optional>
 #include <cerrno>
 #include <sys/stat.h>
+#include <sys/iosupport.h>
 
 #include "bsod.h"
 #include "bbf.hpp"
 #include "log.h"
 #include "timing.h"
 #include "cmsis_os.h"
+#include "stm32f4xx.h"
 
+#include "semihosting/semihosting.hpp"
 #include "resources/bootstrap.hpp"
 #include "resources/hash.hpp"
 
@@ -175,22 +179,16 @@ static bool has_bbf_suffix(const char *fname) {
     return strcasecmp(dot, ".bbf") == 0;
 }
 
-static bool is_relevant_bbf_for_bootstrap(const char *fname, const buddy::resources::Revision &revision, buddy::bbf::TLVType tlv_entry) {
-    std::unique_ptr<FILE, FILEDeleter> bbf(fopen(fname, "rb"));
-    if (bbf.get() == nullptr) {
-        log_error(Resources, "Failed to open %s", fname);
-        return false;
-    }
-
+static bool is_relevant_bbf_for_bootstrap(FILE *bbf, const char *path, const buddy::resources::Revision &revision, buddy::bbf::TLVType tlv_entry) {
     uint32_t hash_len;
-    if (!buddy::bbf::seek_to_tlv_entry(bbf.get(), tlv_entry, hash_len)) {
-        log_error(Resources, "Failed to seek to resources revision %s", fname);
+    if (!buddy::bbf::seek_to_tlv_entry(bbf, tlv_entry, hash_len)) {
+        log_error(Resources, "Failed to seek to resources revision %s", path);
         return false;
     }
 
     buddy::resources::Revision bbf_revision;
-    if (fread(&bbf_revision.hash[0], 1, revision.hash.size(), bbf.get()) != hash_len) {
-        log_error(Resources, "Failed to read resources revision %s", fname);
+    if (fread(&bbf_revision.hash[0], 1, revision.hash.size(), bbf) != hash_len) {
+        log_error(Resources, "Failed to read resources revision %s", path);
         return false;
     }
 
@@ -384,6 +382,56 @@ static bool copy_resources_directory(Path &source, Path &target, BootstrapProgre
     return true;
 }
 
+static bool bootstrap_over_debugger_possible() {
+    // debugger flag is located at the beginning of the CCMRAM
+    // to enable bootstrap over debugger, the debugger has to set the flag to 0xABCDABCD
+    static uint32_t debugger_flag __attribute__((__section__(".ccmram_beginning"), used));
+
+    bool flag_set = debugger_flag == 0xABCDABCD;
+    bool debugger_connected = DBGMCU->CR != 0;
+
+    return debugger_connected && flag_set;
+}
+
+static FILE *open_bbf_over_debugger(Path &path_buffer, const buddy::resources::Revision &revision, buddy::bbf::TLVType &bbf_entry) {
+    // find the path first
+    auto retval = semihosting::sys_getcmdline(path_buffer.get_buffer(), path_buffer.maximum_length());
+    if (retval != 0) {
+        return nullptr;
+    }
+    const char *first_space = strchr(path_buffer.get(), ' ');
+    if (first_space == nullptr) {
+        return nullptr;
+    }
+    const char *filepath = first_space + 1;
+    log_warning(Resources, "BBF over debugger filename: %s", filepath);
+
+    // open the bbf file
+    // we have to keep this within the critical section, as
+    // setDefaultDevice does not work per-task and we need to make
+    // sure someone else does not set it to something different before
+    // we open the file
+    taskENTER_CRITICAL();
+    setDefaultDevice(FindDevice("/semihosting"));
+    FILE *bbf = fopen(filepath, "rb");
+    taskEXIT_CRITICAL();
+    if (bbf == nullptr) {
+        return nullptr;
+    }
+
+    if (is_relevant_bbf_for_bootstrap(bbf, filepath, revision, buddy::bbf::TLVType::RESOURCES_IMAGE_HASH)) {
+        log_info(Resources, "Found suitable bbf provided by debugger: %s", filepath);
+        bbf_entry = buddy::bbf::TLVType::RESOURCES_IMAGE;
+        return bbf;
+    } else if (is_relevant_bbf_for_bootstrap(bbf, filepath, revision, buddy::bbf::TLVType::RESOURCES_BOOTLOADER_IMAGE_HASH)) {
+        log_info(Resources, "Found suitable bbf provided by debugger: %s", filepath);
+        bbf_entry = buddy::bbf::TLVType::RESOURCES_BOOTLOADER_IMAGE;
+        return bbf;
+    } else {
+        return nullptr;
+    }
+}
+
 static bool find_suitable_bbf_file(const buddy::resources::Revision &revision, Path &bbf, buddy::bbf::TLVType &bbf_entry) {
     log_debug(Resources, "Searching for a bbf...");
 
@@ -406,13 +454,20 @@ static bool find_suitable_bbf_file(const buddy::resources::Revision &revision, P
         // create full path
         bbf.set("/usb");
         bbf.push(entry->d_name);
+        // open the bbf
+        std::unique_ptr<FILE, FILEDeleter> bbf_file(fopen(bbf.get(), "rb"));
+        if (bbf.get() == nullptr) {
+            log_error(Resources, "Failed to open %s", bbf.get());
+            continue;
+        }
+
         // check if the file contains required resources
-        if (is_relevant_bbf_for_bootstrap(bbf.get(), revision, buddy::bbf::TLVType::RESOURCES_IMAGE_HASH)) {
+        if (is_relevant_bbf_for_bootstrap(bbf_file.get(), bbf.get(), revision, buddy::bbf::TLVType::RESOURCES_IMAGE_HASH)) {
             log_info(Resources, "Found suitable bbf for bootstraping: %s", bbf.get());
             bbf_found = true;
             bbf_entry = buddy::bbf::TLVType::RESOURCES_IMAGE;
             break;
-        } else if (is_relevant_bbf_for_bootstrap(bbf.get(), revision, buddy::bbf::TLVType::RESOURCES_BOOTLOADER_IMAGE_HASH)) {
+        } else if (is_relevant_bbf_for_bootstrap(bbf_file.get(), bbf.get(), revision, buddy::bbf::TLVType::RESOURCES_BOOTLOADER_IMAGE_HASH)) {
             log_info(Resources, "Found suitable bbf for bootstraping: %s", bbf.get());
             bbf_found = true;
             bbf_entry = buddy::bbf::TLVType::RESOURCES_BOOTLOADER_IMAGE;
@@ -434,21 +489,29 @@ static bool find_suitable_bbf_file(const buddy::resources::Revision &revision, P
 static bool do_bootstrap(const buddy::resources::Revision &revision, buddy::resources::ProgressHook progress_hook) {
     BootstrapProgressReporter reporter(progress_hook, BootstrapStage::LookingForBbf);
     Path source_path("/");
+    std::unique_ptr<FILE, FILEDeleter> bbf;
+    buddy::bbf::TLVType bbf_entry = buddy::bbf::TLVType::RESOURCES_IMAGE;
 
     reporter.report(); // initial report
-    buddy::bbf::TLVType bbf_entry;
-    if (!find_suitable_bbf_file(revision, source_path, bbf_entry)) {
+
+    // try to find required BBF on attached USB drive
+    if (find_suitable_bbf_file(revision, source_path, bbf_entry)) {
+        bbf.reset(fopen(source_path.get(), "rb"));
+    }
+
+    // try to open BBF supplied over semihosting (connected debugger)
+    if (bbf.get() == nullptr && bootstrap_over_debugger_possible()) {
+        bbf.reset(open_bbf_over_debugger(source_path, revision, bbf_entry));
+    }
+
+    if (bbf.get() == nullptr) {
         return false;
     }
 
     reporter.update_stage(BootstrapStage::PreparingBootstrap);
 
-    // open the bbf
-    std::unique_ptr<FILE, FILEDeleter> bbf(fopen(source_path.get(), "rb"));
-    if (bbf.get() == nullptr) {
-        log_warning(Resources, "Failed to open %s", source_path.get());
-        return false;
-    }
+    // use a small buffer for the BBF
+    setvbuf(bbf.get(), NULL, _IOFBF, 32);
 
     // mount the filesystem stored in the bbf
     ScopedFileSystemLittlefsBBF scoped_bbf_mount(bbf.get(), bbf_entry);

--- a/src/resources/fileutils.hpp
+++ b/src/resources/fileutils.hpp
@@ -70,4 +70,12 @@ public:
         }
         *slash = 0;
     }
+
+    char *get_buffer() {
+        return path;
+    }
+
+    static int maximum_length() {
+        return sizeof(path);
+    }
 };

--- a/src/semihosting/CMakeLists.txt
+++ b/src/semihosting/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_sources(firmware PRIVATE semihosting.cpp)

--- a/src/semihosting/semihosting.cpp
+++ b/src/semihosting/semihosting.cpp
@@ -1,0 +1,166 @@
+#include <semihosting/semihosting.hpp>
+
+namespace semihosting {
+
+static inline int32_t semihosting_call(int32_t R0, int32_t R1) {
+    int32_t rc;
+    __asm__ volatile(
+        "mov r0, %1\n" /* move int R0 to register r0 */
+        "mov r1, %2\n" /* move int R1 to register r1 */
+        "bkpt #0xAB\n" /* thumb mode semihosting call */
+        "mov %0, r0"   /* move register r0 to int rc */
+        : "=r"(rc)
+        : "r"(R0), "r"(R1)
+        : "r0", "r1", "ip", "lr", "memory", "cc");
+    return rc;
+}
+
+int32_t sys_clock() {
+    return semihosting_call(SYS_CLOCK, 0);
+}
+
+int32_t sys_close(int32_t handle) {
+    return semihosting_call(SYS_CLOSE, (int32_t)&handle);
+}
+
+int32_t sys_elapsed(uint64_t *ticks) {
+    return semihosting_call(SYS_ELAPSED, (int32_t)ticks);
+}
+
+int32_t sys_errno() {
+    return semihosting_call(SYS_ERRNO, 0);
+}
+
+void sys_exit(int32_t reason) {
+    semihosting_call(SYS_EXIT, reason);
+    for (;;)
+        ;
+    return;
+}
+
+void sys_exit(uint32_t reason, int32_t code) {
+    uint32_t args[] = {
+        (uint32_t)reason,
+        (uint32_t)code,
+    };
+    semihosting_call(SYS_EXIT_EXTENDED, (int32_t)args);
+    for (;;)
+        ;
+    return;
+}
+
+int32_t sys_flen(int32_t handle) {
+    return semihosting_call(SYS_FLEN, (int32_t)&handle);
+}
+
+int32_t sys_getcmdline(void *buf, uint32_t size) {
+    uint32_t args[] = {
+        (uint32_t)buf,
+        (uint32_t)size,
+    };
+    return semihosting_call(SYS_GET_CMDLINE, (int32_t)args);
+}
+
+int32_t sys_heapinfo(heapinfo_block_t *block) {
+    return semihosting_call(SYS_HEAPINFO, (int32_t)block);
+}
+
+int32_t sys_iserror(int32_t status) {
+    return semihosting_call(SYS_ISERROR, (int32_t)&status);
+}
+
+int32_t sys_istty(int32_t handle) {
+    return semihosting_call(SYS_ISTTY, (int32_t)&handle);
+}
+
+int32_t sys_open(const char *path, open_mode_t mode, uint32_t path_len) {
+    uint32_t args[] = {
+        (uint32_t)path,
+        (uint32_t)mode,
+        (uint32_t)path_len,
+    };
+    return semihosting_call(SYS_OPEN, (int32_t)args);
+}
+
+int32_t sys_read(int32_t handle, void *buf, uint32_t count) {
+    uint32_t args[] = {
+        (uint32_t)handle,
+        (uint32_t)buf,
+        (uint32_t)count,
+    };
+    return semihosting_call(SYS_READ, (int32_t)args);
+}
+
+int32_t sys_readc() {
+    return semihosting_call(SYS_READC, 0);
+}
+
+int32_t sys_remove(char *path, uint32_t path_len) {
+    uint32_t args[] = {
+        (uint32_t)path,
+        (uint32_t)path_len,
+    };
+    return semihosting_call(SYS_REMOVE, (int32_t)args);
+}
+
+int32_t sys_rename(char *old_path, uint32_t old_path_len, char *new_path, uint32_t new_path_len) {
+    uint32_t args[] = {
+        (uint32_t)old_path,
+        (uint32_t)old_path_len,
+        (uint32_t)new_path,
+        (uint32_t)new_path_len,
+    };
+    return semihosting_call(SYS_RENAME, (int32_t)args);
+}
+
+int32_t sys_seek(int32_t handle, int32_t pos) {
+    uint32_t args[] = {
+        (uint32_t)handle,
+        (uint32_t)pos,
+    };
+    return semihosting_call(SYS_SEEK, (int32_t)args);
+}
+
+int32_t sys_system(const char *command, uint32_t length) {
+    uint32_t args[] = {
+        (uint32_t)command,
+        (uint32_t)length,
+    };
+    return semihosting_call(SYS_SYSTEM, (int32_t)args);
+}
+
+int32_t sys_tickfreq() {
+    return semihosting_call(SYS_TICKFREQ, 0);
+}
+
+int32_t sys_time() {
+    return semihosting_call(SYS_TIME, 0);
+}
+
+int32_t sys_tmpnam(void *buf, int32_t target_id, uint32_t buf_size) {
+    uint32_t args[] = {
+        (uint32_t)buf,
+        (uint32_t)target_id,
+        (uint32_t)buf_size,
+    };
+    return semihosting_call(SYS_TMPNAM, (int32_t)args);
+}
+
+int32_t sys_write(int32_t handle, void *buf, uint32_t count) {
+    uint32_t args[] = {
+        (uint32_t)handle,
+        (uint32_t)buf,
+        (uint32_t)count,
+    };
+    return semihosting_call(SYS_WRITE, (int32_t)args);
+}
+
+void sys_writec(char ch) {
+    semihosting_call(SYS_WRITEC, (int32_t)&ch);
+}
+
+void sys_write0(char *str) {
+    semihosting_call(SYS_WRITE0, (int32_t)str);
+}
+
+}

--- a/utils/debug/20_board_buddy.cfg
+++ b/utils/debug/20_board_buddy.cfg
@@ -27,3 +27,16 @@ $_TARGETNAME configure -event reset-start {
 $BUDDY_TARGET configure -event gdb-detach {
     shutdown
 }
+
+$BUDDY_TARGET configure -event reset-init {
+    global bbf_over_debugger_path
+    if {[info exists bbf_over_debugger_path]} {
+        puts "Enabling BBF over debugger with path ${bbf_over_debugger_path}"
+        arm semihosting enable
+        arm semihosting_cmdline firmware ${bbf_over_debugger_path}
+        mww 0x10000000 0xABCDABCD
+    } else {
+        puts "BBF over debugger not enabled. Set bbf_over_debugger_path variable to enable it."
+        mww 0x10000000 0x0
+    }
+}


### PR DESCRIPTION
- The firmware now automatically discovers, whether it has a debugger able to serve the required BBF connected; if so and no viable BBF is found on USB drive, it uses the BBF served over the debugger.
- It optimizes the bootstrap procedure itself. On MINI, it now takes about 20 seconds only (over USB).