### PR TITLE
Longer nonce valid period for PUT and POST

### DIFF
--- a/lib/WUI/nhttp/req_parser.cpp
+++ b/lib/WUI/nhttp/req_parser.cpp
@@ -294,10 +294,13 @@ bool RequestParser::nonce_valid(uint64_t nonce_to_check) const {
     uint32_t random = static_cast<uint32_t>(nonce_to_check >> 32);
     uint32_t time = nonce_to_check & 0xffffffff;
     auto age = ticks_s() - time;
+    // Make valid period for POST and PUT longer, to avoid infinit uploading
+    // loops if nonce get stale for upload request.
+    uint32_t max_valid_age = has_body(method) ? http::extended_valid_nonce_period : http::valid_nonce_period;
     // sanity check
     if (age >= 0 && nonce_random != 0) {
         // really valid?
-        if (random == nonce_random && age < 5)
+        if (random == nonce_random && age < max_valid_age)
             return true;
     }
     return false;

--- a/lib/WUI/nhttp/status_page.cpp
+++ b/lib/WUI/nhttp/status_page.cpp
@@ -28,16 +28,7 @@ StatusPage::StatusPage(http::Status status, const RequestParser &parser, const c
     , status(status)
     , json_content(parser.accepts_json) {
     auto default_close_handling = parser.can_keep_alive() ? CloseHandling::KeepAlive : CloseHandling::Close;
-    switch (parser.method) {
-    case http::Get:
-    case http::Head:
-    case http::Delete:
-        close_handling = default_close_handling;
-        break;
-    default:
-        close_handling = status >= 300 ? CloseHandling::ErrorClose : default_close_handling;
-        break;
-    }
+    close_handling = has_body(parser.method) and status >= 300 ? CloseHandling::ErrorClose : default_close_handling;
 }
 StatusPage::StatusPage(http::Status status, CloseHandling close_handling, bool json_content, const char *extra_content)
     : extra_content(extra_content)

--- a/src/common/http/httpc.cpp
+++ b/src/common/http/httpc.cpp
@@ -181,7 +181,7 @@ optional<Error> HttpClient::send_request(const char *host, Connection *conn, Req
     CHECKED(buffer.write_fmt("%s %s HTTP/1.1\r\n", to_str(method), request.url()));
     CHECKED(buffer.header("Host", host, nullopt));
     CHECKED(buffer.header("Connection", "keep-alive", nullopt));
-    if (has_out_body(method)) {
+    if (has_body(method)) {
         CHECKED(buffer.header("Transfer-Encoding", "chunked", nullopt));
         CHECKED(buffer.header("Content-Type", to_str(request.content_type()), nullopt));
     }
@@ -195,7 +195,7 @@ optional<Error> HttpClient::send_request(const char *host, Connection *conn, Req
 
     optional<Error> err_out = nullopt;
 
-    if (has_out_body(method)) {
+    if (has_body(method)) {
         bool has_more = true;
         while (has_more) {
             // Currently, the body generation doesn't handle split/small buffer. So

--- a/src/common/http/types.h
+++ b/src/common/http/types.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstdlib>
 #include <cassert>
+#include <cstdint>
 
 namespace http {
 
@@ -34,7 +35,7 @@ constexpr const char *to_str(Method method) {
     }
 }
 
-constexpr bool has_out_body(Method method) {
+constexpr bool has_body(Method method) {
     switch (method) {
     case Post:
     case Put:
@@ -134,5 +135,13 @@ enum Status {
 // That saves quite some space compared with having two buffers.
 static const size_t MAX_URL_LEN = 100;
 using Url = std::array<char, MAX_URL_LEN>;
+
+// # of seconds after which nonce becomes stale for digest authentication
+// the extended version is used for requests with body, so that PrusaLink
+// hopefully never gets stale nonce for request uploading a gcode, which
+// can cause an infinit upload loop, if the browser does not read errors
+// before sending the whole body.
+static const uint32_t valid_nonce_period = 5;
+static const uint32_t extended_valid_nonce_period = 8;
 
 }


### PR DESCRIPTION
 Many browsers can't handle early error on request and keep sending the body anyway and only read the error afterwards. This doesn't work well with uploading gcode with digest authentication, because if the nonce at first is stale, we sent Unauthorized with a new one, but if the upload takes longer then the valid period of the nonce it is already stale, when they retry the request, thus creating a nice infinit upload loop.
 
The longer valid period for upload requests should solve this, by making it impossible to send them with invalid nonce in the first place, because the periodic GET for stats about the printer will always get stale first and get a new nonce.

BFW-3074