### PR TITLE
Transfer monitor might not known destination of the file being uploaded.

### DIFF
--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -367,7 +367,11 @@ namespace {
                     JSON_FIELD_INT_G(transfer_status.has_value(), "size", transfer_status->expected) JSON_COMMA;
                     JSON_FIELD_INT_G(transfer_status.has_value(), "transferred", transfer_status->transferred) JSON_COMMA;
                     JSON_FIELD_INT_G(transfer_status.has_value(), "time_transferring", (transfer_status->start - ticks_ms()) / 1000) JSON_COMMA;
-                    JSON_FIELD_STR_G(transfer_status.has_value(), "path", transfer_status->destination) JSON_COMMA;
+                    // Note: This works, because destination cannot go from non null to null
+                    // (if one transfer ends and another starts mid report, we bail out)
+                    if (transfer_status->destination) {
+                        JSON_FIELD_STR_G(transfer_status.has_value(), "path", transfer_status->destination) JSON_COMMA;
+                    }
                     JSON_FIELD_STR_G(transfer_status.has_value(), "type", to_str(transfer_status->type));
                } else {
                     JSON_FIELD_STR("type", "NO_TRANSFER");

--- a/src/transfers/monitor.cpp
+++ b/src/transfers/monitor.cpp
@@ -96,7 +96,7 @@ optional<Monitor::Status> Monitor::status(bool allow_stale) const {
     result.start = start;
     result.expected = expected;
     result.transferred = transferred;
-    result.destination = destination_path;
+    result.destination = strlen(destination_path) > 0 ? destination_path : nullptr;
 
     return result;
 }
@@ -153,7 +153,11 @@ optional<Monitor::Slot> Monitor::allocate(Type type, const char *dest, size_t ex
     expected = expected_size;
     transferred = 0;
     start = ticks_ms();
-    strlcpy(destination_path, dest, sizeof(destination_path));
+    if (dest != nullptr) {
+        strlcpy(destination_path, dest, sizeof(destination_path));
+    } else {
+        destination_path[0] = '\0';
+    }
 
     return Slot(*this);
 }

--- a/src/transfers/monitor.hpp
+++ b/src/transfers/monitor.hpp
@@ -149,6 +149,10 @@ public:
         ///
         /// Note that usually the file doesn't yet exist, the data is being
         /// saved into some kind of temp file and then moved.
+        ///
+        /// Also this could be nullptr if uploading by POST in Link,
+        /// because in that case the path is not known from the beginning of
+        /// the upload.
         const char *destination;
     };
 
@@ -208,6 +212,7 @@ private:
     Timestamp start;
     size_t expected;
     size_t transferred;
+
     char destination_path[FILE_PATH_BUFFER_LEN];
 
     // History related

--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -265,6 +265,36 @@ TEST_CASE("Render") {
         // clang-format on
         expected = e.str();
     }
+    // if nullptr passed instead of a path, the resulting
+    // response should omit the path param.
+    SECTION("Event - transfer info no upload path") {
+        action = Event {
+            EventType::TransferInfo,
+            11,
+        };
+        params = params_idle();
+        transfer_slot = Monitor::instance.allocate(Monitor::Type::Connect, nullptr, 1024);
+        REQUIRE(transfer_slot.has_value());
+        auto id = Monitor::instance.id();
+        REQUIRE(id.has_value());
+        stringstream e;
+        // clang-format off
+        e << "{"
+            "\"data\":{"
+                "\"transfer_id\":" << *id << ","
+                "\"size\":1024,"
+                "\"transferred\":0,"
+                "\"time_transferring\":0,"
+                "\"type\":\"FROM_CONNECT\""
+            "},"
+            "\"state\":\"IDLE\","
+            "\"command_id\":11,"
+            "\"transfer_id\":" << *id << ","
+            "\"event\":\"TRANSFER_INFO\""
+        "}";
+        // clang-format on
+        expected = e.str();
+    }
 
     MockPrinter printer(params);
     Tracked telemetry_changes;


### PR DESCRIPTION
This happens in case of POST from PrusaLink.