### PR TITLE
Inicialized marlin_logging before wait_for_dependecies

### DIFF
--- a/lib/Arduino_Core_Buddy/cores/arduino/USBSerial.cpp
+++ b/lib/Arduino_Core_Buddy/cores/arduino/USBSerial.cpp
@@ -47,10 +47,12 @@ void USBSerial::flush(void) {
     if (enabled)
         tud_cdc_write_flush();
 
-    if (lineBufferUsed) {
-        lineBufferHook(&lineBuffer[0], lineBufferUsed);
-        lineBufferUsed = 0;
+    if (!lineBufferHook || !lineBufferUsed) {
+        return;
     }
+
+    lineBufferHook(&lineBuffer[0], lineBufferUsed);
+    lineBufferUsed = 0;
 }
 
 void USBSerial::LineBufferAppend(char character) {

--- a/lib/Arduino_Core_Buddy/cores/arduino/USBSerial.h
+++ b/lib/Arduino_Core_Buddy/cores/arduino/USBSerial.h
@@ -33,7 +33,7 @@ public:
     virtual size_t write(const uint8_t *buffer, size_t size);
     operator bool(void);
 
-    void (*lineBufferHook)(const uint8_t *buf, int len);
+    void (*lineBufferHook)(const uint8_t *buf, int len) { nullptr };
 };
 
 extern USBSerial SerialUSB;

--- a/src/buddy/main.cpp
+++ b/src/buddy/main.cpp
@@ -32,6 +32,7 @@
 #include <option/filament_sensor.h>
 #include <option/has_gui.h>
 #include "tasks.h"
+#include <appmain.hpp>
 
 #if ENABLED(POWER_PANIC)
     #include "power_panic.hpp"
@@ -244,9 +245,7 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
 }
 
 void StartDefaultTask(void const *argument) {
-    log_info(Buddy, "marlin task waiting for dependecies");
-    wait_for_dependecies(DEFAULT_TASK_DEPS);
-    log_info(Buddy, "marlin task is starting");
+    app_startup();
 
     app_run();
     for (;;) {

--- a/src/common/appmain.hpp
+++ b/src/common/appmain.hpp
@@ -11,3 +11,5 @@
 extern CFanCtl fanCtlPrint;
 extern CFanCtl fanCtlHeatBreak;
 #endif
+
+extern "C" void app_startup();


### PR DESCRIPTION
Fix bug in USBSerial. Set lineBufferHook in constructor to nullptr and check if correctly set hook in flush