### PR TITLE
Fix the time_transferring in connect TRANSFER_INFO event + change the

### DIFF
--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -366,7 +366,7 @@ namespace {
                     JSON_FIELD_INT_G(transfer_status.has_value(), "transfer_id", transfer_status->id) JSON_COMMA;
                     JSON_FIELD_INT_G(transfer_status.has_value(), "size", transfer_status->expected) JSON_COMMA;
                     JSON_FIELD_INT_G(transfer_status.has_value(), "transferred", transfer_status->transferred) JSON_COMMA;
-                    JSON_FIELD_INT_G(transfer_status.has_value(), "time_transferring", (transfer_status->start - ticks_ms()) / 1000) JSON_COMMA;
+                    JSON_FIELD_INT_G(transfer_status.has_value(), "time_transferring", ticks_s() - transfer_status->start) JSON_COMMA;
                     // Note: This works, because destination cannot go from non null to null
                     // (if one transfer ends and another starts mid report, we bail out)
                     if (transfer_status->destination) {

--- a/src/transfers/monitor.cpp
+++ b/src/transfers/monitor.cpp
@@ -152,7 +152,7 @@ optional<Monitor::Slot> Monitor::allocate(Type type, const char *dest, size_t ex
     this->type = type;
     expected = expected_size;
     transferred = 0;
-    start = ticks_ms();
+    start = ticks_s();
     if (dest != nullptr) {
         strlcpy(destination_path, dest, sizeof(destination_path));
     } else {

--- a/src/transfers/monitor.hpp
+++ b/src/transfers/monitor.hpp
@@ -135,7 +135,7 @@ public:
         /// In our own internal timestamp ‒ not necessarily anchored to
         /// anything and may wrap around!
         ///
-        /// In milliseconds.
+        /// In seconds.
         Timestamp start;
 
         /// The expected size.

--- a/tests/unit/connect/missing_functions.cpp
+++ b/tests/unit/connect/missing_functions.cpp
@@ -12,6 +12,11 @@ uint32_t ticks_ms() {
     return 0;
 }
 
+uint32_t ticks_s() {
+    // Mock only
+    return 0;
+}
+
 void get_LFN(char *lfn, size_t lfn_size, char *path) {
     strlcpy(lfn, basename(path), lfn_size);
 }

--- a/tests/unit/connect/planner.cpp
+++ b/tests/unit/connect/planner.cpp
@@ -45,7 +45,7 @@ struct Test {
         const auto sleep_typed = get_if<Sleep>(&sleep);
         REQUIRE(sleep_typed != nullptr);
         // Pretend to sleep a bit by moving the clock.
-        advance_time(sleep_typed->milliseconds);
+        advance_time_ms(sleep_typed->milliseconds);
 
         return sleep_typed->milliseconds;
     }

--- a/tests/unit/connect/time_mock.cpp
+++ b/tests/unit/connect/time_mock.cpp
@@ -2,11 +2,16 @@
 
 namespace {
 
+//in milliseconds
 uint32_t mock_time = 0;
 
 }
 
-void advance_time(uint32_t by) {
+void advance_time_s(uint32_t by) {
+    mock_time += 1000 * by;
+}
+
+void advance_time_ms(uint32_t by) {
     mock_time += by;
 }
 
@@ -14,5 +19,9 @@ extern "C" {
 
 uint32_t ticks_ms() {
     return mock_time;
+}
+
+uint32_t ticks_s() {
+    return mock_time / 1000;
 }
 }

--- a/tests/unit/connect/time_mock.h
+++ b/tests/unit/connect/time_mock.h
@@ -2,4 +2,5 @@
 
 #include <cstdint>
 
-void advance_time(uint32_t by);
+void advance_time_s(uint32_t by);
+void advance_time_ms(uint32_t by);

--- a/tests/unit/transfers/missing_functions.c
+++ b/tests/unit/transfers/missing_functions.c
@@ -3,3 +3,7 @@
 uint32_t ticks_ms() {
     return 0;
 }
+
+uint32_t ticks_s() {
+    return 0;
+}


### PR DESCRIPTION
transfer timestamp from ms to s, seconds are fine enough, we divided it by 1000 to send it out anyway.