### PR TITLE
Transfer init

### DIFF
--- a/src/buddy/main.cpp
+++ b/src/buddy/main.cpp
@@ -168,7 +168,7 @@ extern "C" void main_cpp(void) {
 
 #ifdef BUDDY_ENABLE_CONNECT
     /* definition and creation of connectTask */
-    osThreadDef(connectTask, StartConnectTask, osPriorityBelowNormal, 0, 2048);
+    osThreadDef(connectTask, StartConnectTask, osPriorityBelowNormal, 0, 2304);
     connectTaskHandle = osThreadCreate(osThread(connectTask), NULL);
 #endif
 

--- a/src/common/http/get_request.hpp
+++ b/src/common/http/get_request.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "httpc.hpp"
+
+namespace http {
+
+class GetRequest : public Request {
+private:
+    const char *url_path;
+
+public:
+    virtual const char *url() const override {
+        return url_path;
+    }
+    virtual Method method() const override {
+        return Method::Get;
+    }
+    virtual ContentType content_type() const override {
+        // This doesn't matter. As the GET method is body-less, this function
+        // is not called. But we need to provide anyway to make C++ happy.
+        return ContentType::ApplicationOctetStream;
+    }
+    GetRequest(const char *url_path)
+        : url_path(url_path) {}
+};
+
+}

--- a/src/common/http/httpc.cpp
+++ b/src/common/http/httpc.cpp
@@ -8,7 +8,7 @@
 #include <cstdarg>
 #include "chunked.h"
 #include "debug.h"
-#include <overloaded_visitor.hpp>
+#include <common/utils/overloaded_visitor.hpp>
 
 using automata::ExecutionControl;
 using http::ConnectionHandling;

--- a/src/common/http/socket.cpp
+++ b/src/common/http/socket.cpp
@@ -19,6 +19,7 @@
 #endif
 #undef log_debug
 #define log_debug(...)
+#include <log.h>
 
 #include <memory>
 

--- a/src/common/shared_buffer.hpp
+++ b/src/common/shared_buffer.hpp
@@ -10,8 +10,6 @@
 #include <cstring>
 #include <memory>
 
-namespace connect_client {
-
 template <size_t S>
 class Buffer {
 private:
@@ -115,5 +113,3 @@ public:
         return path + plen + 1;
     }
 };
-
-}

--- a/src/connect/command.hpp
+++ b/src/connect/command.hpp
@@ -38,8 +38,16 @@ struct StartPrint {
 };
 struct SetPrinterReady {};
 struct CancelPrinterReady {};
+struct StartConnectDownload {
+    // The hash itself is max 28 chars
+    static constexpr size_t HASH_BUFF = 29;
+    SharedPath path;
+    uint64_t team;
+    // In the original string form
+    char hash[HASH_BUFF];
+};
 
-using CommandData = std::variant<UnknownCommand, BrokenCommand, GcodeTooLarge, ProcessingOtherCommand, ProcessingThisCommand, Gcode, SendInfo, SendJobInfo, SendFileInfo, SendTransferInfo, PausePrint, ResumePrint, StopPrint, StartPrint, SetPrinterReady, CancelPrinterReady>;
+using CommandData = std::variant<UnknownCommand, BrokenCommand, GcodeTooLarge, ProcessingOtherCommand, ProcessingThisCommand, Gcode, SendInfo, SendJobInfo, SendFileInfo, SendTransferInfo, PausePrint, ResumePrint, StopPrint, StartPrint, SetPrinterReady, CancelPrinterReady, StartConnectDownload>;
 
 struct Command {
     CommandId id;

--- a/src/connect/command.hpp
+++ b/src/connect/command.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "buffer.hpp"
+#include <common/shared_buffer.hpp>
 
 #include <cstdint>
 #include <string_view>

--- a/src/connect/connect.hpp
+++ b/src/connect/connect.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "buffer.hpp"
 #include "changes.hpp"
 #include "planner.hpp"
 #include "printer.hpp"
 
 #include <http/httpc.hpp>
+#include <common/shared_buffer.hpp>
 
 namespace connect_client {
 

--- a/src/connect/marlin_printer.hpp
+++ b/src/connect/marlin_printer.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "buffer.hpp"
 #include "printer.hpp"
 
+#include <common/shared_buffer.hpp>
 #include <marlin_client.h>
 
 namespace connect_client {

--- a/src/connect/planner.cpp
+++ b/src/connect/planner.cpp
@@ -374,6 +374,10 @@ void Planner::command(const Command &command, const ProcessingThisCommand &) {
     assert(0);
 }
 
+void Planner::command(const Command &command, const StartConnectDownload &download) {
+    // TODO
+}
+
 // FIXME: Handle the case when we are resent a command we are already
 // processing for a while. In that case, we want to re-Accept it. Nevertheless,
 // we may not be able to parse it again because the background command might be

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -137,6 +137,7 @@ private:
     void command(const Command &, const StartPrint &);
     void command(const Command &, const CancelPrinterReady &);
     void command(const Command &, const SetPrinterReady &);
+    void command(const Command &, const StartConnectDownload &);
 
     // Try to perform some background work, if any is available.
     //

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "buffer.hpp"
 #include "changes.hpp"
 #include "command.hpp"
 #include "printer.hpp"
 
+#include <common/shared_buffer.hpp>
 #include <transfers/monitor.hpp>
+#include <transfers/download.hpp>
 
 #include <cstdint>
 #include <optional>
@@ -164,6 +165,11 @@ private:
     Tracked file_changes;
     // Tracking of ongoing transfers.
     std::optional<transfers::TransferId> observed_transfer;
+    // A download running in background.
+    //
+    // As we may have a background _task_ and a download at the same time, we
+    // need to have variables for both.
+    std::optional<transfers::Download> download;
 
 public:
     Planner(Printer &printer)

--- a/src/transfers/CMakeLists.txt
+++ b/src/transfers/CMakeLists.txt
@@ -1,1 +1,1 @@
-target_sources(firmware PRIVATE monitor.cpp)
+target_sources(firmware PRIVATE download.cpp monitor.cpp)

--- a/src/transfers/CMakeLists.txt
+++ b/src/transfers/CMakeLists.txt
@@ -1,1 +1,1 @@
-target_sources(firmware PRIVATE download.cpp monitor.cpp)
+target_sources(firmware PRIVATE download.cpp files.cpp monitor.cpp)

--- a/src/transfers/download.cpp
+++ b/src/transfers/download.cpp
@@ -1,9 +1,90 @@
 #include "download.hpp"
+#include "files.hpp"
+
+#include <common/http/get_request.hpp>
+
+#include <sys/stat.h>
+
+using http::GetRequest;
+using http::HttpClient;
+using http::Response;
+using http::Status;
+using std::get_if;
+using std::make_unique;
+using std::move;
+
+extern "C" {
+
+// Inject for tests, which are compiled on systems without it in the header.
+size_t strlcpy(char *, const char *, size_t);
+size_t strlcat(char *, const char *, size_t);
+}
 
 namespace transfers {
 
-DownloadResult start_connect_download(const char *host, uint16_t port, const char *url_path, SharedPath destination) {
-    return RefusedRequest {};
+Download::Download(ConnFactory &&factory, Response &&response, Monitor::Slot &&slot, const char *filepath, unique_file_ptr &&dest_file, size_t transfer_idx)
+    : conn_factory(move(factory))
+    , response(move(response))
+    , slot(move(slot))
+    , dest_file(move(dest_file))
+    , transfer_idx(transfer_idx) {
+    strlcpy(this->filepath.begin(), filepath, this->filepath.size());
+}
+
+Download::DownloadResult Download::start_connect_download(const char *host, uint16_t port, const char *url_path, SharedPath destination) {
+    // Early check for free transfer slot. This is not perfect, there's a race
+    // and we can _lose_ the slot before we start the download. But we can
+    // allocate it only once we know the size and for that we need to do the
+    // HTTP request. And we don't want to do that if we already know we
+    // wouldn't have the slot anyway.
+    if (Monitor::instance.id().has_value()) {
+        return NoTransferSlot {};
+    }
+
+    // Unlike the "Link" way from arbitrary client, we assume the file name
+    // doesn't contain any invalid characters and such, that the server checks
+    // it for us. That's non-critical assumption - in case the server doesn't
+    // do the check properly, we would just fail _after_ transferring the data,
+    // we just don't bother doing it at the start.
+    //
+    // We still want to check early if the file already exists (improper sync
+    // of the file tree is quite possible).
+    struct stat st = {};
+    if (stat(destination.path(), &st) == 0) {
+        return AlreadyExists {};
+    }
+
+    // TODO: The timeout is a dummy for now, will be tuned once we start
+    // reading the body.
+    ConnFactory factory(make_unique<http::SocketConnectionFactory>(host, port, 42));
+    HttpClient client(*factory.get());
+    GetRequest request {
+        url_path,
+    };
+
+    auto resp_any = client.send(request);
+
+    if (auto *resp = get_if<Response>(&resp_any); resp != nullptr) {
+        if (resp->status != Status::Ok) {
+            return RefusedRequest {};
+        }
+
+        auto slot = Monitor::instance.allocate(Monitor::Type::Connect, destination.path(), resp->content_length());
+        if (!slot.has_value()) {
+            return NoTransferSlot {};
+        }
+
+        const size_t transfer_idx = next_transfer_idx();
+        const auto fname = transfer_name(transfer_idx);
+        auto preallocated = file_preallocate(fname.begin(), resp->content_length());
+        if (auto *err = get_if<const char *>(&preallocated); err != nullptr) {
+            return Storage { *err };
+        }
+
+        return Download(move(factory), move(*resp), move(*slot), destination.path(), move(get<unique_file_ptr>(preallocated)), transfer_idx);
+    } else {
+        return RefusedRequest {};
+    }
 }
 
 }

--- a/src/transfers/download.cpp
+++ b/src/transfers/download.cpp
@@ -1,0 +1,9 @@
+#include "download.hpp"
+
+namespace transfers {
+
+DownloadResult start_connect_download(const char *host, uint16_t port, const char *url_path, SharedPath destination) {
+    return RefusedRequest {};
+}
+
+}

--- a/src/transfers/download.hpp
+++ b/src/transfers/download.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <common/shared_buffer.hpp>
+
+#include <variant>
+
+namespace transfers {
+
+class Download {
+};
+
+struct NoTransferSlot {};
+struct Filename {};
+struct RefusedRequest {};
+struct AlreadyExists {};
+
+using DownloadResult = std::variant<Download, NoTransferSlot, Filename, AlreadyExists, RefusedRequest>;
+
+DownloadResult start_connect_download(const char *host, uint16_t port, const char *url_path, SharedPath destination);
+
+}

--- a/src/transfers/download.hpp
+++ b/src/transfers/download.hpp
@@ -1,21 +1,56 @@
 #pragma once
 
+#include "monitor.hpp"
+
 #include <common/shared_buffer.hpp>
+#include <common/http/httpc.hpp>
+#include <common/http/socket_connection_factory.hpp>
+#include <common/unique_file_ptr.hpp>
 
 #include <variant>
+#include <memory>
 
 namespace transfers {
 
-class Download {
-};
-
+// Some error states
 struct NoTransferSlot {};
-struct Filename {};
 struct RefusedRequest {};
 struct AlreadyExists {};
+struct Storage {
+    const char *msg;
+};
 
-using DownloadResult = std::variant<Download, NoTransferSlot, Filename, AlreadyExists, RefusedRequest>;
+// TODO:
+//
+// Any idea how to make this thing smaller? :-(
+//
+// We could "gut" the response and keep only the part that is necessary to read
+// the body data. Would need some refactoring, but we could do that _after_
+// exhausting the temporary buffer there, so we wouldn't have to keep that one
+// around.
+//
+// If we had a FILE *->filename function, we could name the temp file as
+// real_file_name.tmp and then change the suffix only, not keeping the filename
+// around.
+class Download {
+private:
+    using ConnFactory = std::unique_ptr<http::SocketConnectionFactory>;
+    // The connection factory. That holds the connection.
+    //
+    // We need to hide it behind a pointer, because the Response holds a
+    // pointer to it and we need to move the Download around.
+    ConnFactory conn_factory;
+    http::Response response;
+    Monitor::Slot slot;
+    std::array<char, FILE_PATH_BUFFER_LEN> filepath;
+    unique_file_ptr dest_file;
+    size_t transfer_idx;
+    Download(ConnFactory &&factory, http::Response &&response, Monitor::Slot &&slot, const char *filepath, unique_file_ptr &&dest_file, size_t transfer_idx);
 
-DownloadResult start_connect_download(const char *host, uint16_t port, const char *url_path, SharedPath destination);
+public:
+    using DownloadResult = std::variant<Download, NoTransferSlot, AlreadyExists, RefusedRequest, Storage>;
+    static DownloadResult start_connect_download(const char *host, uint16_t port, const char *url_path, SharedPath destination);
+    // TODO: A way to read the body + some timeouts (timeout for now / total timeout / error)
+};
 
 }

--- a/src/transfers/files.cpp
+++ b/src/transfers/files.cpp
@@ -1,0 +1,63 @@
+#include "files.hpp"
+
+#include <atomic>
+#include <cstdio>
+#include <sys/statvfs.h>
+#include <unistd.h>
+
+using std::atomic;
+using std::memory_order_relaxed;
+
+namespace transfers {
+
+namespace {
+
+    atomic<size_t> transfer_idx = 0;
+
+    static const char *const TRANSFER_TEMPLATE = "/usb/%zu.tmp";
+
+}
+
+size_t next_transfer_idx() {
+    return transfer_idx.fetch_add(1, memory_order_relaxed);
+}
+
+TransferName transfer_name(size_t idx) {
+    TransferName result = {};
+    snprintf(result.begin(), result.size(), TRANSFER_TEMPLATE, idx);
+    return result;
+}
+
+PreallocateResult file_preallocate(const char *fname, size_t size) {
+    unique_file_ptr file(fopen(fname, "wb"));
+    // We assume the fname is valid transfer name ‒ eg /usb/XXX.tmp
+    if (!file) {
+        return "Missing USB drive";
+    }
+
+    struct statvfs svfs;
+    if (statvfs(fname, &svfs) || (svfs.f_bavail * svfs.f_frsize * svfs.f_bsize) < size) {
+        file.reset();
+        remove(fname);
+        return "USB drive full";
+    }
+    const size_t csize = svfs.f_frsize * svfs.f_bsize;
+    /* Pre-allocate the area needed for the file to prevent frequent metadata updates during the transfer.
+       We do the pre-allocation incrementally cluster-by-cluster to minimize the chance of stalling
+       the media and blocking other tasks potentially waiting for the file system lock.
+       The file size doesn't need to be exactly the size of the uploaded content. We will truncate
+       the file later on. */
+    for (unsigned long sz = csize; sz < size; sz += csize) {
+        if (fseek(file.get(), sz, SEEK_SET)) {
+            file.reset();
+            remove(fname);
+            return "USB drive full";
+        }
+    }
+    fsync(fileno(file.get()));
+    fseek(file.get(), 0, SEEK_SET);
+
+    return file;
+}
+
+}

--- a/src/transfers/files.hpp
+++ b/src/transfers/files.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <common/unique_file_ptr.hpp>
+
+#include <array>
+#include <cstdlib>
+#include <cstring>
+#include <variant>
+
+namespace transfers {
+
+static const char *const USB_MOUNT_POINT = "/usb/";
+static const size_t USB_MOUNT_POINT_LENGTH = strlen(USB_MOUNT_POINT);
+
+// Length of the temporary file name. Due to the template below, we are sure to
+// fit.
+static const size_t TRANSFER_NAME_LEN = 20;
+static const char *const CHECK_FILENAME = "/usb/check.tmp";
+
+using TransferName = std::array<char, TRANSFER_NAME_LEN>;
+
+/// Allocate a new index for temp transfer files.
+///
+/// Unique during each boot of the printer, starting at 0.
+size_t next_transfer_idx();
+
+/// Converts the index into full file name.
+///
+/// Eg. /usb/42.tmp
+TransferName transfer_name(size_t idx);
+
+using PreallocateResult = std::variant<const char *, unique_file_ptr>;
+
+/// Tries to preallocate a given file of at least given size.
+///
+/// Returns either a file handle to the opened file or a string description of
+/// an error.
+PreallocateResult file_preallocate(const char *fname, size_t size);
+
+}

--- a/tests/unit/connect/CMakeLists.txt
+++ b/tests/unit/connect/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/connect/planner.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/printer.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/hostname.cpp
+  ${CMAKE_SOURCE_DIR}/src/transfers/download.cpp
   ${CMAKE_SOURCE_DIR}/src/transfers/monitor.cpp
   command.cpp
   missing_functions.cpp
@@ -61,6 +62,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/connect/command.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/printer.cpp
   ${CMAKE_SOURCE_DIR}/src/transfers/monitor.cpp
+  ${CMAKE_SOURCE_DIR}/src/transfers/download.cpp
   ${CMAKE_SOURCE_DIR}/tests/stubs/jsmn_impl.c
   ${CMAKE_SOURCE_DIR}/tests/stubs/strlcpy.c
   ${CMAKE_SOURCE_DIR}/tests/stubs/fake_freertos_mutex.cpp

--- a/tests/unit/connect/CMakeLists.txt
+++ b/tests/unit/connect/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/common/gcode_filename.cpp
   ${CMAKE_SOURCE_DIR}/src/common/base64_stream_decoder.cpp
   ${CMAKE_SOURCE_DIR}/src/common/http/resp_parser.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/http/httpc.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/http/socket.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/http/connection.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/http/socket_connection_factory.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/render.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/command.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/planner.cpp
@@ -17,8 +21,10 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/connect/hostname.cpp
   ${CMAKE_SOURCE_DIR}/src/transfers/download.cpp
   ${CMAKE_SOURCE_DIR}/src/transfers/monitor.cpp
+  ${CMAKE_SOURCE_DIR}/src/transfers/files.cpp
   command.cpp
   missing_functions.cpp
+  missing_functions_time.cpp
   render.cpp
   hostname.cpp
   printer.cpp
@@ -57,16 +63,25 @@ add_dependencies(connect_tests generate-httpc-automata-tests-connect)
 # Planner tests are separate. They mock time and don't want to poison that for others.
 add_executable(
   connect_planner_tests
+  ${CMAKE_CURRENT_BINARY_DIR}/http_resp_automaton.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/automata/core.cpp
   ${CMAKE_SOURCE_DIR}/src/common/crc32.c
+  ${CMAKE_SOURCE_DIR}/src/common/http/resp_parser.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/http/httpc.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/http/socket.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/http/connection.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/http/socket_connection_factory.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/planner.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/command.cpp
   ${CMAKE_SOURCE_DIR}/src/connect/printer.cpp
   ${CMAKE_SOURCE_DIR}/src/transfers/monitor.cpp
   ${CMAKE_SOURCE_DIR}/src/transfers/download.cpp
+  ${CMAKE_SOURCE_DIR}/src/transfers/files.cpp
   ${CMAKE_SOURCE_DIR}/tests/stubs/jsmn_impl.c
   ${CMAKE_SOURCE_DIR}/tests/stubs/strlcpy.c
   ${CMAKE_SOURCE_DIR}/tests/stubs/fake_freertos_mutex.cpp
   time_mock.cpp
+  missing_functions.cpp
   planner.cpp
   )
 target_include_directories(
@@ -75,6 +90,7 @@ target_include_directories(
           ${CMAKE_SOURCE_DIR}/src/common ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/lib/jsmn
   )
 add_definitions(-DUNITTESTS)
+add_dependencies(connect_planner_tests generate-httpc-automata-tests-connect)
 
 add_catch_test(connect_tests)
 add_catch_test(connect_planner_tests)

--- a/tests/unit/connect/command.cpp
+++ b/tests/unit/connect/command.cpp
@@ -92,3 +92,25 @@ TEST_CASE("Set printer ready") {
 TEST_CASE("Send transfer info") {
     command_test<SendTransferInfo>("{\"command\": \"SEND_TRANSFER_INFO\", \"args\": [], \"kwargs\": {}}");
 }
+
+TEST_CASE("Start connect download - missing params") {
+    command_test<BrokenCommand>("{\"command\": \"START_CONNECT_DOWNLOAD\", \"args\": [], \"kwargs\": {}}");
+    command_test<BrokenCommand>("{\"command\": \"START_CONNECT_DOWNLOAD\", \"args\": [], \"kwargs\": {\"path\":\"/usb/whatever.gcode\", \"hash\": \"abcdef\"}}");
+    command_test<BrokenCommand>("{\"command\": \"START_CONNECT_DOWNLOAD\", \"args\": [], \"kwargs\": {\"path\":\"/usb/whatever.gcode\", \"team_id\": 42}}");
+    command_test<BrokenCommand>("{\"command\": \"START_CONNECT_DOWNLOAD\", \"args\": [], \"kwargs\": {\"team_id\": 42, \"hash\": \"abcdef\"}}");
+}
+
+TEST_CASE("Start connect download") {
+    auto cmd = command_test<StartConnectDownload>("{\"command\": \"START_CONNECT_DOWNLOAD\", \"args\": [], \"kwargs\": {\"path\":\"/usb/whatever.gcode\", \"team_id\": 42, \"hash\": \"abcdef\"}}");
+    REQUIRE(strcmp(cmd.hash, "abcdef") == 0);
+    REQUIRE(cmd.team == 42);
+    REQUIRE(strcmp(cmd.path.path(), "/usb/whatever.gcode") == 0);
+}
+
+TEST_CASE("Start connect download - reversed") {
+    // The command field is after the args, check that we are able to deal with it in the wrong order too.
+    auto cmd = command_test<StartConnectDownload>("{\"args\": [], \"kwargs\": {\"path\":\"/usb/whatever.gcode\", \"team_id\": 42, \"hash\": \"abcdef\"}, \"command\": \"START_CONNECT_DOWNLOAD\"}");
+    REQUIRE(strcmp(cmd.hash, "abcdef") == 0);
+    REQUIRE(cmd.team == 42);
+    REQUIRE(strcmp(cmd.path.path(), "/usb/whatever.gcode") == 0);
+}

--- a/tests/unit/connect/log.h
+++ b/tests/unit/connect/log.h
@@ -1,0 +1,6 @@
+#pragma once
+#define LOG_COMPONENT_DEF(...)
+#define LOG_COMPONENT_REF(...)
+#define log_info(...)
+#define log_warning(...)
+#define log_error(...)

--- a/tests/unit/connect/missing_functions.cpp
+++ b/tests/unit/connect/missing_functions.cpp
@@ -7,16 +7,6 @@ extern "C" {
 
 size_t strlcpy(char *, const char *, size_t);
 
-uint32_t ticks_ms() {
-    // Mock only
-    return 0;
-}
-
-uint32_t ticks_s() {
-    // Mock only
-    return 0;
-}
-
 void get_LFN(char *lfn, size_t lfn_size, char *path) {
     strlcpy(lfn, basename(path), lfn_size);
 }

--- a/tests/unit/connect/missing_functions_time.cpp
+++ b/tests/unit/connect/missing_functions_time.cpp
@@ -1,0 +1,14 @@
+#include <cstdint>
+
+extern "C" {
+
+uint32_t ticks_ms() {
+    // Mock only
+    return 0;
+}
+
+uint32_t ticks_s() {
+    // Mock only
+    return 0;
+}
+}

--- a/tests/unit/lib/WUI/nhttp/CMakeLists.txt
+++ b/tests/unit/lib/WUI/nhttp/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/common/basename.c
   ${CMAKE_SOURCE_DIR}/src/common/http/url_decode.cpp
   ${CMAKE_SOURCE_DIR}/src/transfers/monitor.cpp
+  ${CMAKE_SOURCE_DIR}/src/transfers/files.cpp
   ${CMAKE_SOURCE_DIR}/lib/Middlewares/Third_Party/mbedtls/library/sha256.c
   ${CMAKE_SOURCE_DIR}/lib/Middlewares/Third_Party/mbedtls/library/md5.c
   # Dependencies.


### PR DESCRIPTION
Few notes for reviewers:

* This doesn't complete the feature ‒ while the download is initialized (the request is sent, etc), it doesn't transfer it. This is left out for another PR, this one is already big.
* It contains a bit of refactoring ‒ I wanted to reuse some code from the Link transfers. 
* I've had to increase the stack size (yes, connect is currently the biggest stack out there, it's because it mostly places everything onto the stack instead of using global variables). I hope this is temporary and I'll try to bring it back down a bit soon, but I didn't want to inflate this PR with memory saving changes.

BFW-3187.