### PR TITLE
Increase timer/daemon task priority to highest - 1

### DIFF
--- a/include/freertos/FreeRTOSConfig.h
+++ b/include/freertos/FreeRTOSConfig.h
@@ -140,8 +140,13 @@ extern uint32_t SystemCoreClock;
     #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
 #endif
 
-#define configUSE_TIMERS             1
-#define configTIMER_TASK_PRIORITY    3
+#define configUSE_TIMERS 1
+/* Apart from running timer the timer task also executes function triggered
+ * from ISR. Notably this includes event group events. This requires the
+ * priority to be high so that the events are delivered timely. Otherwise
+ * high priority tasks might end up waiting for their events until low priority
+ * tasks yield.*/
+#define configTIMER_TASK_PRIORITY    ((configMAX_PRIORITIES - 1) - 1)
 #define configTIMER_QUEUE_LENGTH     10
 #define configTIMER_TASK_STACK_DEPTH configMINIMAL_STACK_SIZE
 


### PR DESCRIPTION
This is to ensure function calls scheduled by FreeRTOS from ISR are not delayed too much. Notably this fixes UART write timeouts.