### PR TITLE
Avoid UB in crc32

### DIFF
--- a/src/common/crc32.c
+++ b/src/common/crc32.c
@@ -2,6 +2,7 @@
 #include "cmsis_os.h"
 #include "crc32.h"
 #include <config.h>
+#include <string.h>
 #include "stm32f4xx_hal.h"
 
 #ifdef CRC32_USE_HW
@@ -33,7 +34,13 @@ static uint32_t reverse_crc32(uint32_t current_crc, uint32_t desired_crc) {
     return desired_crc ^ current_crc;
 }
 
-static uint32_t crc32_hw(const uint32_t *buffer, uint32_t length, uint32_t crc) {
+static uint32_t crc32_hw(const uint8_t *buffer, uint32_t length, uint32_t crc) {
+    // We may get called on too short buffer to have any work for the HW. In
+    // such case, avoid all the expensive mutex stuff.
+    if (length == 0) {
+        return crc;
+    }
+
     // ensure nobody else uses the peripheral
     osMutexWait(crc32_hw_mutex_id, osWaitForever);
 
@@ -52,7 +59,18 @@ static uint32_t crc32_hw(const uint32_t *buffer, uint32_t length, uint32_t crc) 
     // calculate the CRC32 value
     uint32_t word_count = length;
     while (word_count--) {
-        uint32_t word = *((uint32_t *)buffer++);
+        uint32_t word;
+        // This is almost like
+        //
+        //   word = *(const uint32_t *) buffer
+        //
+        // But that could create mis-alligned pointer and alias something
+        // that's not uint32_t in reality, and both is UB. memcpy overcomes
+        // both these issues, but disappears from the actual generated code ‒
+        // it simply tells the compiler it must not make some assumptions about
+        // the pointer.
+        memcpy(&word, buffer, 4);
+        buffer += 4;
         CRC->DR = __RBIT(word);
     }
     uint32_t result = __RBIT(CRC->DR) ^ 0xFFFFFFFF;
@@ -98,7 +116,7 @@ extern uint32_t crc32_calc_ex(uint32_t crc, const uint8_t *data, uint32_t count)
 #ifdef CRC32_USE_HW
     // use the hw peripheral to calculate crc for all full words
     uint32_t word_count = count / 4;
-    crc = crc32_hw((const uint32_t *)data, word_count, crc);
+    crc = crc32_hw(data, word_count, crc);
     count -= word_count * 4;
     data += (word_count * 4);
 #endif //CRC32_USE_HW


### PR DESCRIPTION
* Don't create a potentially mis-alligned uint32_t pointer.
* Avoid breaking strict aliasing rules by casting something unknown into an uint32_t.
* Piggy-back: short-circuit empty buffers in there.