### PR TITLE
Inicialize marlin_logging before wait_for_dependecies

### DIFF
--- a/lib/Arduino_Core_Buddy/cores/arduino/USBSerial.cpp
+++ b/lib/Arduino_Core_Buddy/cores/arduino/USBSerial.cpp
@@ -47,10 +47,12 @@ void USBSerial::flush(void) {
     if (enabled)
         tud_cdc_write_flush();
 
-    if (lineBufferUsed) {
-        lineBufferHook(&lineBuffer[0], lineBufferUsed);
-        lineBufferUsed = 0;
+    if (!lineBufferHook || !lineBufferUsed) {
+        return;
     }
+
+    lineBufferHook(&lineBuffer[0], lineBufferUsed);
+    lineBufferUsed = 0;
 }
 
 void USBSerial::LineBufferAppend(char character) {

--- a/lib/Arduino_Core_Buddy/cores/arduino/USBSerial.h
+++ b/lib/Arduino_Core_Buddy/cores/arduino/USBSerial.h
@@ -33,7 +33,7 @@ public:
     virtual size_t write(const uint8_t *buffer, size_t size);
     operator bool(void);
 
-    void (*lineBufferHook)(const uint8_t *buf, int len);
+    void (*lineBufferHook)(const uint8_t *buf, int len) { nullptr };
 };
 
 extern USBSerial SerialUSB;

--- a/src/buddy/main.cpp
+++ b/src/buddy/main.cpp
@@ -30,6 +30,7 @@
 #include "logging.h"
 #include "common/disable_interrupts.h"
 #include "tasks.h"
+#include <appmain.hpp>
 
 #if ENABLED(POWER_PANIC)
     #include "power_panic.hpp"
@@ -244,9 +245,7 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart) {
 }
 
 void StartDefaultTask(void const *argument) {
-    log_info(Buddy, "marlin task waiting for dependecies");
-    wait_for_dependecies(DEFAULT_TASK_DEPS);
-    log_info(Buddy, "marlin task is starting");
+    app_startup();
 
     app_run();
     for (;;) {

--- a/src/common/appmain.cpp
+++ b/src/common/appmain.cpp
@@ -30,6 +30,8 @@
 #include <Arduino.h>
 #include "trinamic.h"
 #include "../Marlin/src/module/configuration_store.h"
+#include <tasks.h>
+
 #if ENABLED(POWER_PANIC)
     #include "power_panic.hpp"
 #endif
@@ -89,6 +91,36 @@ extern uartslave_t uart6slave; // PUT slave
 extern osThreadId webServerTaskHandle; // Webserver thread(used for fast boot mode)
 #endif                                 //BUDDY_ENABLE_ETHERNET
 
+void app_marlin_serial_output_write_hook(const uint8_t *buffer, int size) {
+    while (size && (buffer[size - 1] == '\n' || buffer[size - 1] == '\r'))
+        size--;
+    log_severity_t severity = LOG_SEVERITY_INFO;
+    if (size == 2 && memcmp("ok", buffer, 2) == 0) {
+        // Do not log "ok" messages
+        return;
+    } else if (size >= 5 && memcmp("echo:", buffer, 5) == 0) {
+        buffer = buffer + 5;
+        size -= 5;
+    }
+    if (size >= 6 && memcmp("Error:", buffer, 6) == 0) {
+        buffer = buffer + 6;
+        size -= 6;
+        severity = LOG_SEVERITY_ERROR;
+    }
+    log_event(severity, Marlin, "%.*s", size, buffer);
+}
+
+void app_setup_marlin_logging() {
+    SerialUSB.lineBufferHook = app_marlin_serial_output_write_hook;
+}
+
+void app_startup() {
+    app_setup_marlin_logging();
+    log_info(Buddy, "marlin task waiting for dependecies");
+    wait_for_dependecies(DEFAULT_TASK_DEPS);
+    log_info(Buddy, "marlin task is starting");
+}
+
 void app_setup(void) {
     if (INIT_TRINAMIC_FROM_MARLIN_ONLY == 0) {
         init_tmc();
@@ -109,11 +141,7 @@ void app_idle(void) {
     osDelay(0); // switch to other threads - without this is UI slow during printing
 }
 
-void app_setup_marlin_logging();
-
 void app_run(void) {
-    app_setup_marlin_logging();
-
     LangEEPROM::getInstance();
 
     marlin_server_init();
@@ -155,29 +183,6 @@ void app_error(void) {
 
 void app_assert(uint8_t *file, uint32_t line) {
     bsod("app_assert");
-}
-
-void app_marlin_serial_output_write_hook(const uint8_t *buffer, int size) {
-    while (size && (buffer[size - 1] == '\n' || buffer[size - 1] == '\r'))
-        size--;
-    log_severity_t severity = LOG_SEVERITY_INFO;
-    if (size == 2 && memcmp("ok", buffer, 2) == 0) {
-        // Do not log "ok" messages
-        return;
-    } else if (size >= 5 && memcmp("echo:", buffer, 5) == 0) {
-        buffer = buffer + 5;
-        size -= 5;
-    }
-    if (size >= 6 && memcmp("Error:", buffer, 6) == 0) {
-        buffer = buffer + 6;
-        size -= 6;
-        severity = LOG_SEVERITY_ERROR;
-    }
-    log_event(severity, Marlin, "%.*s", size, buffer);
-}
-
-void app_setup_marlin_logging() {
-    SerialUSB.lineBufferHook = app_marlin_serial_output_write_hook;
 }
 
 #ifdef NEW_FANCTL

--- a/src/common/appmain.hpp
+++ b/src/common/appmain.hpp
@@ -11,3 +11,5 @@
 extern CFanCtl fanCtlPrint;
 extern CFanCtl fanCtlHeatBreak;
 #endif
+
+extern "C" void app_startup();


### PR DESCRIPTION
Fix bug in USBSerial. Set lineBufferHook in constructor to nullptr and check if correctly set hook in flush

Without this fix GUI is unable to start after previous commits: "Fix bootloop in GUI startup..."
"Prevent '\0' from being printed in FW version report" "Suspend other tasks while firmware version is printed onto serial" "Manufacturing report - send to SerialUSB"
Are applied.

Probable reason is that delaying Marlin (default) task start after manufacture report hits USBSerial not fully initialized.