### PR TITLE
Refactor first layer selftest data serialization

### DIFF
--- a/src/common/selftest_firstlayer_type.hpp
+++ b/src/common/selftest_firstlayer_type.hpp
@@ -13,15 +13,15 @@ struct SelftestFirstLayer_t {
     union {
         float current_offset;
         Response preselect_response;
-        uint32_t dummy; // can erase union to zeroes
-        std::array<uint8_t, 4> converter;
+        fsm::PhaseData converter;
     };
 
     constexpr SelftestFirstLayer_t(float current_offset)
         : current_offset(current_offset) {}
 
-    constexpr SelftestFirstLayer_t()
-        : dummy(0) {}
+    constexpr SelftestFirstLayer_t() {
+        converter.fill(0);
+    }
 
     constexpr SelftestFirstLayer_t(Response preselect_response)
         : preselect_response(preselect_response) {}
@@ -53,4 +53,4 @@ struct SelftestFirstLayer_t {
     void Abort() {} // currently not needed
 };
 
-static_assert(sizeof(SelftestFirstLayer_t::dummy) == sizeof(SelftestFirstLayer_t), "Erase of SelftestFirstLayer_t does not work properly");
+static_assert(sizeof(SelftestFirstLayer_t) == sizeof(fsm::PhaseData), "Data fits into phase data");


### PR DESCRIPTION
Avoid specifying the size of the FSM data.

This is low priority (below idle). I run into this once I thought I can extend the FSM data. I the end I gave up, so this is not really important.