### PR TITLE
connect: Give up sending event after max attempts

### DIFF
--- a/src/common/http/httpc.cpp
+++ b/src/common/http/httpc.cpp
@@ -275,6 +275,11 @@ variant<Response, Error> HttpClient::send(Request &request) {
     const char *host = factory.host();
 
     if (auto error = send_request(host, conn, request); error.has_value()) {
+        // Note: the current architecture doesn't go well with early results
+        // from server. If a server sends a response early on (after headers or
+        // mid-body) and closes the connection hard way, we get connection
+        // reset which prevents more writing into it. But it also, at that
+        // point, prevents reading the response.
         factory.invalidate();
         return *error;
     }

--- a/src/connect/planner.cpp
+++ b/src/connect/planner.cpp
@@ -42,6 +42,11 @@ namespace {
     // communication with a new init event.
     const constexpr Duration RECONNECT_AFTER = 1000 * 10;
 
+    // Max number of attempts per specific event before we throw it out of the
+    // window. Safety measure, as it may be related to that specific event and
+    // we would never recover if the failure is repeateble with it.
+    const constexpr uint8_t GIVE_UP_AFTER_ATTEMPTS = 5;
+
     // Just rename for better readability
     Timestamp now() {
         return ticks_ms();
@@ -102,6 +107,7 @@ void Planner::reset() {
     last_telemetry = nullopt;
     cooldown = nullopt;
     perform_cooldown = false;
+    failed_attempts = 0;
 }
 
 Action Planner::next_action() {
@@ -149,6 +155,7 @@ void Planner::action_done(ActionResult result) {
         last_success = n;
         perform_cooldown = false;
         cooldown = nullopt;
+        failed_attempts = 0;
         if (planned_event.has_value()) {
             planned_event = nullopt;
             // Enforce telemetry now. We may get a new command with it.
@@ -159,6 +166,17 @@ void Planner::action_done(ActionResult result) {
         break;
     }
     case ActionResult::Failed:
+        if (++failed_attempts >= GIVE_UP_AFTER_ATTEMPTS) {
+            // Give up after too many failed attemts when trying to send the
+            // same thing. The failure may be related to the specific event in
+            // some way (we have seen a "payload too large" error from the
+            // server, for example, which, due to our limitations, we are
+            // unable to distinguish from just a network error while sending
+            // the data), so avoid some kind of infinite loop/blocked state.
+            planned_event.reset();
+            failed_attempts = 0;
+        }
+
         if (const auto since_success = since(last_success); since_success.value_or(0) >= RECONNECT_AFTER && !planned_event.has_value()) {
             // We have talked to the server long time ago (it's probably in
             // a galaxy far far away), so next time we manage to do so,

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -101,6 +101,13 @@ private:
     /// want to keep the value in case the retry also fails.
     bool perform_cooldown;
 
+    /// How many times we've tried and failed due to some kind of network error
+    /// or such? After enough, we give up sending a specific event because the
+    /// failure might be related to that specific event in some way (in theory,
+    /// it should not, they should be detected as Refused instead of Failed,
+    /// but there are always corner cases).
+    uint8_t failed_attempts = 0;
+
     /// Some command that is accepted but still being worked on.
     std::optional<BackgroundCommand> background_command;
 


### PR DESCRIPTION
Even if the errors are supposed to be transient. It turns out, the issue may be related to that one specific event and we shall not block us by infinitely retrying that one. Seen at least with "payload too large" error from the server, because during that one it closes the connection on us, which is a network error for us.

In theory, we should be able to read that response, but it's hard in current architecture and a cornercase that should not happen in production (it was caused by misconfigured server), so it's not worth that effort.

BFW-2929.