### PR TITLE
Network previews handle unexpected sizes

### DIFF
--- a/lib/WUI/link_content/previews.cpp
+++ b/lib/WUI/link_content/previews.cpp
@@ -31,14 +31,17 @@ optional<ConnectionState> Previews::accept(const RequestParser &parser) const {
 
     uint16_t width;
     uint16_t height;
+    bool allow_larger;
 
     if (uri[prefix.size()] == 's') {
         width = 16;
         height = 16;
+        allow_larger = false;
     } else if (uri[prefix.size()] == 'l') {
-        // TODO: Can we say "something bigger than 16" instead of hardcoding?
-        width = 220;
-        height = 140;
+        // Anything bigger than 16
+        width = 17;
+        height = 17;
+        allow_larger = true;
     } else {
         return StatusPage(Status::NotFound, parser, "Thumbnail size specification not recognized");
     }
@@ -55,7 +58,7 @@ optional<ConnectionState> Previews::accept(const RequestParser &parser) const {
         FILE *f = fopen(fname, "rb");
 
         if (f) {
-            return GCodePreview(f, fname, parser.can_keep_alive(), parser.accepts_json, width, height, parser.if_none_match);
+            return GCodePreview(f, fname, parser.can_keep_alive(), parser.accepts_json, width, height, allow_larger, parser.if_none_match);
         } else {
             return StatusPage(Status::NotFound, parser);
         }

--- a/lib/WUI/nhttp/gcode_preview.cpp
+++ b/lib/WUI/nhttp/gcode_preview.cpp
@@ -19,9 +19,9 @@ using http::ContentType;
 using http::Status;
 using std::string_view;
 
-GCodePreview::GCodePreview(FILE *f, const char *path, bool can_keep_alive, bool json_errors, uint16_t width, uint16_t height, uint32_t if_none_match)
+GCodePreview::GCodePreview(FILE *f, const char *path, bool can_keep_alive, bool json_errors, uint16_t width, uint16_t height, bool allow_larger, uint32_t if_none_match)
     : gcode(f)
-    , decoder(f, width, height, true)
+    , decoder(f, width, height, true, allow_larger)
     , can_keep_alive(can_keep_alive)
     , json_errors(json_errors) {
     struct stat finfo;

--- a/lib/WUI/nhttp/gcode_preview.h
+++ b/lib/WUI/nhttp/gcode_preview.h
@@ -23,7 +23,7 @@ private:
     bool etag_matches = false;
 
 public:
-    GCodePreview(FILE *f, const char *path, bool can_keep_alive, bool json_errors, uint16_t width, uint16_t height, uint32_t if_none_match);
+    GCodePreview(FILE *f, const char *path, bool can_keep_alive, bool json_errors, uint16_t width, uint16_t height, bool allow_larger, uint32_t if_none_match);
     bool want_read() const { return false; }
     bool want_write() const { return true; }
     handler::Step step(std::string_view input, bool terminated_by_client, uint8_t *buffer, size_t buffer_size);

--- a/src/common/gcode_thumb_decoder.cpp
+++ b/src/common/gcode_thumb_decoder.cpp
@@ -1,6 +1,6 @@
 #include "gcode_thumb_decoder.h"
 
-bool SLine::IsBeginThumbnail() const {
+bool SLine::IsBeginThumbnail(uint16_t expected_width, uint16_t expected_height, bool allow_larder) const {
     static const char thumbnailBegin[] = "; thumbnail begin "; // pozor na tu mezeru na konci
     // pokud zacina radka na ; thumbnail, lze se tim zacit zabyvat
     // nemuzu pouzivat zadne pokrocile algoritmy, musim vystacit se strcmp
@@ -17,7 +17,7 @@ bool SLine::IsBeginThumbnail() const {
         int ss = sscanf(lc, "%ux%u %lu", &x, &y, &bytes);
         if (ss == 3) { // 3 uspesne prectene itemy - rozliseni
             // je to platny zacatek thumbnailu, je to ten muj?
-            if (x == 220 && y == 124) {
+            if ((x == expected_width && y == expected_height) || (allow_larder && x >= expected_width && y >= expected_height)) {
                 // je to ten muj, ktery chci
                 return true;
             }
@@ -92,7 +92,7 @@ int GCodeThumbDecoder::Read(char *pc, int n) {
                 state = States::Error;
                 break; // konec souboru
             }
-            if (l.IsBeginThumbnail()) {
+            if (l.IsBeginThumbnail(expected_width, expected_height, allow_larger)) {
                 state = States::Base64;
                 break; // nalezen png meho rozmeru, budu cist jeho data
             }

--- a/src/common/gcode_thumb_decoder.h
+++ b/src/common/gcode_thumb_decoder.h
@@ -47,14 +47,10 @@ struct SLine {
         return (const char *)(l);
     }
 
-    bool IsBeginThumbnail() const;
+    bool IsBeginThumbnail(uint16_t expected_width, uint16_t expected_height, bool allow_larder) const;
     bool IsEndThumbnail() const;
 };
 
-// zamerne je to singleton, aby se vsude vynutilo, ze je opravdu jen jedna
-// instance v celem programu Lze to pripadne predelat, ale je potreba myslet na
-// to, ze dekodovaci automaty nejsou bezestavove a musi nekde svoje stavy
-// pamatovat.
 class GCodeThumbDecoder {
     std::optional<Base64StreamDecoder> base64SD;
 
@@ -137,13 +133,15 @@ class GCodeThumbDecoder {
     States state = States::Searching;
 
     FILE *f;
+    bool allow_larger;
     uint16_t expected_width;
     uint16_t expected_height;
 
 public:
-    inline GCodeThumbDecoder(FILE *f, uint16_t expected_width, uint16_t expected_height, bool decode_base64)
+    inline GCodeThumbDecoder(FILE *f, uint16_t expected_width, uint16_t expected_height, bool decode_base64, bool allow_larger = false)
         : base64SD(decode_base64 ? std::make_optional(Base64StreamDecoder()) : std::nullopt)
         , f(f)
+        , allow_larger(allow_larger)
         , expected_width(expected_width)
         , expected_height(expected_height) {}
 

--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -295,9 +295,6 @@ namespace {
                     JSON_FIELD_STR("display_name", event.path->name()) JSON_COMMA;
                     JSON_FIELD_STR("type", state.file_extra.renderer.holds_alternative<DirRenderer>() ? "FOLDER" : file_type_by_ext(event.path->path())) JSON_COMMA;
                     JSON_FIELD_STR("path", event.path->path());
-                    // TODO: There's a lot of other things we want to extract
-                    // from the file. To do that, we would also pre-open the
-                    // file, extract the preview, extract the info...
                 JSON_OBJ_END JSON_COMMA;
             }
 
@@ -396,8 +393,8 @@ namespace {
 }
 
 PreviewRenderer::PreviewRenderer(FILE *f)
-    // FIXME: The 16x16 request gives us 220x124 image. Any idea why? :-O
-    : decoder(f, 16, 16, false) {}
+    // Ask for anything bigger than 16x16 (at least 17x17).
+    : decoder(f, 17, 17, false, true) {}
 
 tuple<JsonResult, size_t> PreviewRenderer::render(uint8_t *buffer, size_t buffer_size) {
     constexpr const char *intro = "\"preview\":\"";


### PR DESCRIPTION
Allow the gcode preview to have arbitrary size for sending it over network (both PrusaLink and Connect). The browser can handle it and it's better than just send nothing in case the gcode has unusual settings.

BFW-3071.