### PR TITLE
Username into GUI + ApiKey is now password

### DIFF
--- a/lib/WUI/nhttp/req_parser.cpp
+++ b/lib/WUI/nhttp/req_parser.cpp
@@ -5,6 +5,7 @@
 #include <timing.h>
 #include <inttypes.h> // PRI* macros (not available in <cinttypes>)
 #include "random.h"
+#include "../wui_api.h"
 
 #include <mbedtls/md5.h>
 
@@ -367,7 +368,7 @@ namespace {
 bool RequestParser::check_digest_auth(uint64_t nonce_to_use) const {
     if (auto digest_params = get_if<DigestAuthParams>(&auth_status)) {
 
-        auto hash_a1 = md5_hash("user:", AUTH_REALM, ":", server->get_api_key());
+        auto hash_a1 = md5_hash(PRUSA_LINK_USERNAME, ":", AUTH_REALM, ":", server->get_api_key());
         auto hash_a2 = md5_hash(to_str(method), ":", uri());
 
         char ha1[MD5_HEX_SIZE];

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -17,6 +17,8 @@
 #include "netif_settings.h"
 #include "marlin_vars.h"
 
+#define PRUSA_LINK_USERNAME "maker"
+
 #define FW_VER_STR_LEN    32  // length of full Firmware version string
 #define MAC_ADDR_STR_LEN  18  // length of mac address string ("MM:MM:MM:SS:SS:SS" + 0)
 #define SER_NUM_STR_LEN   16  // length of serial number string

--- a/src/gui/screen_prusa_link.cpp
+++ b/src/gui/screen_prusa_link.cpp
@@ -11,14 +11,14 @@
 
 #include "wui_api.h"
 
-#define api_key_format "Current Api Key\n    %s"
+#define api_key_format "Username\n    " PRUSA_LINK_USERNAME "\nCurrent Password\n    %s"
 static constexpr size_t API_KEY_STR_LENGTH = PL_API_KEY_SIZE + sizeof(api_key_format) - sizeof("%s"); // don't need space for '%s' and '\0' since PL_API_KEY_SIZE contains '\0' too
 typedef char api_key_str_t[API_KEY_STR_LENGTH];
 
 // ----------------------------------------------------------------
 // GUI Prusa Link X-Api_Key regenerate
 class MI_PL_REGENERATE_API_KEY : public WI_LABEL_t {
-    constexpr static const char *const label = N_("Generate Api key");
+    constexpr static const char *const label = N_("Generate Password");
 
 public:
     MI_PL_REGENERATE_API_KEY()

--- a/tests/unit/lib/WUI/nhttp/server_tests.cpp
+++ b/tests/unit/lib/WUI/nhttp/server_tests.cpp
@@ -466,7 +466,7 @@ TEST_CASE("Authenticated Digest") {
     const size_t client_conn = server.new_conn();
     REQUIRE(client_conn == 1);
 
-    string request = digest_auth_header("GET", "user", "aaaaaaaa00000000", "/secret.html", "98d83e2a0dfd67eb0c3a13bae4dff1c7");
+    string request = digest_auth_header("GET", "maker", "aaaaaaaa00000000", "/secret.html", "0cbf0ac5ca4c879c35a3b91430214a47");
     INFO(request);
     server.send(client_conn, request);
     const auto response = server.recv_all(client_conn);
@@ -488,7 +488,7 @@ TEST_CASE("Not authenticated Digest") {
     }
 
     SECTION("Invalid nonce") {
-        string request = digest_auth_header("GET", "user", "not a valid nonce", "/secret.html", "1dd8be56e6996b274258d7412e671e5f");
+        string request = digest_auth_header("GET", "maker", "not a valid nonce", "/secret.html", "1dd8be56e6996b274258d7412e671e5f");
         server.send(client_conn, request);
     }
 
@@ -515,7 +515,7 @@ TEST_CASE("Digest stale nonce") {
 
     SECTION("Real stale nonce") {
         set_time(0x0000000f);
-        string request = digest_auth_header("GET", "user", "aaaaaaaa00000000", "/secret.html", "98d83e2a0dfd67eb0c3a13bae4dff1c7");
+        string request = digest_auth_header("GET", "maker", "aaaaaaaa00000000", "/secret.html", "0cbf0ac5ca4c879c35a3b91430214a47");
         server.send(client_conn, request);
     }
 
@@ -523,7 +523,7 @@ TEST_CASE("Digest stale nonce") {
     // In this case, we don't want to bother the client with unnecessary login prompting
     // so we say its stale.
     SECTION("Wrong nonce, correct user and password") {
-        string request = digest_auth_header("GET", "user", "dcd98b7102dd2f0e", "/secret.html", "491a37d687a1604d170aeaf12f7a67ec");
+        string request = digest_auth_header("GET", "maker", "dcd98b7102dd2f0e", "/secret.html", "285b9c363d25d31c5867bca2bd4121af");
         server.send(client_conn, request);
     }
 


### PR DESCRIPTION
Since we have md5 digest authentication working, we have to inform user about the username to use to authenticate and ApiKey now goes into the password box so rename it in GUI.