### PR TITLE
WUI: Always bump the modified gcodes number

### DIFF
--- a/lib/WUI/wui_api.cpp
+++ b/lib/WUI/wui_api.cpp
@@ -363,11 +363,8 @@ StartPrintResult wui_start_print(char *filename, bool autostart_if_able) {
 }
 
 bool wui_uploaded_gcode(char *filename, bool start_print) {
-
     StartPrintResult res = wui_start_print(filename, start_print);
-    if (res != StartPrintResult::Failed) {
-        modified_gcodes++;
-    }
+    wui_gcode_modified();
     if (res == StartPrintResult::Uploaded) {
         uploaded_gcodes++;
     }


### PR DESCRIPTION
Even if starting a print was requested and it fails. The gcode got uploaded nevertheless.