### PR TITLE
Initialize translations to a valid default even if empty

### DIFF
--- a/src/lang/translator.cpp
+++ b/src/lang/translator.cpp
@@ -15,7 +15,7 @@ ProviderRegistrator prEN("en", EmptyTranslationProvider::Instance());
 Translations::Translations()
     : currentProvider(EmptyTranslationProvider::Instance()) {
     // this is a safety precaution - initialize the array with valid pointers even if the cells are empty
-    std::fill(translations.begin(), translations.end(), TranRec({ currentProvider, 0U }));
+    translations.fill(TranRec({ currentProvider, 0U }));
 }
 
 bool Translations::RegisterProvider(uint16_t langCode, const ITranslationProvider *provider) {

--- a/src/lang/translator.cpp
+++ b/src/lang/translator.cpp
@@ -14,6 +14,8 @@ ProviderRegistrator prEN("en", EmptyTranslationProvider::Instance());
 // even if there were no registered languages at all
 Translations::Translations()
     : currentProvider(EmptyTranslationProvider::Instance()) {
+    // this is a safety precaution - initialize the array with valid pointers even if the cells are empty
+    std::fill(translations.begin(), translations.end(), TranRec({ currentProvider, 0U }));
 }
 
 bool Translations::RegisterProvider(uint16_t langCode, const ITranslationProvider *provider) {


### PR DESCRIPTION
A safety precaution - initialize the translations array with valid pointers even if the cells are empty - prevents accessing invalid pointers in some edge cases.