### PR TITLE
Connection timeout

### DIFF
--- a/src/common/crash_dump/crash_dump_distribute.cpp
+++ b/src/common/crash_dump/crash_dump_distribute.cpp
@@ -11,6 +11,8 @@ LOG_COMPONENT_DEF(CrashDump, LOG_SEVERITY_INFO);
 
 namespace crash_dump {
 
+inline constexpr uint8_t socket_timeout_s { 6 };
+
 bool escape_url_string(std::span<char> escaped_url_string, const std::array<char, url_buff_size> &url_buff) {
     // escaping of special characters, should probably be done elswhere (somewhere that handles the url string)
     size_t cur_written { 0 };
@@ -51,7 +53,7 @@ void create_url_string(std::array<char, url_buff_size> &url_buff, std::array<cha
 }
 
 bool upload_dump_to_server(http::Request &req) {
-    http::SocketConnectionFactory conn_factory(server, port);
+    http::SocketConnectionFactory conn_factory(server, port, socket_timeout_s);
     http::HttpClient http(conn_factory);
 
     if (auto result = http.send(req); std::holds_alternative<http::Error>(result)) {

--- a/src/common/http/CMakeLists.txt
+++ b/src/common/http/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(
   firmware
-  PRIVATE httpc.cpp
+  PRIVATE connection.cpp
+          httpc.cpp
           os_porting.cpp
           post_file_request.cpp
           resp_parser.cpp

--- a/src/common/http/connection.cpp
+++ b/src/common/http/connection.cpp
@@ -1,0 +1,10 @@
+#include "connection.hpp"
+
+namespace http {
+
+Connection::Connection(uint8_t timeout_s)
+    : timeout_s(timeout_s) {}
+
+uint8_t Connection::get_timeout_s() const { return timeout_s; }
+
+}

--- a/src/common/http/connection.hpp
+++ b/src/common/http/connection.hpp
@@ -7,14 +7,18 @@
 
 namespace http {
 
-constexpr uint8_t SOCKET_TIMEOUT_SEC = 3;
-
 class Connection {
 public:
+    Connection(uint8_t timeout_s);
     virtual std::optional<Error> connection(const char *host, uint16_t port) = 0;
     virtual std::variant<size_t, Error> rx(uint8_t *buffer, size_t len) = 0;
     virtual std::variant<size_t, Error> tx(const uint8_t *buffer, size_t len) = 0;
     virtual ~Connection() = default;
+
+    uint8_t get_timeout_s() const;
+
+private:
+    uint8_t timeout_s;
 };
 
 }

--- a/src/common/http/httpc.cpp
+++ b/src/common/http/httpc.cpp
@@ -66,7 +66,7 @@ namespace {
                 // FIXME: Conceptually, how do we handle timeouts? This is timeout
                 // for a single write. We may write multiple times per request.
                 // Also, what is the timeout in the tx?
-                if ((epoch_time + SOCKET_TIMEOUT_SEC * 1000) < ticks_ms()) {
+                if ((epoch_time + conn->get_timeout_s() * 1000) < ticks_ms()) {
                     break;
                 }
             }

--- a/src/common/http/socket.cpp
+++ b/src/common/http/socket.cpp
@@ -39,7 +39,8 @@ public:
 
 namespace http {
 
-socket_con::socket_con() {
+socket_con::socket_con(uint8_t timeout_s)
+    : Connection(timeout_s) {
     fd = -1;
     connected = false;
     if ((fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1) {
@@ -59,7 +60,7 @@ socket_con::~socket_con() {
 
 std::optional<Error> socket_con::connection(const char *host, uint16_t port) {
 
-    const struct timeval timeout = { SOCKET_TIMEOUT_SEC, 0 };
+    const struct timeval timeout = { get_timeout_s(), 0 };
     if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) == -1) {
         return Error::SetSockOpt;
     }

--- a/src/common/http/socket.hpp
+++ b/src/common/http/socket.hpp
@@ -12,7 +12,7 @@ private:
     bool connected;
 
 public:
-    socket_con();
+    socket_con(uint8_t timeout_s);
     ~socket_con();
     socket_con(const socket_con &other);
     socket_con(socket_con &&other);

--- a/src/common/http/socket_connection_factory.cpp
+++ b/src/common/http/socket_connection_factory.cpp
@@ -1,9 +1,10 @@
 #include "socket_connection_factory.hpp"
 
 namespace http {
-SocketConnectionFactory::SocketConnectionFactory(const char *host, uint16_t port)
+SocketConnectionFactory::SocketConnectionFactory(const char *host, uint16_t port, uint8_t timeout_s)
     : hostname(host)
-    , port(port) {
+    , port(port)
+    , con(timeout_s) {
 }
 
 std::variant<Connection *, Error> SocketConnectionFactory::connection() {

--- a/src/common/http/socket_connection_factory.hpp
+++ b/src/common/http/socket_connection_factory.hpp
@@ -5,7 +5,7 @@
 namespace http {
 class SocketConnectionFactory : public ConnectionFactory {
 public:
-    SocketConnectionFactory(const char *host, uint16_t port);
+    SocketConnectionFactory(const char *host, uint16_t port, uint8_t timeout_s);
     virtual ~SocketConnectionFactory() = default;
 
 protected:

--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -37,6 +37,8 @@ LOG_COMPONENT_DEF(connect, LOG_SEVERITY_DEBUG);
 
 namespace connect_client {
 
+inline constexpr uint8_t SOCKET_TIMEOUT_SEC = 3;
+
 namespace {
 
     std::atomic<OnlineStatus> last_known_status = OnlineStatus::Unknown;
@@ -289,10 +291,10 @@ optional<OnlineStatus> connect::communicate(CachedFactory &conn_factory) {
     conn_factory.refresh(config.host, [&](Cache &cache) {
         Connection *connection;
         if (config.tls) {
-            cache.emplace<tls>();
+            cache.emplace<tls>(SOCKET_TIMEOUT_SEC);
             connection = &std::get<tls>(cache);
         } else {
-            cache.emplace<socket_con>();
+            cache.emplace<socket_con>(SOCKET_TIMEOUT_SEC);
             connection = &std::get<socket_con>(cache);
         }
 

--- a/src/connect/tls/tls.cpp
+++ b/src/connect/tls/tls.cpp
@@ -7,7 +7,8 @@ using http::Error;
 
 namespace connect_client {
 
-tls::tls() {
+tls::tls(uint8_t timeout_s)
+    : http::Connection(timeout_s) {
     mbedtls_net_init(&net_context);
     mbedtls_ssl_init(&ssl_context);
     mbedtls_ssl_config_init(&ssl_config);

--- a/src/connect/tls/tls.hpp
+++ b/src/connect/tls/tls.hpp
@@ -21,7 +21,7 @@ private:
     mbedtls_ssl_context ssl_context;
 
 public:
-    tls();
+    tls(uint8_t timeout_s);
     ~tls();
     tls(const tls &other) = delete;
     tls(tls &&other) = delete;

--- a/tests/unit/common/http/CMakeLists.txt
+++ b/tests/unit/common/http/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(
   common_http_tests
   ${CMAKE_CURRENT_BINARY_DIR}/http_resp_automaton.cpp
   ${CMAKE_SOURCE_DIR}/src/common/automata/core.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/http/connection.cpp
   ${CMAKE_SOURCE_DIR}/src/common/http/httpc.cpp
   ${CMAKE_SOURCE_DIR}/src/common/http/resp_parser.cpp
   ${CMAKE_SOURCE_DIR}/src/common/http/os_porting.cpp

--- a/tests/unit/common/http/http_client.cpp
+++ b/tests/unit/common/http/http_client.cpp
@@ -6,8 +6,6 @@
 #include <string>
 #include <string_view>
 
-using http::ContentType;
-using http::Status;
 using std::get;
 using std::holds_alternative;
 using std::min;
@@ -22,6 +20,8 @@ namespace {
 
 class DummyConnection final : public Connection {
 public:
+    DummyConnection()
+        : Connection(5) {}
     string sent;
     string received;
     virtual optional<Error> connection(const char *, uint16_t) override {

--- a/utils/dumpserver/server.py
+++ b/utils/dumpserver/server.py
@@ -28,4 +28,4 @@ def post_dump():
     with open(metadata_filepath, 'w') as f:
         f.write(json.dumps(metadata))
 
-    return 'ok'
+    return '', 204


### PR DESCRIPTION
Socket timeout is now made as a constructor parameter for `http::Connection`. This allows it to be specified per use case rather than once globally. 

The dump server has gotten it's response changed to 204. This makes the transaction 'clean'.

Also subsequently increase the timeout of crash dump sending to 6s. 