### PR TITLE
Avoid global python package installs in bootstrap

### DIFF
--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -214,7 +214,7 @@ def main() -> int:
             continue
         print('Installing Python package %s' % package)
         run(sys.executable, '-m', 'pip', 'install', package,
-            '--disable-pip-version-check')
+            '--disable-pip-version-check', '--user')
 
     # also, install openocd config meant for customization
     install_openocd_config_template()


### PR DESCRIPTION
Add --user to install commandline to avoid breaking system packages.