### PR TITLE
connect: Include command_id in telemetry

### DIFF
--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -138,6 +138,10 @@ namespace {
                     }
                 }
 
+                if (state.background_command_id.has_value()) {
+                    JSON_FIELD_INT("command_id", *state.background_command_id) JSON_COMMA;
+                }
+
                 // State is sent always, first because it seems important, but
                 // also, we want something that doesn't have the final comma on
                 // it.
@@ -604,12 +608,13 @@ FileExtra::FileExtra(unique_file_ptr file)
 FileExtra::FileExtra(const char *base_path, unique_dir_ptr dir)
     : renderer(move(DirRenderer(base_path, move(dir)))) {}
 
-RenderState::RenderState(const Printer &printer, const Action &action, Tracked &telemetry_changes)
+RenderState::RenderState(const Printer &printer, const Action &action, Tracked &telemetry_changes, optional<CommandId> background_command_id)
     : printer(printer)
     , action(action)
     , telemetry_changes(telemetry_changes)
     , lan(printer.net_info(Printer::Iface::Ethernet))
-    , wifi(printer.net_info(Printer::Iface::Wifi)) {
+    , wifi(printer.net_info(Printer::Iface::Wifi))
+    , background_command_id(background_command_id) {
     memset(&st, 0, sizeof st);
 
     if (const auto *event = get_if<Event>(&action); event != nullptr) {

--- a/src/connect/render.hpp
+++ b/src/connect/render.hpp
@@ -79,7 +79,9 @@ struct RenderState {
     std::optional<Printer::NetInfo> lan;
     std::optional<Printer::NetInfo> wifi;
 
-    RenderState(const Printer &printer, const Action &action, Tracked &telemetry_changes);
+    std::optional<CommandId> background_command_id = std::nullopt;
+
+    RenderState(const Printer &printer, const Action &action, Tracked &telemetry_changes, std::optional<CommandId> background_command_id);
 };
 
 class Renderer : public json::JsonRenderer<RenderState> {

--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -42,6 +42,7 @@ TEST_CASE("Render") {
     string_view expected;
     Printer::Params params {};
     Action action;
+    optional<CommandId> background_command_id = nullopt;
 
     SECTION("Telemetry - empty") {
         params = params_printing();
@@ -87,6 +88,27 @@ TEST_CASE("Render") {
             "\"axis_x\":0.00,"
             "\"axis_y\":0.00,"
             "\"axis_z\":0.00,"
+            "\"state\":\"IDLE\""
+        "}";
+        // clang-format on
+    }
+
+    SECTION("Telemetry with background command") {
+        params = params_idle();
+        action = SendTelemetry { false };
+        background_command_id = 13;
+        // clang-format off
+        expected = "{"
+            "\"temp_nozzle\":0.0,"
+            "\"temp_bed\":0.0,"
+            "\"target_nozzle\":0.0,"
+            "\"target_bed\":0.0,"
+            "\"speed\":0,"
+            "\"flow\":0,"
+            "\"axis_x\":0.00,"
+            "\"axis_y\":0.00,"
+            "\"axis_z\":0.00,"
+            "\"command_id\":13,"
             "\"state\":\"IDLE\""
         "}";
         // clang-format on
@@ -166,7 +188,7 @@ TEST_CASE("Render") {
     MockPrinter printer(params);
     uint32_t fingerprint_out = 0;
     Tracked telemetry_changes;
-    RenderState state(printer, action, telemetry_changes);
+    RenderState state(printer, action, telemetry_changes, background_command_id);
     Renderer renderer(std::move(state));
     uint8_t buffer[1024];
     const auto [result, amount] = renderer.render(buffer, sizeof buffer);


### PR DESCRIPTION
If we are performing a background command, include the ID in telemetry. The server then can check that we are, in fact, still doing so, that we haven't lost the command.

BFW-3303.