### PR TITLE
Connection closing policy after error reworked.

### DIFF
--- a/lib/WUI/link_content/static_file.cpp
+++ b/lib/WUI/link_content/static_file.cpp
@@ -9,6 +9,7 @@
 
 namespace nhttp::link_content {
 
+using http::Method;
 using std::nullopt;
 using std::optional;
 using std::string_view;
@@ -43,18 +44,20 @@ optional<ConnectionState> StaticFile::accept(const RequestParser &parser) const 
         cache_enabled = false;
     }
 
-    FILE *f = fopen(fname, "rb");
-    if (f) {
-        static const char *extra_hdrs_cache[] = {
-            "Content-Encoding: gzip\r\n",
-            "Cache-Control: private, max-age=86400\r\n",
-            nullptr
-        };
-        static const char *extra_hdrs_no_cache[] = {
-            "Content-Encoding: gzip\r\n",
-            nullptr
-        };
-        return SendFile(f, fname, guess_content_by_ext(fname), parser.can_keep_alive(), parser.accepts_json, parser.if_none_match, cache_enabled ? extra_hdrs_cache : extra_hdrs_no_cache);
+    if (parser.method == Method::Get) {
+        FILE *f = fopen(fname, "rb");
+        if (f) {
+            static const char *extra_hdrs_cache[] = {
+                "Content-Encoding: gzip\r\n",
+                "Cache-Control: private, max-age=86400\r\n",
+                nullptr
+            };
+            static const char *extra_hdrs_no_cache[] = {
+                "Content-Encoding: gzip\r\n",
+                nullptr
+            };
+            return SendFile(f, fname, guess_content_by_ext(fname), parser.can_keep_alive(), parser.accepts_json, parser.if_none_match, cache_enabled ? extra_hdrs_cache : extra_hdrs_no_cache);
+        }
     }
 
     return nullopt;

--- a/lib/WUI/link_content/usb_files.cpp
+++ b/lib/WUI/link_content/usb_files.cpp
@@ -29,7 +29,7 @@ optional<ConnectionState> UsbFiles::accept(const RequestParser &parser) const {
 
     char fname[FILE_PATH_BUFFER_LEN];
     if (!parser.uri_filename(fname, sizeof(fname))) {
-        return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json, "This doesn't look like file name");
+        return StatusPage(Status::NotFound, parser, "This doesn't look like file name");
     }
 
     if (parser.method == Method::Get) {
@@ -55,9 +55,9 @@ optional<ConnectionState> UsbFiles::accept(const RequestParser &parser) const {
             return std::move(step);
         }
 
-        return StatusPage(Status::NotFound, parser.status_page_handling(), parser.accepts_json);
+        return StatusPage(Status::NotFound, parser);
     } else {
-        return StatusPage(Status::MethodNotAllowed, parser.status_page_handling(), parser.accepts_json);
+        return StatusPage(Status::MethodNotAllowed, parser);
     }
 }
 

--- a/lib/WUI/nhttp/common_selectors.cpp
+++ b/lib/WUI/nhttp/common_selectors.cpp
@@ -18,7 +18,7 @@ optional<ConnectionState> ValidateRequest::accept(const RequestParser &request) 
     }
 
     if (request.method == Method::UnknownMethod) {
-        return StatusPage(Status::MethodNotAllowed, request.status_page_handling(), request.accepts_json, "Unrecognized method");
+        return StatusPage(Status::MethodNotAllowed, request, "Unrecognized method");
     }
     return nullopt;
 }
@@ -26,7 +26,7 @@ optional<ConnectionState> ValidateRequest::accept(const RequestParser &request) 
 const ValidateRequest validate_request;
 
 optional<ConnectionState> UnknownRequest::accept(const RequestParser &request) const {
-    return StatusPage(Status::NotFound, request.status_page_handling(), request.accepts_json);
+    return StatusPage(Status::NotFound, request);
 }
 
 const UnknownRequest unknown_request;

--- a/lib/WUI/nhttp/req_parser.cpp
+++ b/lib/WUI/nhttp/req_parser.cpp
@@ -310,7 +310,7 @@ std::optional<std::variant<StatusPage, UnauthenticatedStatusPage>> RequestParser
     if (holds_alternative<bool>(params) and get<bool>(params))
         return std::nullopt;
     else
-        return UnauthenticatedStatusPage(status_page_handling(), accepts_json, ApiKeyAuth {});
+        return UnauthenticatedStatusPage(*this, ApiKeyAuth {});
 }
 std::optional<std::variant<StatusPage, UnauthenticatedStatusPage>> RequestParser::authenticated_status(const DigestAuthParams &params) const {
     if (nonce_random == 0) {
@@ -322,14 +322,14 @@ std::optional<std::variant<StatusPage, UnauthenticatedStatusPage>> RequestParser
         if (check_digest_auth(params.recieved_nonce)) {
             return std::nullopt;
         } else {
-            return UnauthenticatedStatusPage(status_page_handling(), accepts_json, DigestAuth { new_nonce(), false });
+            return UnauthenticatedStatusPage(*this, DigestAuth { new_nonce(), false });
         }
     } else {
         // We set stale=true for every nonce with valid digest for that nonce,
         // because it means the client knows the username and password and we want
         // him to retry with new nonce.
         bool stale = check_digest_auth(params.recieved_nonce);
-        return UnauthenticatedStatusPage(status_page_handling(), accepts_json, DigestAuth { new_nonce(), stale });
+        return UnauthenticatedStatusPage(*this, DigestAuth { new_nonce(), stale });
     }
 }
 

--- a/lib/WUI/nhttp/status_page.h
+++ b/lib/WUI/nhttp/status_page.h
@@ -13,6 +13,8 @@
 
 namespace nhttp::handler {
 
+class RequestParser;
+
 class StatusPage {
 public:
     enum class CloseHandling {
@@ -37,11 +39,9 @@ protected:
     Step step_impl(std::string_view input, bool terminated_by_client, uint8_t *output, size_t output_size, const char *const *extra_hdrs);
 
 public:
-    StatusPage(http::Status status, CloseHandling close_handling, bool json_content, const char *extra_content = "")
-        : extra_content(extra_content)
-        , status(status)
-        , close_handling(close_handling)
-        , json_content(json_content) {}
+    StatusPage(http::Status status, const RequestParser &parser, const char *extra_content = "");
+    StatusPage(http::Status status, CloseHandling close_handling, bool json_content, const char *extra_content = "");
+
     bool want_read() const { return false; }
     bool want_write() const { return true; }
     virtual Step step(std::string_view input, bool terminated_by_client, uint8_t *output, size_t output_size);
@@ -60,7 +60,7 @@ private:
     Step step(std::string_view input, bool terminated_by_client, uint8_t *output, size_t output_size, ApiKeyAuth api_key_auth);
 
 public:
-    UnauthenticatedStatusPage(CloseHandling close_handling, bool json_content, AuthMethod auth_method);
+    UnauthenticatedStatusPage(const RequestParser &parser, AuthMethod auth_method);
 
     Step step(std::string_view input, bool terminated_by_client, uint8_t *output, size_t output_size) override;
 };


### PR DESCRIPTION
We need to close connection after error with requests, that have a body not yet recieved at the time of the error. This caused double error (Unauthorized and MethodNotAllowed) when post authorization failed, because we were trying to parse the body as another request.

Solves BFW-2961.