### PR TITLE
Marlin2 2.1.x imports

### DIFF
--- a/lib/Marlin/Marlin/src/HAL/shared/Marduino.h
+++ b/lib/Marlin/Marlin/src/HAL/shared/Marduino.h
@@ -83,3 +83,9 @@
 #ifndef UNUSED
   #define UNUSED(x) ((void)(x))
 #endif
+
+class __FlashStringHelper;
+typedef const __FlashStringHelper* FSTR_P;
+#ifndef FPSTR
+  #define FPSTR(S) (reinterpret_cast<FSTR_P>(S))
+#endif

--- a/lib/Marlin/Marlin/src/core/language.h
+++ b/lib/Marlin/Marlin/src/core/language.h
@@ -324,6 +324,8 @@
 // Never translate these strings
 #define MSG_X "X"
 #define MSG_Y "Y"
+#define STR_X MSG_X
+#define STR_Y MSG_Y
 #define MSG_Z "Z"
 #define MSG_E "E"
 #if IS_KINEMATIC


### PR DESCRIPTION
- stub/Marlin2: stub STR_X/STR_Y due to partial migration
- Marlin2: Import FSTR_P from 2.1.x