### PR TITLE
connect: Include command_id in telemetry

### DIFF
--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -90,7 +90,7 @@ namespace {
         }
 
     public:
-        BasicRequest(Printer &printer, const Printer::Config &config, const Action &action, Tracked &telemetry_changes)
+        BasicRequest(Printer &printer, const Printer::Config &config, const Action &action, Tracked &telemetry_changes, optional<CommandId> background_command_id)
             : hdrs {
                 // Even though the fingerprint is on a temporary, that
                 // pointer is guaranteed to stay stable.
@@ -98,7 +98,7 @@ namespace {
                 { "Token", config.token, nullopt },
                 { nullptr, nullptr, nullopt }
             }
-            , renderer(RenderState(printer, action, telemetry_changes))
+            , renderer(RenderState(printer, action, telemetry_changes, background_command_id))
             , target_url(visit([](const auto &action) { return url(action); }, action)) {}
         virtual const char *url() const override {
             return target_url;
@@ -342,7 +342,9 @@ optional<OnlineStatus> connect::communicate(CachedFactory &conn_factory) {
         telemetry_changes.mark_dirty();
     }
 
-    BasicRequest request(printer, config, action, telemetry_changes);
+    const auto background_command_id = planner.background_command_id();
+
+    BasicRequest request(printer, config, action, telemetry_changes, background_command_id);
     const auto result = http.send(request);
 
     if (holds_alternative<Error>(result)) {

--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -185,6 +185,10 @@ namespace {
                     }
                 }
 
+                if (state.background_command_id.has_value()) {
+                    JSON_FIELD_INT("command_id", *state.background_command_id) JSON_COMMA;
+                }
+
                 // State is sent always, first because it seems important, but
                 // also, we want something that doesn't have the final comma on
                 // it.
@@ -692,13 +696,14 @@ FileExtra::FileExtra(unique_file_ptr file)
 FileExtra::FileExtra(const char *base_path, unique_dir_ptr dir)
     : renderer(move(DirRenderer(base_path, move(dir)))) {}
 
-RenderState::RenderState(const Printer &printer, const Action &action, Tracked &telemetry_changes)
+RenderState::RenderState(const Printer &printer, const Action &action, Tracked &telemetry_changes, optional<CommandId> background_command_id)
     : printer(printer)
     , action(action)
     , telemetry_changes(telemetry_changes)
     , lan(printer.net_info(Printer::Iface::Ethernet))
     , wifi(printer.net_info(Printer::Iface::Wifi))
-    , transfer_id(Monitor::instance.id()) {
+    , transfer_id(Monitor::instance.id())
+    , background_command_id(background_command_id) {
     memset(&st, 0, sizeof st);
 
     if (const auto *event = get_if<Event>(&action); event != nullptr) {

--- a/src/connect/render.hpp
+++ b/src/connect/render.hpp
@@ -81,8 +81,9 @@ struct RenderState {
     std::optional<Printer::NetInfo> wifi;
 
     std::optional<transfers::TransferId> transfer_id = std::nullopt;
+    std::optional<CommandId> background_command_id = std::nullopt;
 
-    RenderState(const Printer &printer, const Action &action, Tracked &telemetry_changes);
+    RenderState(const Printer &printer, const Action &action, Tracked &telemetry_changes, std::optional<CommandId> background_command_id);
 };
 
 class Renderer : public json::JsonRenderer<RenderState> {

--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -49,6 +49,7 @@ TEST_CASE("Render") {
     Printer::Params params {};
     Action action;
     optional<Monitor::Slot> transfer_slot = nullopt;
+    optional<CommandId> background_command_id = nullopt;
 
     SECTION("Telemetry - empty") {
         params = params_printing();
@@ -124,6 +125,28 @@ TEST_CASE("Render") {
         "}";
         // clang-format on
         expected = e.str();
+    }
+
+    SECTION("Telemetry with background command") {
+        params = params_idle();
+        action = SendTelemetry { false };
+        stringstream e;
+        background_command_id = 13;
+        // clang-format off
+        expected = "{"
+            "\"temp_nozzle\":0.0,"
+            "\"temp_bed\":0.0,"
+            "\"target_nozzle\":0.0,"
+            "\"target_bed\":0.0,"
+            "\"speed\":0,"
+            "\"flow\":0,"
+            "\"axis_x\":0.00,"
+            "\"axis_y\":0.00,"
+            "\"axis_z\":0.00,"
+            "\"command_id\":13,"
+            "\"state\":\"IDLE\""
+        "}";
+        // clang-format on
     }
 
     SECTION("Event - rejected") {
@@ -298,7 +321,7 @@ TEST_CASE("Render") {
 
     MockPrinter printer(params);
     Tracked telemetry_changes;
-    RenderState state(printer, action, telemetry_changes);
+    RenderState state(printer, action, telemetry_changes, background_command_id);
     Renderer renderer(std::move(state));
     uint8_t buffer[1024];
     const auto [result, amount] = renderer.render(buffer, sizeof buffer);


### PR DESCRIPTION
If we are performing a background command, include the ID in telemetry. The server then can check that we are, in fact, still doing so, that we haven't lost the command.

BFW-3303.