### PR TITLE
Enable skew correction by G code

### DIFF
--- a/include/marlin/Configuration_MINI.h
+++ b/include/marlin/Configuration_MINI.h
@@ -1352,7 +1352,7 @@
  *    +-------------->X     +-------------->X     +-------------->Y
  *     XY_SKEW_FACTOR        XZ_SKEW_FACTOR        YZ_SKEW_FACTOR
  */
-//#define SKEW_CORRECTION
+#define SKEW_CORRECTION
 
 #if ENABLED(SKEW_CORRECTION)
     // Input all length measurements here:
@@ -1376,7 +1376,7 @@
     #endif
 
 // Enable this option for M852 to set skew at runtime
-//#define SKEW_CORRECTION_GCODE
+  #define SKEW_CORRECTION_GCODE
 #endif
 
 //=============================================================================


### PR DESCRIPTION
Simple construction of MINI allows significant skew. If the skew is measured, it can be easily compensated by the G code.