### PR TITLE
Connect info sending

### DIFF
--- a/lib/WUI/link_content/prusa_link_api.cpp
+++ b/lib/WUI/link_content/prusa_link_api.cpp
@@ -112,6 +112,7 @@ namespace {
                 return StatusPage(Status::NotFound, parser);
             }
         } else {
+            wui_gcode_modified();
             return StatusPage(Status::NoContent, parser);
         }
     }

--- a/lib/WUI/wui_api.cpp
+++ b/lib/WUI/wui_api.cpp
@@ -40,6 +40,7 @@ bool sntp_time_init = false;
 static char wui_media_LFN[FILE_NAME_BUFFER_LEN]; // static buffer for gcode file name
 static char wui_media_SFN_path[FILE_PATH_BUFFER_LEN];
 static std::atomic<uint32_t> uploaded_gcodes;
+static std::atomic<uint32_t> modified_gcodes;
 
 // example of simple callback automatically sending print response (click on print button) in preview fsm
 // it would be better to use queue to fet rid of no longer current commands
@@ -342,6 +343,10 @@ uint32_t wui_gcodes_uploaded() {
     return uploaded_gcodes;
 }
 
+uint32_t wui_gcodes_mods() {
+    return modified_gcodes;
+}
+
 bool wui_start_print(char *filename, bool autostart_if_able) {
     marlin_update_vars(MARLIN_VAR_MSK2(MARLIN_VAR_PRNSTATE, MARLIN_VAR_FILENAME));
     const bool printer_can_print = marlin_remote_print_ready(!autostart_if_able);
@@ -371,9 +376,14 @@ bool wui_start_print(char *filename, bool autostart_if_able) {
 }
 
 bool wui_uploaded_gcode(char *filename, bool start_print) {
+    modified_gcodes++;
     uploaded_gcodes++;
 
     return wui_start_print(filename, start_print);
+}
+
+void wui_gcode_modified() {
+    modified_gcodes++;
 }
 
 bool wui_is_file_being_printed(const char *filename) {

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -189,6 +189,16 @@ bool wui_uploaded_gcode(char *path, bool start_print);
 /// Thread safe.
 uint32_t wui_gcodes_uploaded();
 
+/// Number of gcode modifications - uploaded, deleted, ...
+///
+/// Similar purpose as with wui_gcodes_uploaded (to watch for something
+/// changing), but also includes deletes (and in future, possible other
+/// operations like renames).
+uint32_t wui_gcodes_mods();
+
+/// A gcode was modified, count it into the number of modifications.
+void wui_gcode_modified();
+
 ////////////////////////////////////////////////////////////////////////////
 /// @brief initialize marlin client for tcpip thread
 ///

--- a/src/common/crc32.c
+++ b/src/common/crc32.c
@@ -1,8 +1,10 @@
 #include <inttypes.h>
-#include "cmsis_os.h"
 #include "crc32.h"
 #include <config.h>
-#include "stm32f4xx_hal.h"
+#ifdef CRC32_USE_HW
+    #include "cmsis_os.h"
+    #include "stm32f4xx_hal.h"
+#endif
 
 #ifdef CRC32_USE_HW
 osMutexDef(crc32_hw_mutex);
@@ -17,6 +19,7 @@ void crc32_init(void) {
 #endif //CRC32_USE_HW
 }
 
+#ifdef CRC32_USE_HW
 static uint32_t reverse_crc32(uint32_t current_crc, uint32_t desired_crc) {
     static const uint32_t table[16] = {
         0x00000000, 0xB2B4BCB6, 0x61A864DB, 0xD31CD86D, 0xC350C9B6, 0x71E47500, 0xA2F8AD6D, 0x104C11DB,
@@ -77,6 +80,7 @@ uint32_t crc32_eeprom(const uint32_t *buffer, uint32_t length) {
     osMutexRelease(crc32_hw_mutex_id);
     return result;
 }
+#endif
 
 static uint32_t crc32_sw(const uint8_t *buffer, uint32_t length, uint32_t crc) {
     uint32_t value = crc ^ 0xFFFFFFFF;

--- a/src/connect/changes.hpp
+++ b/src/connect/changes.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace connect_client {
+
+class Tracked {
+private:
+    uint32_t hash = 0;
+    bool dirty = true;
+
+public:
+    bool is_dirty() const {
+        return dirty;
+    }
+
+    void mark_clean() {
+        dirty = false;
+    }
+
+    void mark_dirty() {
+        dirty = true;
+    }
+
+    bool set_hash(uint32_t new_hash) {
+        if (new_hash != hash) {
+            mark_dirty();
+            hash = new_hash;
+        }
+
+        return is_dirty();
+    }
+};
+
+}

--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -274,6 +274,8 @@ optional<OnlineStatus> connect::communicate(CachedFactory &conn_factory) {
         return OnlineStatus::NoConfig;
     }
 
+    printer.renew();
+
     auto action = planner.next_action();
 
     // Handle sleeping first. That one doesn't need the connection.
@@ -316,8 +318,6 @@ optional<OnlineStatus> connect::communicate(CachedFactory &conn_factory) {
             cache = *result;
         }
     });
-
-    printer.renew();
 
     HttpClient http(conn_factory);
 

--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -88,7 +88,7 @@ namespace {
         }
 
     public:
-        BasicRequest(Printer &printer, const Printer::Config &config, const Action &action)
+        BasicRequest(Printer &printer, const Printer::Config &config, const Action &action, optional<uint32_t> last_telemetry_fingerprint, uint32_t &telemetry_fingerprint_out)
             : hdrs {
                 // Even though the fingerprint is on a temporary, that
                 // pointer is guaranteed to stay stable.
@@ -96,7 +96,7 @@ namespace {
                 { "Token", config.token, nullopt },
                 { nullptr, nullptr, nullopt }
             }
-            , renderer(RenderState(printer, action))
+            , renderer(RenderState(printer, action, last_telemetry_fingerprint, telemetry_fingerprint_out))
             , target_url(visit([](const auto &action) { return url(action); }, action)) {}
         virtual const char *url() const override {
             return target_url;
@@ -294,6 +294,8 @@ optional<OnlineStatus> connect::communicate(CachedFactory &conn_factory) {
     // Make sure to reconnect if the configuration changes .
     if (cfg_changed) {
         conn_factory.invalidate();
+        // Possibly new server, new telemetry cache...
+        telemetry_fingerprint = nullopt;
     }
 
     // Let it reconnect if it needs it.
@@ -316,7 +318,10 @@ optional<OnlineStatus> connect::communicate(CachedFactory &conn_factory) {
 
     HttpClient http(conn_factory);
 
-    BasicRequest request(printer, config, action);
+    uint32_t telemetry_out = 0;
+    const bool is_full_telemetry = holds_alternative<SendTelemetry>(action) && !get<SendTelemetry>(action).empty;
+
+    BasicRequest request(printer, config, action, telemetry_fingerprint, telemetry_out);
     const auto result = http.send(request);
 
     if (holds_alternative<Error>(result)) {
@@ -333,8 +338,16 @@ optional<OnlineStatus> connect::communicate(CachedFactory &conn_factory) {
     // The server has nothing to tell us
     case Status::NoContent:
         planner.action_done(ActionResult::Ok);
+        if (is_full_telemetry) {
+            telemetry_fingerprint = telemetry_out;
+        }
         return OnlineStatus::Ok;
     case Status::Ok: {
+        if (is_full_telemetry) {
+            // Yes, even before checking the command we got is OK. We did send
+            // the telemetry, what happens to the command doesn't matter.
+            telemetry_fingerprint = telemetry_out;
+        }
         if (resp.command_id.has_value()) {
             const auto sub_resp = handle_server_resp(resp);
             return visit([&](auto &&arg) -> optional<OnlineStatus> {

--- a/src/connect/connect.hpp
+++ b/src/connect/connect.hpp
@@ -36,6 +36,7 @@ private:
     Planner planner;
     Printer &printer;
     SharedBuffer &buffer;
+    std::optional<uint32_t> telemetry_fingerprint;
 
     using ServerResp = std::variant<std::monostate, Command, http::Error>;
 

--- a/src/connect/connect.hpp
+++ b/src/connect/connect.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "buffer.hpp"
-#include <http/httpc.hpp>
+#include "changes.hpp"
 #include "planner.hpp"
 #include "printer.hpp"
+
+#include <http/httpc.hpp>
 
 namespace connect_client {
 
@@ -33,19 +35,23 @@ class connect {
 private:
     class CachedFactory;
 
+    Tracked telemetry_changes;
+    // We want to make sure to send a full telemetry every now and then even if nothing changed.
+    // (There seems to be a problem on the server, not being able to cope with that).
+    //
+    // This is in addition to the telemetry changes tracker.
+    uint32_t last_full_telemetry;
     Planner planner;
     Printer &printer;
     SharedBuffer &buffer;
-    std::optional<uint32_t> telemetry_fingerprint;
-    // We want to make sure to send a full telemetry every now and then even if nothing changed.
-    // (There seems to be a problem on the server, not being able to cope with that).
-    uint32_t last_full_telemetry;
 
     using ServerResp = std::variant<std::monostate, Command, http::Error>;
 
     // transmission and reception with Connect server
     std::optional<OnlineStatus> communicate(CachedFactory &conn_factory);
     ServerResp handle_server_resp(http::Response response);
+    connect(const connect &other) = delete;
+    connect(connect &&other) = delete;
 
 public:
     connect(Printer &printer, SharedBuffer &buffer);

--- a/src/connect/connect.hpp
+++ b/src/connect/connect.hpp
@@ -37,6 +37,9 @@ private:
     Printer &printer;
     SharedBuffer &buffer;
     std::optional<uint32_t> telemetry_fingerprint;
+    // We want to make sure to send a full telemetry every now and then even if nothing changed.
+    // (There seems to be a problem on the server, not being able to cope with that).
+    uint32_t last_full_telemetry;
 
     using ServerResp = std::variant<std::monostate, Command, http::Error>;
 

--- a/src/connect/marlin_printer.cpp
+++ b/src/connect/marlin_printer.cpp
@@ -9,6 +9,7 @@
 #include <odometer.hpp>
 #include <netdev.h>
 #include <print_utils.hpp>
+#include <wui_api.h>
 
 #include <cassert>
 #include <cstdlib>
@@ -379,6 +380,10 @@ bool MarlinPrinter::set_ready(bool ready) {
 
 bool MarlinPrinter::is_printing() const {
     return marlin_is_printing();
+}
+
+uint32_t MarlinPrinter::files_hash() const {
+    return wui_gcodes_mods();
 }
 
 }

--- a/src/connect/marlin_printer.cpp
+++ b/src/connect/marlin_printer.cpp
@@ -377,4 +377,8 @@ bool MarlinPrinter::set_ready(bool ready) {
     return true;
 }
 
+bool MarlinPrinter::is_printing() const {
+    return marlin_is_printing();
+}
+
 }

--- a/src/connect/marlin_printer.hpp
+++ b/src/connect/marlin_printer.hpp
@@ -34,6 +34,7 @@ public:
     virtual void submit_gcode(const char *code) override;
     virtual bool set_ready(bool ready) override;
     virtual bool is_printing() const override;
+    virtual uint32_t files_hash() const override;
 
     static bool load_cfg_from_ini();
 };

--- a/src/connect/marlin_printer.hpp
+++ b/src/connect/marlin_printer.hpp
@@ -33,6 +33,7 @@ public:
     virtual bool start_print(const char *path) override;
     virtual void submit_gcode(const char *code) override;
     virtual bool set_ready(bool ready) override;
+    virtual bool is_printing() const override;
 
     static bool load_cfg_from_ini();
 };

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -46,6 +46,7 @@ struct Event {
     /// Reasons are constant strings, therefore the non-owned const char * ‒
     /// they are not supposed to get "constructed" or interpolated.
     const char *reason = nullptr;
+    bool info_rescan_files = false;
 };
 
 using Action = std::variant<
@@ -150,6 +151,8 @@ private:
 
     // Tracking if we should resend the INFO message due to some changes.
     Tracked info_changes;
+    // Tracking if we should ask for rescan of our files.
+    Tracked file_changes;
 
 public:
     Planner(Printer &printer)

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "buffer.hpp"
+#include "changes.hpp"
 #include "command.hpp"
 #include "printer.hpp"
 
@@ -146,6 +147,9 @@ private:
     };
 
     BackgroundResult background_task(BackgroundGcode &);
+
+    // Tracking if we should resend the INFO message due to some changes.
+    Tracked info_changes;
 
 public:
     Planner(Printer &printer)

--- a/src/connect/printer.cpp
+++ b/src/connect/printer.cpp
@@ -106,7 +106,7 @@ uint32_t Printer::info_fingerprint() const {
 
     return crc
         .add_str(creds.ssid)
-        .add_str(creds.api_key)
+        .add_str(creds.pl_password)
         .add(params().has_usb)
         .done();
 }

--- a/src/connect/printer.cpp
+++ b/src/connect/printer.cpp
@@ -7,16 +7,73 @@
 using std::make_tuple;
 using std::tuple;
 
+namespace {
+
+struct Crc {
+    uint32_t crc = 0;
+
+    template <class T>
+    Crc &add(const T &value) {
+        crc = crc32_calc_ex(crc, reinterpret_cast<const uint8_t *>(&value), sizeof value);
+        return *this;
+    }
+
+    Crc &add_str(const char *s) {
+        crc = crc32_calc_ex(crc, reinterpret_cast<const uint8_t *>(s), strlen(s));
+        return *this;
+    }
+
+    uint32_t done() const {
+        return crc;
+    }
+};
+
+}
+
 namespace connect_client {
 
+uint32_t Printer::Params::telemetry_fingerprint(bool include_xy_axes) const {
+    // Note: keep in sync with the rendering of telemetry in render.cpp
+    // Note: There are some guessed "precision" constants - making sure we
+    //   don't resend the telemetry too often because something changes only a
+    //   little bit.
+
+    Crc crc;
+
+    if (include_xy_axes) {
+        // Add the axes, but with only whole-int precision.
+        crc
+            .add(int(pos[Printer::X_AXIS_POS]))
+            .add(int(pos[Printer::Y_AXIS_POS]));
+    }
+
+    return crc
+        .add(int(pos[Printer::Z_AXIS_POS]))
+        .add(print_speed)
+        .add(flow_factor)
+        .add(job_id)
+        // The RPM values are in thousands and fluctuating a bit, we don't want
+        // that to trigger the send too often, only when it actually really
+        // changes.
+        .add(print_fan_rpm / 500)
+        .add(heatbreak_fan_rpm / 500)
+        // Report only about once every 10mm of filament
+        .add(int(filament_used / 10))
+        .add(int(temp_nozzle))
+        .add(int(target_nozzle))
+        .add(int(temp_bed))
+        .add(int(temp_nozzle))
+        .done();
+}
+
 uint32_t Printer::Config::crc() const {
-    uint32_t crc = 0;
-    crc = crc32_calc_ex(crc, reinterpret_cast<const uint8_t *>(host), strlen(host));
-    crc = crc32_calc_ex(crc, reinterpret_cast<const uint8_t *>(token), strlen(token));
-    crc = crc32_calc_ex(crc, reinterpret_cast<const uint8_t *>(&port), sizeof port);
-    crc = crc32_calc_ex(crc, reinterpret_cast<const uint8_t *>(&tls), sizeof tls);
-    crc = crc32_calc_ex(crc, reinterpret_cast<const uint8_t *>(&enabled), sizeof enabled);
-    return crc;
+    return Crc()
+        .add_str(host)
+        .add_str(token)
+        .add(port)
+        .add(tls)
+        .add(enabled)
+        .done();
 }
 
 tuple<Printer::Config, bool> Printer::config(bool reset_fingerprint) {

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -141,6 +141,8 @@ public:
     std::tuple<Config, bool> config(bool reset_fingerprint = true);
 
     virtual ~Printer() = default;
+
+    uint32_t info_fingerprint() const;
 };
 
 }

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -133,6 +133,7 @@ public:
     // it in. But that doesn't meen it has been executed.
     virtual void submit_gcode(const char *gcode) = 0;
     virtual bool set_ready(bool ready) = 0;
+    virtual bool is_printing() const = 0;
 
     // Returns a newly reloaded config and a flag if it changed since last load
     // (unless the reset_fingerprint is set to false, in which case the flag is

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -63,6 +63,8 @@ public:
         uint8_t progress_percent;
         bool has_usb;
         DeviceState state;
+
+        uint32_t telemetry_fingerprint(bool include_xy_axes) const;
     };
 
     struct Config {

--- a/src/connect/printer.hpp
+++ b/src/connect/printer.hpp
@@ -134,6 +134,7 @@ public:
     virtual void submit_gcode(const char *gcode) = 0;
     virtual bool set_ready(bool ready) = 0;
     virtual bool is_printing() const = 0;
+    virtual uint32_t files_hash() const = 0;
 
     // Returns a newly reloaded config and a flag if it changed since last load
     // (unless the reset_fingerprint is set to false, in which case the flag is

--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -15,6 +15,7 @@ using json::JsonResult;
 using std::get_if;
 using std::make_tuple;
 using std::move;
+using std::optional;
 using std::tuple;
 using std::visit;
 
@@ -85,32 +86,46 @@ namespace {
     JsonResult render_msg(size_t resume_point, JsonOutput &output, const RenderState &state, const SendTelemetry &telemetry) {
         const auto params = state.printer.params();
         const bool printing = is_printing(params.state);
+
+        const uint32_t current_fingerprint = params.telemetry_fingerprint(!printing);
+        const bool update_telemetry = !state.last_telemetry_fingerprint.has_value() || state.last_telemetry_fingerprint.value() != current_fingerprint;
+        state.telemetry_fingerprint_out = current_fingerprint;
         // Keep the indentation of the JSON in here!
         // clang-format off
         JSON_START;
         JSON_OBJ_START;
             if (!telemetry.empty) {
-                JSON_FIELD_FFIXED("temp_nozzle", params.temp_nozzle, 1) JSON_COMMA;
-                JSON_FIELD_FFIXED("temp_bed", params.temp_bed, 1) JSON_COMMA;
-                JSON_FIELD_FFIXED("target_nozzle", params.target_nozzle, 1) JSON_COMMA;
-                JSON_FIELD_FFIXED("target_bed", params.target_bed, 1) JSON_COMMA;
-                JSON_FIELD_INT("speed", params.print_speed) JSON_COMMA;
-                JSON_FIELD_INT("flow", params.flow_factor) JSON_COMMA;
-                if (!printing) {
-                    // To avoid spamming the DB, connect doesn't want positions during printing
-                    JSON_FIELD_FFIXED("axis_x", params.pos[Printer::X_AXIS_POS], 2) JSON_COMMA;
-                    JSON_FIELD_FFIXED("axis_y", params.pos[Printer::Y_AXIS_POS], 2) JSON_COMMA;
-                }
-                JSON_FIELD_FFIXED("axis_z", params.pos[Printer::Z_AXIS_POS], 2) JSON_COMMA;
+                // These are not included in the fingerprint as they are changing a lot.
                 if (printing) {
-                    JSON_FIELD_INT("job_id", params.job_id) JSON_COMMA;
                     JSON_FIELD_INT("time_printing", params.print_duration) JSON_COMMA;
                     JSON_FIELD_INT("time_remaining", params.time_to_end) JSON_COMMA;
                     JSON_FIELD_INT("progress", params.progress_percent) JSON_COMMA;
-                    JSON_FIELD_INT("fan_extruder", params.heatbreak_fan_rpm) JSON_COMMA;
-                    JSON_FIELD_INT("fan_print", params.print_fan_rpm) JSON_COMMA;
-                    JSON_FIELD_FFIXED("filament", params.filament_used, 1) JSON_COMMA;
                 }
+
+                if (update_telemetry) {
+                    JSON_FIELD_FFIXED("temp_nozzle", params.temp_nozzle, 1) JSON_COMMA;
+                    JSON_FIELD_FFIXED("temp_bed", params.temp_bed, 1) JSON_COMMA;
+                    JSON_FIELD_FFIXED("target_nozzle", params.target_nozzle, 1) JSON_COMMA;
+                    JSON_FIELD_FFIXED("target_bed", params.target_bed, 1) JSON_COMMA;
+                    JSON_FIELD_INT("speed", params.print_speed) JSON_COMMA;
+                    JSON_FIELD_INT("flow", params.flow_factor) JSON_COMMA;
+                    if (!printing) {
+                        // To avoid spamming the DB, connect doesn't want positions during printing
+                        JSON_FIELD_FFIXED("axis_x", params.pos[Printer::X_AXIS_POS], 2) JSON_COMMA;
+                        JSON_FIELD_FFIXED("axis_y", params.pos[Printer::Y_AXIS_POS], 2) JSON_COMMA;
+                    }
+                    JSON_FIELD_FFIXED("axis_z", params.pos[Printer::Z_AXIS_POS], 2) JSON_COMMA;
+                    if (printing) {
+                        JSON_FIELD_INT("job_id", params.job_id) JSON_COMMA;
+                        JSON_FIELD_INT("fan_extruder", params.heatbreak_fan_rpm) JSON_COMMA;
+                        JSON_FIELD_INT("fan_print", params.print_fan_rpm) JSON_COMMA;
+                        JSON_FIELD_FFIXED("filament", params.filament_used, 1) JSON_COMMA;
+                    }
+                }
+
+                // State is sent always, first because it seems important, but
+                // also, we want something that doesn't have the final comma on
+                // it.
                 JSON_FIELD_STR("state", to_str(params.state));
             }
         JSON_OBJ_END;
@@ -571,11 +586,13 @@ FileExtra::FileExtra(unique_file_ptr file)
 FileExtra::FileExtra(const char *base_path, unique_dir_ptr dir)
     : renderer(move(DirRenderer(base_path, move(dir)))) {}
 
-RenderState::RenderState(const Printer &printer, const Action &action)
+RenderState::RenderState(const Printer &printer, const Action &action, optional<uint32_t> last_telemetry_fingerprint, uint32_t &fingerprint_out)
     : printer(printer)
     , action(action)
     , lan(printer.net_info(Printer::Iface::Ethernet))
-    , wifi(printer.net_info(Printer::Iface::Wifi)) {
+    , wifi(printer.net_info(Printer::Iface::Wifi))
+    , last_telemetry_fingerprint(last_telemetry_fingerprint)
+    , telemetry_fingerprint_out(fingerprint_out) {
     memset(&st, 0, sizeof st);
 
     if (const auto *event = get_if<Event>(&action); event != nullptr) {

--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -232,6 +232,9 @@ namespace {
                             //
                             // We'll set it to false once we support something of it.
                             JSON_FIELD_BOOL("ro", true) JSON_COMMA;
+                            if (event.info_rescan_files) {
+                                JSON_FIELD_BOOL("rescan", true) JSON_COMMA;
+                            }
                             JSON_FIELD_BOOL("is_sfn", true);
                         JSON_OBJ_END;
                     }

--- a/src/connect/render.hpp
+++ b/src/connect/render.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "changes.hpp"
 #include "printer.hpp"
 #include "planner.hpp"
 
@@ -70,16 +71,15 @@ public:
 struct RenderState {
     const Printer &printer;
     const Action &action;
+    Tracked &telemetry_changes;
     bool has_stat = false;
     struct stat st;
     FileExtra file_extra;
     // XXX: Variantize
     std::optional<Printer::NetInfo> lan;
     std::optional<Printer::NetInfo> wifi;
-    std::optional<uint32_t> last_telemetry_fingerprint;
-    uint32_t &telemetry_fingerprint_out;
 
-    RenderState(const Printer &printer, const Action &action, std::optional<uint32_t> last_telemetry_fingerprint, uint32_t &telemetry_fingerprint_out);
+    RenderState(const Printer &printer, const Action &action, Tracked &telemetry_changes);
 };
 
 class Renderer : public json::JsonRenderer<RenderState> {

--- a/src/connect/render.hpp
+++ b/src/connect/render.hpp
@@ -76,8 +76,10 @@ struct RenderState {
     // XXX: Variantize
     std::optional<Printer::NetInfo> lan;
     std::optional<Printer::NetInfo> wifi;
+    std::optional<uint32_t> last_telemetry_fingerprint;
+    uint32_t &telemetry_fingerprint_out;
 
-    RenderState(const Printer &printer, const Action &action);
+    RenderState(const Printer &printer, const Action &action, std::optional<uint32_t> last_telemetry_fingerprint, uint32_t &telemetry_fingerprint_out);
 };
 
 class Renderer : public json::JsonRenderer<RenderState> {

--- a/tests/unit/connect/CMakeLists.txt
+++ b/tests/unit/connect/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(
   connect_tests
   ${CMAKE_CURRENT_BINARY_DIR}/http_resp_automaton.cpp
   ${CMAKE_SOURCE_DIR}/src/common/automata/core.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/crc32.c
   ${CMAKE_SOURCE_DIR}/src/common/json_encode.c
   ${CMAKE_SOURCE_DIR}/src/common/segmented_json.cpp
   ${CMAKE_SOURCE_DIR}/src/common/basename.c
@@ -12,11 +13,13 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/connect/render.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/command.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/planner.cpp
+  ${CMAKE_SOURCE_DIR}/src/connect/printer.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/hostname.cpp
   command.cpp
   missing_functions.cpp
   render.cpp
   hostname.cpp
+  printer.cpp
   ${CMAKE_SOURCE_DIR}/tests/stubs/jsmn_impl.c
   ${CMAKE_SOURCE_DIR}/tests/stubs/strlcpy.c
   )

--- a/tests/unit/connect/CMakeLists.txt
+++ b/tests/unit/connect/CMakeLists.txt
@@ -49,9 +49,14 @@ add_dependencies(connect_tests generate-httpc-automata-tests-connect)
 # Planner tests are separate. They mock time and don't want to poison that for others.
 add_executable(
   connect_planner_tests
-  ${CMAKE_SOURCE_DIR}/src/connect/planner.cpp ${CMAKE_SOURCE_DIR}/src/connect/command.cpp
-  ${CMAKE_SOURCE_DIR}/tests/stubs/jsmn_impl.c ${CMAKE_SOURCE_DIR}/tests/stubs/strlcpy.c
-  time_mock.cpp planner.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/crc32.c
+  ${CMAKE_SOURCE_DIR}/src/connect/planner.cpp
+  ${CMAKE_SOURCE_DIR}/src/connect/command.cpp
+  ${CMAKE_SOURCE_DIR}/src/connect/printer.cpp
+  ${CMAKE_SOURCE_DIR}/tests/stubs/jsmn_impl.c
+  ${CMAKE_SOURCE_DIR}/tests/stubs/strlcpy.c
+  time_mock.cpp
+  planner.cpp
   )
 target_include_directories(
   connect_planner_tests

--- a/tests/unit/connect/config.h
+++ b/tests/unit/connect/config.h
@@ -1,0 +1,4 @@
+// Intentionally left black.
+//
+// Just replace the system-wide config.h with test-specific one that enables
+// nothing.

--- a/tests/unit/connect/mock_printer.h
+++ b/tests/unit/connect/mock_printer.h
@@ -65,6 +65,10 @@ public:
     virtual bool set_ready(bool) override {
         return true;
     }
+
+    virtual bool is_printing() const override {
+        return false;
+    }
 };
 
 }

--- a/tests/unit/connect/mock_printer.h
+++ b/tests/unit/connect/mock_printer.h
@@ -69,6 +69,10 @@ public:
     virtual bool is_printing() const override {
         return false;
     }
+
+    virtual uint32_t files_hash() const override {
+        return 0;
+    }
 };
 
 }

--- a/tests/unit/connect/printer.cpp
+++ b/tests/unit/connect/printer.cpp
@@ -1,0 +1,18 @@
+#include <printer.hpp>
+
+#include <catch2/catch.hpp>
+
+using namespace connect_client;
+
+TEST_CASE("Params CRC") {
+    Printer::Params params;
+
+    uint32_t empty_crc = params.telemetry_fingerprint(true);
+
+    params.temp_bed = 50;
+    params.temp_nozzle = 150;
+
+    uint32_t warm_crc = params.telemetry_fingerprint(true);
+
+    REQUIRE(empty_crc != warm_crc);
+}

--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -54,6 +54,9 @@ TEST_CASE("Render") {
         action = SendTelemetry { false };
         // clang-format off
         expected = "{"
+            "\"time_printing\":0,"
+            "\"time_remaining\":0,"
+            "\"progress\":12,"
             "\"temp_nozzle\":200.0,"
             "\"temp_bed\":65.0,"
             "\"target_nozzle\":195.0,"
@@ -62,9 +65,6 @@ TEST_CASE("Render") {
             "\"flow\":0,"
             "\"axis_z\":0.00,"
             "\"job_id\":42,"
-            "\"time_printing\":0,"
-            "\"time_remaining\":0,"
-            "\"progress\":12,"
             "\"fan_extruder\":0,"
             "\"fan_print\":0,"
             "\"filament\":0.0,"
@@ -164,7 +164,8 @@ TEST_CASE("Render") {
     }
 
     MockPrinter printer(params);
-    RenderState state(printer, action);
+    uint32_t fingerprint_out = 0;
+    RenderState state(printer, action, nullopt, fingerprint_out);
     Renderer renderer(std::move(state));
     uint8_t buffer[1024];
     const auto [result, amount] = renderer.render(buffer, sizeof buffer);

--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -165,7 +165,8 @@ TEST_CASE("Render") {
 
     MockPrinter printer(params);
     uint32_t fingerprint_out = 0;
-    RenderState state(printer, action, nullopt, fingerprint_out);
+    Tracked telemetry_changes;
+    RenderState state(printer, action, telemetry_changes);
     Renderer renderer(std::move(state));
     uint8_t buffer[1024];
     const auto [result, amount] = renderer.render(buffer, sizeof buffer);


### PR DESCRIPTION
(In the same PR, as this shares some similar/same code)

*Differential telemetry*

Depending on how much changed in telemetry, send the full version or smaller set, to save the amount of changes transferred & processed by the server.

*Notifications about changes to USB/network/files*

Proactively sending the relevant INFO message when something changes.