### PR TITLE
connect: Fix off-by-one error in gcode submitting

### DIFF
--- a/src/connect/planner.cpp
+++ b/src/connect/planner.cpp
@@ -369,7 +369,7 @@ Planner::BackgroundResult Planner::background_task(BackgroundGcode &gcode) {
 
     const char *newline = reinterpret_cast<const char *>(memchr(start, '\n', tail_size));
     // If there's no newline at all, pretend that there's one just behind the end.
-    const size_t end_pos = newline != nullptr ? newline - start : tail_size + 1;
+    const size_t end_pos = newline != nullptr ? newline - start : tail_size;
 
     // We'll replace the \n with \0
     char gcode_buf[end_pos + 1];


### PR DESCRIPTION
Don't include "one extra" at the end of the gcode string; we don't copy the \n on previous lines either.

Avoids copying one garbage character after the last gcode line (which was accidentally passing through tests, since that garbage character was very often \0).

BFW-3311.