### PR TITLE
Add the green items back

### DIFF
--- a/src/guiapi/include/GuiDefaults.hpp
+++ b/src/guiapi/include/GuiDefaults.hpp
@@ -111,7 +111,7 @@ struct GuiDefaults {
     static constexpr bool MenuSwitchHasBrackets = false; // draw brackets around switch values in menus
     static constexpr bool MenuSpinHasUnits = false;      // draw units behind spin
 #endif                                                   // USE_<display>
-    static constexpr bool ShowDevelopmentTools = false;  // Show menu items for development
+    static constexpr bool ShowDevelopmentTools = true;   // Show menu items for development
 
     // New menu feature settings
 #if defined(USE_ST7789) || defined(USE_MOCK_DISPLAY)


### PR DESCRIPTION
We wanted to turn them off only in release branches and the exact opposite happened, they got turned off only in master. So I turn them back on.