### PR TITLE
Fix http error response for garbage request.

### DIFF
--- a/lib/WUI/nhttp/common_selectors.cpp
+++ b/lib/WUI/nhttp/common_selectors.cpp
@@ -8,10 +8,6 @@ using std::optional;
 namespace nhttp::handler::selectors {
 
 optional<ConnectionState> ValidateRequest::accept(const RequestParser &request) const {
-    if (request.method == Method::UnknownMethod) {
-        return StatusPage(Status::MethodNotAllowed, request.status_page_handling(), request.accepts_json, "Unrecognized method");
-    }
-
     if (request.error_code != Status::UnknownStatus) {
         /*
          * BadRequest may mean badly formed/unparsed request. Always close in
@@ -21,6 +17,9 @@ optional<ConnectionState> ValidateRequest::accept(const RequestParser &request) 
         return StatusPage(request.error_code, request.error_code == Status::BadRequest ? StatusPage::CloseHandling::ErrorClose : request.status_page_handling(), request.accepts_json);
     }
 
+    if (request.method == Method::UnknownMethod) {
+        return StatusPage(Status::MethodNotAllowed, request.status_page_handling(), request.accepts_json, "Unrecognized method");
+    }
     return nullopt;
 }
 


### PR DESCRIPTION
First check for error_code and then for unknown method, otherwise we return MethodNotAllowed for any garbage request that is not http at all.