### PR TITLE
connect: Don't lose reset-config flag on sleeps

### DIFF
--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -261,6 +261,13 @@ connect::ServerResp connect::handle_server_resp(Response resp) {
 optional<OnlineStatus> connect::communicate(CachedFactory &conn_factory) {
     const auto [config, cfg_changed] = printer.config();
 
+    // Make sure to reconnect if the configuration changes .
+    if (cfg_changed) {
+        conn_factory.invalidate();
+        // Possibly new server, new telemetry cache...
+        telemetry_changes.mark_dirty();
+    }
+
     if (!config.enabled) {
         planner.reset();
         osDelay(IDLE_WAIT);
@@ -293,13 +300,6 @@ optional<OnlineStatus> connect::communicate(CachedFactory &conn_factory) {
         osDelay(s->milliseconds % IDLE_WAIT);
         // Don't change the status now, we just slept
         return nullopt;
-    }
-
-    // Make sure to reconnect if the configuration changes .
-    if (cfg_changed) {
-        conn_factory.invalidate();
-        // Possibly new server, new telemetry cache...
-        telemetry_changes.mark_dirty();
     }
 
     // Let it reconnect if it needs it.


### PR DESCRIPTION
Prevent losing the configuration has changed -> reset the connection (and other things) flag in case there is an early return in the handling (most commonly a config changed in the middle of longer but segmented sleep).

BFW-3120.