### PR TITLE
First layer calibration bugfix

### DIFF
--- a/src/common/selftest/selftest_firstlayer.hpp
+++ b/src/common/selftest/selftest_firstlayer.hpp
@@ -38,7 +38,6 @@ class CSelftestPart_FirstLayer {
     int temp_bed;
 
     uint32_t how_many_times_finished;
-    bool filament_known_but_detected_as_not_inserted;
     bool current_offset_is_default;
     bool reprint;
     StateSelectedByUser state_selected_by_user;


### PR DESCRIPTION
BFW-3231

When user clicks on Next in FLC initial dialog:
If filament is loaded and set, continue to calibration, otherwise ask for correct filament preheat option