### PR TITLE
Dump error - improvements

### DIFF
--- a/src/buddy/main.cpp
+++ b/src/buddy/main.cpp
@@ -126,17 +126,14 @@ extern "C" void main_cpp(void) {
      * Checking this first, before starting the GUI thread. The GUI thread
      * resets/consumes the dump as a side effect.
      */
-    if (dump_in_xflash_is_valid() && !dump_in_xflash_is_displayed()) {
-        int dump_type = dump_in_xflash_get_type();
-        if (dump_type == DUMP_HARDFAULT || dump_type == DUMP_FATALERROR) {
-            /*
-             * This corresponds to booting into a bluescreen or serious
-             * redscreen. In such case, the GUI is blocked. Similar logic
-             * should apply to any network communication ‒ one probably shall
-             * not eg. start a print from there.
-             */
-            block_networking = true;
-        }
+    if ((dump_in_xflash_is_valid() && !dump_in_xflash_is_displayed() && dump_in_xflash_get_type() == DUMP_HARDFAULT) || (dump_err_in_xflash_is_valid() && !dump_err_in_xflash_is_displayed())) {
+        /*
+        * This corresponds to booting into a bluescreen or serious
+        * redscreen. In such case, the GUI is blocked. Similar logic
+        * should apply to any network communication ‒ one probably shall
+        * not eg. start a print from there.
+        */
+        block_networking = true;
     }
 
     eeprom_init_status_t status = eeprom_init();

--- a/src/common/bsod_gui.cpp
+++ b/src/common/bsod_gui.cpp
@@ -148,41 +148,38 @@ char nth_char(const char str[], uint16_t nth) {
 
 //! Fatal error that causes Redscreen
 void fatal_error(const char *error, const char *module) {
-    uint16_t *perror_code_short = (uint16_t *)(DUMP_INFO_ADDR + 1);
-    bool dump_error_message = false;
+    uint16_t error_code = 0;
 
     /// Decision tree to define error code
     using namespace Language_en;
     /// TODO share these strings (saves ~100 B of binary size)
     if (strcmp("Emergency stop (M112)", error) == 0) {
-        *perror_code_short = 510;
+        error_code = 510;
     } else if (strcmp(MSG_ERR_HOMING, error) == 0) {
-        *perror_code_short = 301;
+        error_code = 301;
     } else if (strcmp(MSG_HEATING_FAILED_LCD_BED, error) == 0) {
-        *perror_code_short = 201;
+        error_code = 201;
     } else if (strcmp(MSG_HEATING_FAILED_LCD, error) == 0) {
-        *perror_code_short = 202;
+        error_code = 202;
     } else if (strcmp(MSG_THERMAL_RUNAWAY_BED, error) == 0) {
-        *perror_code_short = 203;
+        error_code = 203;
     } else if (strcmp(MSG_THERMAL_RUNAWAY, error) == 0) {
-        *perror_code_short = 204;
+        error_code = 204;
     } else if (strcmp(MSG_ERR_MAXTEMP_BED, error) == 0) {
-        *perror_code_short = 205;
+        error_code = 205;
     } else if (strcmp(MSG_ERR_MAXTEMP, error) == 0) {
-        *perror_code_short = 206;
+        error_code = 206;
     } else if (strcmp(MSG_ERR_MINTEMP_BED, error) == 0) {
-        *perror_code_short = 207;
+        error_code = 207;
     } else if (strcmp(MSG_ERR_MINTEMP, error) == 0) {
-        *perror_code_short = 208;
+        error_code = 208;
     } else {
-        *perror_code_short = 0; // Unknown error code = we don't have help.prusa3d site support for this error
-        dump_error_message = true;
+        // Unknown error code = we don't have help.prusa3d site support for this error
+        // In this case we have to dump error message and error title
+        error_code = 0;
     }
 
-    DUMP_FATALERROR_TO_CCRAM();
-    dump_to_xflash();
-    if (dump_error_message)
-        dump_err_to_xflash(error, module);
+    dump_err_to_xflash(error_code, error, module);
     sys_reset();
 }
 

--- a/src/common/crash_dump/dump.cpp
+++ b/src/common/crash_dump/dump.cpp
@@ -236,7 +236,7 @@ int dump_hardfault_test_1(void) {
 
 // Dumping error message
 
-void dump_err_to_xflash(const char *error, const char *title) {
+void dump_err_to_xflash(uint16_t error_code, const char *error, const char *title) {
     w25x_sector_erase(w25x_error_start_adress);
 
     decltype(dumpmessage_t::invalid) invalid = 0;
@@ -244,6 +244,7 @@ void dump_err_to_xflash(const char *error, const char *title) {
     const size_t msg_len = strnlen(error, sizeof(dumpmessage_t::msg));
 
     w25x_program(reinterpret_cast<uint32_t>(&dumpmessage_flash->invalid), reinterpret_cast<uint8_t *>(&invalid), sizeof(invalid));
+    w25x_program(reinterpret_cast<uint32_t>(&dumpmessage_flash->error_code), reinterpret_cast<uint8_t *>(&error_code), sizeof(error_code));
     w25x_program(reinterpret_cast<uint32_t>(&dumpmessage_flash->title), reinterpret_cast<const uint8_t *>(title), title_len);
     w25x_program(reinterpret_cast<uint32_t>(&dumpmessage_flash->msg), reinterpret_cast<const uint8_t *>(error), msg_len);
     w25x_fetch_error();
@@ -286,4 +287,15 @@ int dump_err_in_xflash_get_message(char *msg_dst, uint16_t msg_dst_size, char *t
     if (w25x_fetch_error())
         return 0;
     return 1;
+}
+
+uint16_t dump_err_in_xflash_get_error_code(void) {
+    uint16_t error_code;
+    w25x_rd_data(
+        reinterpret_cast<uint32_t>(&dumpmessage_flash->error_code),
+        reinterpret_cast<uint8_t *>(&error_code),
+        sizeof(dumpmessage_t::error_code));
+    if (w25x_fetch_error())
+        return 0;
+    return error_code;
 }

--- a/src/common/crash_dump/dump.cpp
+++ b/src/common/crash_dump/dump.cpp
@@ -237,6 +237,10 @@ int dump_hardfault_test_1(void) {
 // Dumping error message
 
 void dump_err_to_xflash(uint16_t error_code, const char *error, const char *title) {
+    vTaskEndScheduler();
+    if (!w25x_init()) {
+        return;
+    }
     w25x_sector_erase(w25x_error_start_adress);
 
     decltype(dumpmessage_t::invalid) invalid = 0;

--- a/src/common/crash_dump/dump.h
+++ b/src/common/crash_dump/dump.h
@@ -157,6 +157,7 @@ typedef struct _dumpinfo_t {
 typedef struct _dumpmessage_t {
     uint8_t not_displayed; // not displayed == 0xFF, displayed == 0x00
     uint8_t invalid;       // valid == 0x00, empty == 0xFF
+    uint16_t error_code;   // error_code (0 == unknown error code -> we read dumped message
     char title[DUMP_MSG_TITLE_MAX_LEN];
     char msg[DUMP_MSG_MAX_LEN];
 } dumpmessage_t;
@@ -199,10 +200,11 @@ extern int dump_hardfault_test_1(void);
 extern void dump_to_xflash(void);
 
 /** Save error message to xflash
+ * @param error_code [in] - code for known errors
  * @param error [in] - pointer to dumped error message
  * @param title [in] - pointer to dumped error title
 */
-extern void dump_err_to_xflash(const char *error, const char *title);
+extern void dump_err_to_xflash(uint16_t error_code, const char *error, const char *title);
 /** Get pointers to dumped error title and error message
  * @param msg_dst [out] - will be filled with adress to dumped error message
  * @param msg_dst_size [in] - size of passed message buffer
@@ -224,6 +226,10 @@ extern int dump_err_in_xflash_is_valid(void);
 extern int dump_err_in_xflash_is_displayed(void);
 /** Set displayed flag to 'Already displayed' == 0x00 */
 extern void dump_err_in_xflash_set_displayed(void);
+/** Returns error code
+ * @retval 0 - Unknown error code
+*/
+extern uint16_t dump_err_in_xflash_get_error_code(void);
 
 #ifdef __cplusplus
 }

--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -259,11 +259,6 @@ void gui_run(void) {
         case DUMP_HARDFAULT:
             error_screen = ScreenFactory::Screen<screen_hardfault_data_t>;
             break;
-        case DUMP_FATALERROR:
-            // TODO uncomment to enable start after click
-            // blockISR();
-            error_screen = ScreenFactory::Screen<ScreenErrorQR>;
-            break;
 #ifndef _DEBUG
         case DUMP_IWDGW:
             error_screen = ScreenFactory::Screen<screen_watchdog_data_t>;
@@ -271,6 +266,12 @@ void gui_run(void) {
 #endif
         }
         dump_in_xflash_set_displayed();
+    }
+
+    if (dump_err_in_xflash_is_valid() && !dump_err_in_xflash_is_displayed()) {
+        // Redscreen rewrites bluescreen
+        error_screen = ScreenFactory::Screen<ScreenErrorQR>;
+        dump_err_in_xflash_set_displayed();
     }
 
 #ifndef _DEBUG

--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -253,22 +253,24 @@ void gui_run(void) {
 
     ScreenFactory::Creator error_screen = nullptr;
 
-    // If both redscreen and bsod are pending - both are set as displayed, but bsod is displayed
+    // If both redscreen and bsod are pending - both are set as displayed, but redscreen is displayed
     if (dump_err_in_xflash_is_valid() && !dump_err_in_xflash_is_displayed()) {
         error_screen = ScreenFactory::Screen<ScreenErrorQR>;
         dump_err_in_xflash_set_displayed();
     }
     if (dump_in_xflash_is_valid() && !dump_in_xflash_is_displayed()) {
-        blockISR(); // TODO delete blockISR() on this line to enable start after click
-        switch (dump_in_xflash_get_type()) {
-        case DUMP_HARDFAULT:
-            error_screen = ScreenFactory::Screen<screen_hardfault_data_t>;
-            break;
+        if (error_screen == nullptr) {
+            blockISR(); // TODO delete blockISR() on this line to enable start after click
+            switch (dump_in_xflash_get_type()) {
+            case DUMP_HARDFAULT:
+                error_screen = ScreenFactory::Screen<screen_hardfault_data_t>;
+                break;
 #ifndef _DEBUG
-        case DUMP_IWDGW:
-            error_screen = ScreenFactory::Screen<screen_watchdog_data_t>;
-            break;
+            case DUMP_IWDGW:
+                error_screen = ScreenFactory::Screen<screen_watchdog_data_t>;
+                break;
 #endif
+            }
         }
         dump_in_xflash_set_displayed();
     }

--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -253,6 +253,11 @@ void gui_run(void) {
 
     ScreenFactory::Creator error_screen = nullptr;
 
+    // If both redscreen and bsod are pending - both are set as displayed, but bsod is displayed
+    if (dump_err_in_xflash_is_valid() && !dump_err_in_xflash_is_displayed()) {
+        error_screen = ScreenFactory::Screen<ScreenErrorQR>;
+        dump_err_in_xflash_set_displayed();
+    }
     if (dump_in_xflash_is_valid() && !dump_in_xflash_is_displayed()) {
         blockISR(); // TODO delete blockISR() on this line to enable start after click
         switch (dump_in_xflash_get_type()) {
@@ -267,16 +272,6 @@ void gui_run(void) {
         }
         dump_in_xflash_set_displayed();
     }
-
-    if (dump_err_in_xflash_is_valid() && !dump_err_in_xflash_is_displayed()) {
-        // Redscreen rewrites bluescreen
-        error_screen = ScreenFactory::Screen<ScreenErrorQR>;
-        dump_err_in_xflash_set_displayed();
-    }
-
-#ifndef _DEBUG
-//        HAL_IWDG_Reset ? ScreenFactory::Screen<screen_watchdog_data_t> : nullptr, // wdt
-#endif
 
     screen_node screen_initializer[] {
         error_screen,

--- a/src/gui/screen_qr_error.cpp
+++ b/src/gui/screen_qr_error.cpp
@@ -43,7 +43,6 @@ ScreenErrorQR::ScreenErrorQR()
     , title_line(this, title_line_rect) {
 
     SetRedLayout();
-    hand_icon.SetRedLayout();
     title_line.SetBackColor(COLOR_WHITE);
     help_link.font = resource_font(IDR_FNT_SMALL);
     qr_code_txt.font = resource_font(IDR_FNT_SMALL);
@@ -60,7 +59,7 @@ ScreenErrorQR::ScreenErrorQR()
     appendix_txt.SetAlignment(Align_t::CenterTop());
 
     // Extract error code from xflash
-    uint16_t error_code_short = dump_in_xflash_get_code();
+    uint16_t error_code_short = dump_err_in_xflash_get_error_code(); // Unknow code == 0x00
     uint16_t error_code = ERR_PRINTER_CODE * 1000 + error_code_short;
     uint32_t i = 0;
     uint32_t count = sizeof(error_list) / sizeof(err_t);
@@ -81,7 +80,6 @@ ScreenErrorQR::ScreenErrorQR()
             err_description.Hide();
             title_line.Hide();
         }
-        dump_err_in_xflash_set_displayed();
         help_txt.Hide();
         help_link.Hide();
         hand_icon.Hide();


### PR DESCRIPTION
- Move error code dumping to error message dumping, making it unrelated to old dump method, that is deprecated.
- Add initialization which is necessary in this context (documented in w25x.h).
- If both red screen and bsod are pending to be displayed, set both as displayed and display only Redscreen (this will maybe change)