### PR TITLE
In code renaming of api_key to password.

### DIFF
--- a/doc/ESP/README.md
+++ b/doc/ESP/README.md
@@ -40,6 +40,6 @@ key_mgmt=WPA
 ## Connect printer to PRUSA LINK ##
 - Make sure your printer is connected to the network
 - Open an internet browser and copy the IP address from **Setting->Lan settings->WiFI**
-- PrusaLink page should open and request you to enter an api-key.You will find it in **Settings->PRUSA LINK->X-Api-Key**
-- Enter the api key
--  Telemetric and graphical information regarding the printer status should be displayed
+- PrusaLink page should open and request you to enter a username and a password.You will find it in **Settings->PRUSA LINK**.
+- Enter the credentials
+- Telemetric and graphical information regarding the printer status should be displayed

--- a/lib/WUI/http_lifetime.cpp
+++ b/lib/WUI/http_lifetime.cpp
@@ -32,7 +32,7 @@ private:
 
 public:
     virtual const Selector *const *selectors() const override { return selectors_array; }
-    virtual const char *get_api_key() const override { return wui_get_api_key(); }
+    virtual const char *get_password() const override { return wui_get_password(); }
     virtual altcp_pcb *listener_alloc() const override {
         /*
          * We know we are in the part where ALTCP is turned off. That means the

--- a/lib/WUI/nhttp/req_parser.cpp
+++ b/lib/WUI/nhttp/req_parser.cpp
@@ -214,7 +214,7 @@ Step RequestParser::step(string_view input, bool terminated_by_client, uint8_t *
         return Step { 0, 0, Continue() };
     }
 
-    api_key = server->get_api_key();
+    api_key = server->get_password();
     const auto [result, consumed] = consume(input);
     api_key = nullptr;
 
@@ -368,7 +368,7 @@ namespace {
 bool RequestParser::check_digest_auth(uint64_t nonce_to_use) const {
     if (auto digest_params = get_if<DigestAuthParams>(&auth_status)) {
 
-        auto hash_a1 = md5_hash(PRUSA_LINK_USERNAME, ":", AUTH_REALM, ":", server->get_api_key());
+        auto hash_a1 = md5_hash(PRUSA_LINK_USERNAME, ":", AUTH_REALM, ":", server->get_password());
         auto hash_a2 = md5_hash(to_str(method), ":", uri());
 
         char ha1[MD5_HEX_SIZE];

--- a/lib/WUI/nhttp/server.h
+++ b/lib/WUI/nhttp/server.h
@@ -44,14 +44,14 @@ public:
      */
     virtual const handler::Selector *const *selectors() const = 0;
     /**
-     * \brief Looks up an API key.
+     * \brief Looks up a password.
      *
-     * Provides the API key. If this is null, all access to restricted
+     * Provides the password. If this is null, all access to restricted
      * resources is denied.
      *
      * FIXME: there are (probably) thread synchronization issues:
      *
-     * * If the API key changes in the middle of parsing of the one provided in
+     * * If the password changes in the middle of parsing of the one provided in
      *   the headers, half of it is checked against the old one and half against
      *   the new one. We probably can live with that (it'll likely result in
      *   refusing the request; if someone can guess where the change happens
@@ -62,7 +62,7 @@ public:
      *   deleting the old one is a data race/UB. We need to find a solution,
      *   but for now, changing the key is very rare and happens in-place.
      */
-    virtual const char *get_api_key() const = 0;
+    virtual const char *get_password() const = 0;
     /**
      * \brief Allocate the listener socket.
      */
@@ -296,8 +296,8 @@ public:
         return defs.selectors();
     }
 
-    const char *get_api_key() const {
-        return defs.get_api_key();
+    const char *get_password() const {
+        return defs.get_password();
     }
 };
 

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -142,25 +142,25 @@ void sntp_set_system_time(uint32_t sec);
 void add_time_to_timestamp(int32_t secs_to_add, struct tm *timestamp);
 
 ////////////////////////////////////////////////////////////////////////////
-/// @brief Authorization key for PrusaLink
+/// @brief Authorization password for PrusaLink
 ///
-/// @return Return an x-api-key
-const char *wui_get_api_key();
+/// @return Return a password
+const char *wui_get_password();
+
+////////////////////////////////////////////////////////////////////////////
+/// @brief Generate authorization password for PrusaLink
+///
+/// @param[out] buffer password buffer
+/// @param[in] length Size of the buffer
+/// @return Return a password
+const char *wui_generate_password(char *, uint32_t);
 
 ////////////////////////////////////////////////////////////////////////////
 /// @brief Generate authorization key for PrusaLink
 ///
-/// @param[out] buffer api key buffer
+/// @param[out] password password buffer
 /// @param[in] length Size of the buffer
-/// @return Return an x-api-key
-const char *wui_generate_api_key(char *, uint32_t);
-
-////////////////////////////////////////////////////////////////////////////
-/// @brief Generate authorization key for PrusaLink
-///
-/// @param[out] api_key api key buffer
-/// @param[in] length Size of the buffer
-void wui_store_api_key(char *, uint32_t);
+void wui_store_password(char *, uint32_t);
 
 /// Start a print of a given filename.
 ///

--- a/src/common/eeprom.cpp
+++ b/src/common/eeprom.cpp
@@ -153,7 +153,7 @@ static const eeprom_entry_t eeprom_map[] = {
     { "ODOMETER_TIME",   VARIANT8_UI32,  1, 0 }, // EEVAR_LAN_ODOMETER_TIME
     { "ACTIVE_NETDEV",   VARIANT8_UI8,   1, 0 },
     { "PL_RUN",          VARIANT8_UI8,   1, 0 },    // EEVAR_PL_RUN
-    { "PL_API_KEY",      VARIANT8_PCHAR, PL_API_KEY_SIZE, 0 }, // EEVAR_PL_API_KEY
+    { "PL_PASSWORD",      VARIANT8_PCHAR, PL_PASSWORD_SIZE, 0 }, // EEVAR_PL_PASSWORD
     { "WIFI_FLAG",       VARIANT8_UI8,   1, 0 }, // EEVAR_WIFI_FLAG
     { "WIFI_IP4_ADDR",   VARIANT8_UI32,  1, 0 }, // EEVAR_WIFI_IP4_ADDR
     { "WIFI_IP4_MSK",    VARIANT8_UI32,  1, 0 }, // EEVAR_WIFI_IP4_MSK

--- a/src/common/eeprom.h
+++ b/src/common/eeprom.h
@@ -121,7 +121,7 @@ enum eevar_id {
     EEVAR_ODOMETER_TIME = 0x3f,       // uin32_t total print duration
     EEVAR_ACTIVE_NETDEV = 0x40,       // active network device
     EEVAR_PL_RUN = 0x41,              // active network device
-    EEVAR_PL_API_KEY = 0x42,          // active network device
+    EEVAR_PL_PASSWORD = 0x42,         // active network device
 
 // wifi variables (comes under the same feature flag as eth LAN)
 // FIXME: EEPROM_FEATURE_LAN probably can't be turned off, the .cpp file won't work then.
@@ -164,7 +164,7 @@ enum {
     LAN_HOSTNAME_MAX_LEN = 20,
     CONNECT_HOST_SIZE = 20,
     CONNECT_TOKEN_SIZE = 20,
-    PL_API_KEY_SIZE = 16,
+    PL_PASSWORD_SIZE = 16,
     LAN_EEFLG_ONOFF = 1,     //EEPROM flag for user-defined settings (SW turn OFF/ON of the LAN)
     LAN_EEFLG_TYPE = 2,      //EEPROM flag for user-defined settings (Switch between dhcp and static)
     WIFI_EEFLG_SEC = 0b1100, // Wifi security (ap_sec_t).

--- a/src/common/eeprom_current.hpp
+++ b/src/common/eeprom_current.hpp
@@ -40,7 +40,7 @@ struct vars_body_t : public eeprom::v11::vars_body_t {
 
 #pragma pack(pop)
 
-static_assert(sizeof(vars_body_t) == sizeof(eeprom::v10::vars_body_t) + sizeof(uint8_t) * 3 + PL_API_KEY_SIZE + LAN_HOSTNAME_MAX_LEN + 1 + WIFI_MAX_SSID_LEN + 1 + WIFI_MAX_PASSWD_LEN + 1 + 1 + 2 + 5 + 4 + 1 + 6 + sizeof(uint32_t) * 5 + sizeof(vars_body_t::CONNECT_HOST) + sizeof(vars_body_t::CONNECT_TOKEN) + sizeof(vars_body_t::CONNECT_PORT) + sizeof(vars_body_t::CONNECT_TLS) + sizeof(vars_body_t::CONNECT_ENABLED),
+static_assert(sizeof(vars_body_t) == sizeof(eeprom::v10::vars_body_t) + sizeof(uint8_t) * 3 + PL_PASSWORD_SIZE + LAN_HOSTNAME_MAX_LEN + 1 + WIFI_MAX_SSID_LEN + 1 + WIFI_MAX_PASSWD_LEN + 1 + 1 + 2 + 5 + 4 + 1 + 6 + sizeof(uint32_t) * 5 + sizeof(vars_body_t::CONNECT_HOST) + sizeof(vars_body_t::CONNECT_TOKEN) + sizeof(vars_body_t::CONNECT_PORT) + sizeof(vars_body_t::CONNECT_TLS) + sizeof(vars_body_t::CONNECT_ENABLED),
     "eeprom body size does not match");
 
 static constexpr int crash_sens[2] =

--- a/src/common/eeprom_v11.hpp
+++ b/src/common/eeprom_v11.hpp
@@ -21,7 +21,7 @@ namespace eeprom::v11 {
 struct vars_body_t : public eeprom::v10::vars_body_t {
     uint8_t EEVAR_ACTIVE_NETDEV;
     uint8_t EEVAR_PL_RUN;
-    char EEVAR_PL_API_KEY[PL_API_KEY_SIZE];
+    char EEVAR_PL_PASSWORD[PL_PASSWORD_SIZE];
     uint8_t WIFI_FLAG;
     uint32_t WIFI_IP4_ADDR;
     uint32_t WIFI_IP4_MSK;
@@ -36,13 +36,13 @@ struct vars_body_t : public eeprom::v10::vars_body_t {
 
 #pragma pack(pop)
 
-static_assert(sizeof(vars_body_t) == sizeof(eeprom::v10::vars_body_t) + sizeof(uint8_t) * 3 + PL_API_KEY_SIZE + LAN_HOSTNAME_MAX_LEN + 1 + WIFI_MAX_SSID_LEN + 1 + WIFI_MAX_PASSWD_LEN + 1 + 1 + sizeof(uint32_t) * 5, "eeprom body size does not match");
+static_assert(sizeof(vars_body_t) == sizeof(eeprom::v10::vars_body_t) + sizeof(uint8_t) * 3 + PL_PASSWORD_SIZE + LAN_HOSTNAME_MAX_LEN + 1 + WIFI_MAX_SSID_LEN + 1 + WIFI_MAX_PASSWD_LEN + 1 + 1 + sizeof(uint32_t) * 5, "eeprom body size does not match");
 
 constexpr vars_body_t body_defaults = {
     eeprom::v10::body_defaults,
     0,                 // EEVAR_ACTIVE_NETDEV
     1,                 // EEVAR_PL_RUN
-    "",                // EEVAR_PL_API_KEY
+    "",                // EEVAR_PL_PASSWORD
     0,                 // EEVAR_WIFI_FLAG
     0,                 // EEVAR_WIFI_IP4_ADDR
     0,                 // EEVAR_WIFI_IP4_MSK

--- a/src/connect/marlin_printer.cpp
+++ b/src/connect/marlin_printer.cpp
@@ -318,7 +318,7 @@ std::optional<Printer::NetInfo> MarlinPrinter::net_info(Printer::Iface iface) co
 
 Printer::NetCreds MarlinPrinter::net_creds() const {
     NetCreds result = {};
-    strextract(result.api_key, sizeof result.api_key, EEVAR_PL_API_KEY);
+    strextract(result.pl_password, sizeof result.pl_password, EEVAR_PL_PASSWORD);
     strextract(result.ssid, sizeof result.ssid, EEVAR_WIFI_AP_SSID);
     return result;
 }

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -96,7 +96,7 @@ public:
         static constexpr size_t SSID_BUF = 33;
         static constexpr size_t KEY_BUF = 17;
         char ssid[SSID_BUF];
-        char api_key[KEY_BUF];
+        char pl_password[KEY_BUF];
     };
 
     enum class JobControl {

--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -183,8 +183,8 @@ namespace {
                     JSON_FIELD_STR("sn", info.serial_number) JSON_COMMA;
                     JSON_FIELD_BOOL("appendix", info.appendix) JSON_COMMA;
                     JSON_FIELD_STR("fingerprint", info.fingerprint) JSON_COMMA;
-                    if (strlen(creds.api_key) > 0) {
-                        JSON_FIELD_STR("api_key", creds.api_key) JSON_COMMA;
+                    if (strlen(creds.pl_password) > 0) {
+                        JSON_FIELD_STR("api_key", creds.pl_password) JSON_COMMA;
                     }
                     JSON_FIELD_ARR("storages");
                     if (params.has_usb) {

--- a/src/gui/screen_prusa_link.cpp
+++ b/src/gui/screen_prusa_link.cpp
@@ -11,15 +11,15 @@
 
 #include "wui_api.h"
 
-static constexpr size_t PASSWD_STR_LENGTH = PL_API_KEY_SIZE + 1; // don't need space for '%s' and '\0' since PL_API_KEY_SIZE contains '\0' too
+static constexpr size_t PASSWD_STR_LENGTH = PL_PASSWORD_SIZE + 1; // don't need space for '%s' and '\0' since PL_PASSWORD_SIZE contains '\0' too
 
 // ----------------------------------------------------------------
-// GUI Prusa Link X-Api_Key regenerate
-class MI_PL_REGENERATE_API_KEY : public WI_LABEL_t {
+// GUI Prusa Link Password regenerate
+class MI_PL_REGENERATE_PASSWORD : public WI_LABEL_t {
     constexpr static const char *const label = N_("Generate Password");
 
 public:
-    MI_PL_REGENERATE_API_KEY()
+    MI_PL_REGENERATE_PASSWORD()
         : WI_LABEL_t(_(label), IDR_NULL, is_enabled_t::yes, is_hidden_t::no) {}
 
 public:
@@ -102,7 +102,7 @@ public:
         : WI_LABEL_t(_(label), (sizeof(PRUSA_LINK_USERNAME) + 1) * GuiDefaults::FontMenuSpecial->w) {}
 };
 
-using PLMenuContainer = WinMenuContainer<MI_RETURN, MI_PL_ENABLED, MI_PL_REGENERATE_API_KEY, MI_PL_USER,
+using PLMenuContainer = WinMenuContainer<MI_RETURN, MI_PL_ENABLED, MI_PL_REGENERATE_PASSWORD, MI_PL_USER,
 #ifdef USE_ST7789
     MI_PL_PASSWORD_LABEL,
 #endif
@@ -116,8 +116,8 @@ class ScreenMenuPrusaLink : public AddSuperWindow<screen_t> {
     window_menu_t menu;
     window_header_t header;
 
-    inline void display_passwd(const char *api_key) {
-        container.Item<MI_PL_PASSWORD_VALUE>().print_password(api_key);
+    inline void display_passwd(const char *password) {
+        container.Item<MI_PL_PASSWORD_VALUE>().print_password(password);
     }
 
 public:
@@ -137,8 +137,8 @@ ScreenMenuPrusaLink::ScreenMenuPrusaLink()
     , header(this) {
     header.SetText(_(label));
     CaptureNormalWindow(menu); // set capture to list
-    display_passwd(wui_get_api_key());
-    // The user might want to read the API key from here, don't time it out on them.
+    display_passwd(wui_get_password());
+    // The user might want to read the password from here, don't time it out on them.
     ClrMenuTimeoutClose();
 }
 
@@ -152,11 +152,11 @@ void ScreenMenuPrusaLink::windowEvent(EventLock /*has private ctor*/, window_t *
         uint32_t action = ((uint32_t)param) & 0xFFFF;
         uint32_t type = ((uint32_t)param) & 0xFFFF0000;
         switch (type) {
-        case MI_PL_REGENERATE_API_KEY::EventMask::value: {
-            char api_key[PL_API_KEY_SIZE] = { 0 };
-            wui_generate_api_key(api_key, PL_API_KEY_SIZE);
-            wui_store_api_key(api_key, PL_API_KEY_SIZE);
-            display_passwd(api_key);
+        case MI_PL_REGENERATE_PASSWORD::EventMask::value: {
+            char password[PL_PASSWORD_SIZE] = { 0 };
+            wui_generate_password(password, PL_PASSWORD_SIZE);
+            wui_store_password(password, PL_PASSWORD_SIZE);
+            display_passwd(password);
             break;
         }
         case MI_PL_ENABLED::EventMask::value:

--- a/tests/unit/lib/WUI/nhttp/req_parser_tests.cpp
+++ b/tests/unit/lib/WUI/nhttp/req_parser_tests.cpp
@@ -15,7 +15,7 @@ using nhttp::handler::Selector;
 class EmptyServerDefs : public ServerDefs {
 public:
     virtual const Selector *const *selectors() const override { return {}; }
-    virtual const char *get_api_key() const override { return ""; }
+    virtual const char *get_password() const override { return ""; }
     virtual altcp_pcb *listener_alloc() const override { return {}; }
 };
 

--- a/tests/unit/lib/WUI/nhttp/server_tests.cpp
+++ b/tests/unit/lib/WUI/nhttp/server_tests.cpp
@@ -224,13 +224,13 @@ private:
         infos.push_back(conn->info);
         return conn;
     }
-    string api_key;
+    string password;
 
 public:
     MockServerDefs(vector<shared_ptr<ConnInfo>> &conn_infos)
         : infos(conn_infos) {}
     virtual const Selector *const *selectors() const override { return selectors_array; }
-    virtual const char *get_api_key() const override { return api_key.c_str(); }
+    virtual const char *get_password() const override { return password.c_str(); }
     virtual altcp_pcb *listener_alloc() const override {
         auto conn = new_conn();
         return altcp_listen(conn);
@@ -312,8 +312,8 @@ public:
         return result;
     }
 
-    void set_api_key(string key) {
-        server_defs.api_key = std::move(key);
+    void set_password(string key) {
+        server_defs.password = std::move(key);
     }
 };
 
@@ -395,7 +395,7 @@ TEST_CASE("Not found") {
 
 TEST_CASE("Authenticated ApiKey") {
     MockServer server;
-    server.set_api_key("SECRET");
+    server.set_password("SECRET");
 
     const size_t client_conn = server.new_conn();
     REQUIRE(client_conn == 1);
@@ -409,7 +409,7 @@ TEST_CASE("Authenticated ApiKey") {
 
 TEST_CASE("Not authenticated ApiKey") {
     MockServer server;
-    server.set_api_key("SECRET");
+    server.set_password("SECRET");
 
     const size_t client_conn = server.new_conn();
     REQUIRE(client_conn == 1);
@@ -461,7 +461,7 @@ TEST_CASE("No Api Key configured") {
 
 TEST_CASE("Authenticated Digest") {
     MockServer server;
-    server.set_api_key("password");
+    server.set_password("password");
 
     const size_t client_conn = server.new_conn();
     REQUIRE(client_conn == 1);
@@ -478,7 +478,7 @@ TEST_CASE("Authenticated Digest") {
 
 TEST_CASE("Not authenticated Digest") {
     MockServer server;
-    server.set_api_key("password");
+    server.set_password("password");
 
     const size_t client_conn = server.new_conn();
     REQUIRE(client_conn == 1);
@@ -508,7 +508,7 @@ TEST_CASE("Not authenticated Digest") {
 
 TEST_CASE("Digest stale nonce") {
     MockServer server;
-    server.set_api_key("password");
+    server.set_password("password");
 
     const size_t client_conn = server.new_conn();
     REQUIRE(client_conn == 1);
@@ -535,7 +535,7 @@ TEST_CASE("Digest stale nonce") {
 // without prompting the user for new auth info
 TEST_CASE("Stale nonce and wrong auth") {
     MockServer server;
-    server.set_api_key("password");
+    server.set_password("password");
 
     const size_t client_conn = server.new_conn();
     REQUIRE(client_conn == 1);


### PR DESCRIPTION
Internally renamed api_key to password, so that it corresponds with what we externally expose to users.