### PR TITLE
Remove unnecesary initializations in redscreen or BSOD

### DIFF
--- a/include/buddy/filesystem.h
+++ b/include/buddy/filesystem.h
@@ -15,6 +15,7 @@ extern "C" {
 #endif //defined(__cplusplus)
 
 void filesystem_init();
+void init_only_littlefs();
 
 static inline const char *process_path(const char *path, const char *dev_name) {
     unsigned int dev_name_len = strlen(dev_name);

--- a/include/buddy/main.h
+++ b/include/buddy/main.h
@@ -19,6 +19,7 @@ void main_cpp();
 extern int HAL_GPIO_Initialized;
 extern int HAL_ADC_Initialized;
 extern int HAL_PWM_Initialized;
+extern void init_error_screen();
 
 extern uartrxbuff_t uart1rxbuff;
 

--- a/src/buddy/filesystem.c
+++ b/src/buddy/filesystem.c
@@ -16,6 +16,7 @@ void filesystem_init() {
 #if !defined(_RETARGETABLE_LOCKING)
     libsysbase_syscalls_init();
 #endif
+
     filesystem_fatfs_init();
     filesystem_littlefs_internal_init();
 
@@ -26,6 +27,17 @@ void filesystem_init() {
 
     int device = filesystem_root_init();
 
+    if (device != -1) {
+        setDefaultDevice(device);
+    }
+}
+void init_only_littlefs() {
+#if !defined(_RETARGETABLE_LOCKING)
+    libsysbase_syscalls_init();
+#endif
+
+    filesystem_littlefs_internal_init();
+    int device = filesystem_root_init();
     if (device != -1) {
         setDefaultDevice(device);
     }

--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -230,36 +230,14 @@ static void manufacture_report() {
     taskEXIT_CRITICAL();
 }
 
-void gui_run(void) {
+void gui_error_run(void) {
 #ifdef USE_ST7789
     st7789v_config = st7789v_cfg;
 #endif
 
     gui_init();
 
-    // select jogwheel type by measured 'reset delay'
-    // original displays with 15 position encoder returns values 1-2 (short delay - no capacitor)
-    // new displays with MK3 encoder returns values around 16000 (long delay - 100nF capacitor)
-#ifdef GUI_JOGWHEEL_SUPPORT
-    #ifdef USE_ST7789
-    // run-time jogwheel type detection decides which type of jogwheel device has (each type has different encoder behaviour)
-    jogwheel.SetJogwheelType(st7789v_reset_delay);
-    #else /* ! USE_ST7789 */
-    jogwheel.SetJogwheelType(0);
-    #endif
-#endif
-
-    GuiDefaults::Font = resource_font(IDR_FNT_NORMAL);
-    GuiDefaults::FontBig = resource_font(IDR_FNT_BIG);
-    GuiDefaults::FontMenuItems = resource_font(IDR_FNT_NORMAL);
-    GuiDefaults::FontMenuSpecial = resource_font(IDR_FNT_SPECIAL);
-    GuiDefaults::FooterFont = resource_font(IDR_FNT_SPECIAL);
-
-    gui::knob::RegisterHeldLeftAction(TakeAScreenshot);
-    gui::knob::RegisterLongPressScreenAction(DialogMoveZ::Show);
-
     ScreenFactory::Creator error_screen = nullptr;
-
     // If both redscreen and bsod are pending - both are set as displayed, but redscreen is displayed
     if (dump_err_in_xflash_is_valid() && !dump_err_in_xflash_is_displayed()) {
         error_screen = ScreenFactory::Screen<ScreenErrorQR>;
@@ -267,7 +245,6 @@ void gui_run(void) {
     }
     if (dump_in_xflash_is_valid() && !dump_in_xflash_is_displayed()) {
         if (error_screen == nullptr) {
-            blockISR(); // TODO delete blockISR() on this line to enable start after click
             switch (dump_in_xflash_get_type()) {
             case DUMP_HARDFAULT:
                 error_screen = ScreenFactory::Screen<screen_hardfault_data_t>;
@@ -282,8 +259,28 @@ void gui_run(void) {
         dump_in_xflash_set_displayed();
     }
 
+    screen_node screen_initializer { error_screen };
+    Screens::Init(screen_initializer);
+
+    while (true) {
+        gui::StartLoop();
+        Screens::Access()->Loop();
+        gui_bare_loop();
+        gui::EndLoop();
+    }
+}
+
+void gui_run(void) {
+#ifdef USE_ST7789
+    st7789v_config = st7789v_cfg;
+#endif
+
+    gui_init();
+
+    gui::knob::RegisterHeldLeftAction(TakeAScreenshot);
+    gui::knob::RegisterLongPressScreenAction(DialogMoveZ::Show);
+
     screen_node screen_initializer[] {
-        error_screen,
         ScreenFactory::Screen<screen_splash_data_t>, // splash
         ScreenFactory::Screen<screen_home_data_t>    // home
     };

--- a/src/guiapi/include/gui.hpp
+++ b/src/guiapi/include/gui.hpp
@@ -41,6 +41,9 @@ extern uint8_t gui_get_nesting(void);
 extern void gui_loop_cb();
 
 extern void gui_loop(void);
+extern void gui_error_run(void);
+
+extern void gui_bare_loop(void);
 
 extern void gui_reset_menu_timer();
 

--- a/src/guiapi/src/gui.cpp
+++ b/src/guiapi/src/gui.cpp
@@ -20,7 +20,7 @@ static bool gui_invalid = false;
 
 #ifdef GUI_USE_RTOS
 osThreadId gui_task_handle = 0;
-#endif //GUI_USE_RTOS
+#endif // GUI_USE_RTOS
 
 font_t *GuiDefaults::Font = nullptr;
 font_t *GuiDefaults::FontBig = nullptr;
@@ -47,7 +47,41 @@ static Sw_Timer<uint32_t> gui_redraw_timer(GUI_DELAY_REDRAW);
 void gui_init(void) {
     display::Init();
     gui_task_handle = osThreadGetId();
+
+    // select jogwheel type by measured 'reset delay'
+    // original displays with 15 position encoder returns values 1-2 (short delay - no capacitor)
+    // new displays with MK3 encoder returns values around 16000 (long delay - 100nF capacitor)
+#ifdef GUI_JOGWHEEL_SUPPORT
+    #ifdef USE_ST7789
+    // run-time jogwheel type detection decides which type of jogwheel device has (each type has different encoder behaviour)
+    jogwheel.SetJogwheelType(st7789v_reset_delay);
+    #else /* ! USE_ST7789 */
+    jogwheel.SetJogwheelType(0);
+    #endif
+#endif
+
+    GuiDefaults::Font = resource_font(IDR_FNT_NORMAL);
+    GuiDefaults::FontBig = resource_font(IDR_FNT_BIG);
+    GuiDefaults::FontMenuItems = resource_font(IDR_FNT_NORMAL);
+    GuiDefaults::FontMenuSpecial = resource_font(IDR_FNT_SPECIAL);
+    GuiDefaults::FooterFont = resource_font(IDR_FNT_SPECIAL);
 }
+
+#ifdef GUI_JOGWHEEL_SUPPORT
+void gui_handle_jogwheel() {
+    BtnState_t btn_ev;
+    bool is_btn = jogwheel.ConsumeButtonEvent(btn_ev);
+    int32_t encoder_diff = jogwheel.ConsumeEncoderDiff();
+
+    if (encoder_diff != 0 || is_btn) {
+        gui::knob::EventEncoder(encoder_diff);
+
+        if (is_btn) {
+            gui::knob::EventClick(btn_ev);
+        }
+    }
+}
+#endif // GUI_JOGWHEEL_SUPPORT
 
 void gui_redraw(void) {
     uint32_t now = ticks_ms();
@@ -66,7 +100,7 @@ void gui_redraw(void) {
     }
 }
 
-//at least one window is invalid
+// at least one window is invalid
 void gui_invalidate(void) {
     gui_invalid = true;
 }
@@ -81,23 +115,29 @@ void gui_loop_cb() {
     GuiMediaEventsHandler::Tick();
 }
 
+void gui_bare_loop() {
+    ++guiloop_nesting;
+
+    #ifdef GUI_JOGWHEEL_SUPPORT
+    gui_handle_jogwheel();
+    #endif // GUI_JOGWHEEL_SUPPORT
+
+    gui_timers_cycle();
+    gui_redraw();
+
+    if (gui_loop_timer.RestartIfIsOver(gui::GetTick())) {
+        Screens::Access()->ScreenEvent(nullptr, GUI_event_t::LOOP, 0);
+    }
+
+    --guiloop_nesting;
+}
+
 void gui_loop(void) {
     ++guiloop_nesting;
 
     #ifdef GUI_JOGWHEEL_SUPPORT
-    BtnState_t btn_ev;
-    bool is_btn = jogwheel.ConsumeButtonEvent(btn_ev);
-    int32_t encoder_diff = jogwheel.ConsumeEncoderDiff();
-
-    if (encoder_diff != 0 || is_btn) {
-        gui_loop_cb();
-        gui::knob::EventEncoder(encoder_diff);
-
-        if (is_btn) {
-            gui::knob::EventClick(btn_ev);
-        }
-    }
-    #endif //GUI_JOGWHEEL_SUPPORT
+    gui_handle_jogwheel();
+    #endif // GUI_JOGWHEEL_SUPPORT
 
     MediaState_t media_state = MediaState_t::unknown;
     if (GuiMediaEventsHandler::ConsumeSent(media_state)) {
@@ -121,4 +161,4 @@ void gui_loop(void) {
     --guiloop_nesting;
 }
 
-#endif //GUI_WINDOW_SUPPORT
+#endif // GUI_WINDOW_SUPPORT


### PR DESCRIPTION
We want to init just bare  minimum to display red screen or BSOD. For it we need to init SPI for xFlash and dislay, some timers for hwio, gui and buzzer and init eeprom. We also init dma for SPI comunication

BFW-2924