### PR TITLE
Sound edit in redscreens

### DIFF
--- a/src/common/sound.cpp
+++ b/src/common/sound.cpp
@@ -156,12 +156,8 @@ void Sound::_playSound(eSOUND_TYPE sound, const eSOUND_TYPE types[],
  */
 void Sound::play(eSOUND_TYPE eSoundType) {
     int t_size = 0;
-    eSOUND_MODE mode = eSoundMode;
 
-    if (eSoundType == eSOUND_TYPE::CriticalAlert)
-        mode = eSOUND_MODE::LOUD;
-
-    switch (mode) {
+    switch (eSoundMode) {
     case eSOUND_MODE::ONCE:
         t_size = sizeof(onceTypes) / sizeof(onceTypes[0]);
         _playSound(eSoundType, onceTypes, onceRepeats, onceDurations, onceDelays, t_size);

--- a/src/gui/screen_qr_error.cpp
+++ b/src/gui/screen_qr_error.cpp
@@ -115,12 +115,14 @@ ScreenErrorQR::ScreenErrorQR()
         // error found
         const uint16_t maxtemp_bed_err_num = 205;
         const uint16_t maxtemp_hotend_err_num = 206;
-        // For Maxtemp errors ignore user preferences and beep very loudly
         if (error_code_short != maxtemp_bed_err_num && error_code_short != maxtemp_hotend_err_num) {
-            // Redscreens play CriticalAlert, which beeps indefinetly
-            // Only MAXTEMP errors should beep in SILENT mode
+            // Redscreens play CriticalAlert, which beeps indefinetly in all modes
             if (Sound_GetMode() == eSOUND_MODE::SILENT)
                 Sound_Stop();
+        } else {
+            // Only MAXTEMP errors should beep in SILENT mode - very loudly
+            volume_changed = true;
+            Sound_SetVolume(10);
         }
         err_title.SetText(_(corresponding_error->err_title));
         err_description.SetText(_(corresponding_error->err_text));

--- a/src/gui/screen_qr_error.cpp
+++ b/src/gui/screen_qr_error.cpp
@@ -113,6 +113,15 @@ ScreenErrorQR::ScreenErrorQR()
         }
     } else {
         // error found
+        const uint16_t maxtemp_bed_err_num = 205;
+        const uint16_t maxtemp_hotend_err_num = 206;
+        // For Maxtemp errors ignore user preferences and beep very loudly
+        if (error_code_short != maxtemp_bed_err_num && error_code_short != maxtemp_hotend_err_num) {
+            // Redscreens play CriticalAlert, which beeps indefinetly
+            // Only MAXTEMP errors should beep in SILENT mode
+            if (Sound_GetMode() == eSOUND_MODE::SILENT)
+                Sound_Stop();
+        }
         err_title.SetText(_(corresponding_error->err_title));
         err_description.SetText(_(corresponding_error->err_text));
         show_qr();

--- a/src/gui/screen_reset_error.cpp
+++ b/src/gui/screen_reset_error.cpp
@@ -3,7 +3,6 @@
 #include "screen_reset_error.hpp"
 #include "config.h"
 #include "ScreenHandler.hpp"
-#include "sound.hpp"
 
 screen_reset_error_data_t::screen_reset_error_data_t()
     : AddSuperWindow<screen_t>()

--- a/src/gui/screen_reset_error.cpp
+++ b/src/gui/screen_reset_error.cpp
@@ -3,6 +3,7 @@
 #include "screen_reset_error.hpp"
 #include "config.h"
 #include "ScreenHandler.hpp"
+#include "sound.hpp"
 
 screen_reset_error_data_t::screen_reset_error_data_t()
     : AddSuperWindow<screen_t>()
@@ -11,6 +12,8 @@ screen_reset_error_data_t::screen_reset_error_data_t()
     ClrMenuTimeoutClose();
     ClrOnSerialClose();
     SetBackColor(COLOR_RED);
+    volume_changed = false;
+    prev_volume = Sound_GetVolume();
     start_sound();
 }
 
@@ -30,6 +33,9 @@ void screen_reset_error_data_t::windowEvent(EventLock /*has private ctor*/, wind
     case GUI_event_t::CLICK:
     case GUI_event_t::HOLD:
         Sound_Stop();
+        if (volume_changed) {
+            Sound_SetVolume(prev_volume);
+        }
     default:
         break;
     }

--- a/src/gui/screen_reset_error.hpp
+++ b/src/gui/screen_reset_error.hpp
@@ -3,7 +3,6 @@
 #include "gui.hpp"
 #include "window_text.hpp"
 #include "screen.hpp"
-#include "sound.hpp"
 
 class screen_reset_error_data_t : public AddSuperWindow<screen_t> {
 
@@ -14,7 +13,9 @@ protected:
     /// starts sound and avoids repetitive starting
     void start_sound();
     virtual void windowEvent(EventLock /*has private ctor*/, window_t *sender, GUI_event_t event, void *param) override;
+    bool volume_changed;
 
 private:
     bool sound_started;
+    int prev_volume;
 };

--- a/src/gui/screen_reset_error.hpp
+++ b/src/gui/screen_reset_error.hpp
@@ -3,6 +3,7 @@
 #include "gui.hpp"
 #include "window_text.hpp"
 #include "screen.hpp"
+#include "sound.hpp"
 
 class screen_reset_error_data_t : public AddSuperWindow<screen_t> {
 


### PR DESCRIPTION
BFW-3085

Mute redscreen sounds on SILENT mode, except for MAXTEMP errors.