### PR TITLE
Enable Link Time Optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,6 @@ add_subdirectory(lib)
 #
 
 add_executable(firmware)
-
 add_subdirectory(src)
 
 if(WUI)
@@ -322,6 +321,13 @@ objcopy(firmware "binary" ".bin")
 
 # generate linker map file
 target_link_options(firmware PUBLIC -Wl,-Map=firmware.map)
+
+# link time optimizations
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  if(MCU MATCHES "STM32F40")
+    set_target_properties(firmware PROPERTIES INTERPROCEDURAL_OPTIMIZATION True)
+  endif()
+endif() # "Release"
 
 # inform about the firmware's size in terminal
 report_size(firmware)

--- a/src/common/dump.h
+++ b/src/common/dump.h
@@ -70,6 +70,7 @@ static const uint32_t DUMP_INFO_SIZE = 0x00000010;
 #define DUMP_REGS_GEN_EXC_TO_CCRAM()                                                    \
     asm volatile(                                                                       \
         "    ldr r1, =0x1000ff00    \n" /* hardcoded ccram addres - todo: use macro  */ \
+        "    .ltorg                 \n" /* put the immediate constant 0x1000ff00 here*/ \
         "    ldr r2, [r0, #0x00]    \n" /* load r0 from stack frame  */                 \
         "    str r2, [r1, #0x00]    \n" /* store r0 to ccram  */                        \
         "    ldr r2, [r0, #0x04]    \n" /* r1  */                                       \


### PR DESCRIPTION
Code size drops by ~24KB
LTO is enabled only in release builds for STM32xxx