### PR TITLE
connect: React to new config in snappier way

### DIFF
--- a/src/connect/printer.cpp
+++ b/src/connect/printer.cpp
@@ -19,12 +19,14 @@ uint32_t Printer::Config::crc() const {
     return crc;
 }
 
-tuple<Printer::Config, bool> Printer::config() {
+tuple<Printer::Config, bool> Printer::config(bool reset_fingerprint) {
     Config result = load_config();
 
     const uint32_t new_fingerprint = result.crc();
     const bool changed = new_fingerprint != cfg_fingerprint;
-    cfg_fingerprint = new_fingerprint;
+    if (reset_fingerprint) {
+        cfg_fingerprint = new_fingerprint;
+    }
     return make_tuple(result, changed);
 }
 

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -132,8 +132,10 @@ public:
     virtual void submit_gcode(const char *gcode) = 0;
     virtual bool set_ready(bool ready) = 0;
 
-    // Returns a newly reloaded config and a flag if it changed since last load.
-    std::tuple<Config, bool> config();
+    // Returns a newly reloaded config and a flag if it changed since last load
+    // (unless the reset_fingerprint is set to false, in which case the flag is
+    // kept).
+    std::tuple<Config, bool> config(bool reset_fingerprint = true);
 
     virtual ~Printer() = default;
 };


### PR DESCRIPTION
If connect can't connect, it wants to sleep for a long time. But interrupt the sleep if a new config comes earlier, as that might make it possible to connect now and don't the user let wait for a whole minute or so.

BFW-2812.