### PR TITLE
connect: Transfer auth headers

### DIFF
--- a/src/common/http/get_request.hpp
+++ b/src/common/http/get_request.hpp
@@ -7,6 +7,7 @@ namespace http {
 class GetRequest : public Request {
 private:
     const char *url_path;
+    const HeaderOut *hdrs;
 
 public:
     virtual const char *url() const override {
@@ -20,8 +21,12 @@ public:
         // is not called. But we need to provide anyway to make C++ happy.
         return ContentType::ApplicationOctetStream;
     }
-    GetRequest(const char *url_path)
-        : url_path(url_path) {}
+    virtual const HeaderOut *extra_headers() const override {
+        return hdrs;
+    }
+    GetRequest(const char *url_path, const HeaderOut *hdrs = nullptr)
+        : url_path(url_path)
+        , hdrs(hdrs) {}
 };
 
 }

--- a/src/connect/planner.cpp
+++ b/src/connect/planner.cpp
@@ -409,6 +409,10 @@ void Planner::command(const Command &command, const StartConnectDownload &downlo
     // Going from 443 to 80 on TLS connections
     const uint16_t port = config.port;
     const char *host = config.host;
+    const char *token = config.token;
+    // Even though we get it from a temporary, the pointer itself is stable.
+    const char *fingerprint = printer.printer_info().fingerprint;
+    const size_t fingerprint_size = Printer::PrinterInfo::FINGERPRINT_HDR_SIZE;
 
     const char *prefix = "/p/teams/";
     const char *infix = "/files/";
@@ -424,7 +428,14 @@ void Planner::command(const Command &command, const StartConnectDownload &downlo
     // Avoid warning about unused in release builds (assert off)
     (void)written;
 
-    auto down_result = Download::start_connect_download(host, port, path, download.path.path(), &printer);
+    // FIXME:
+    // We can pass the fingerprint/token now, because we only support the
+    // "development" case where even the main connection is plaintext.
+    //
+    // We can't use this in production, where we would have a TLS main
+    // connection but plaintext download connection (with encrypted file). That
+    // would leak the info.
+    auto down_result = Download::start_connect_download(host, port, path, download.path.path(), token, fingerprint, fingerprint_size, &printer);
 
     visit([&](auto &&arg) {
         using T = std::decay_t<decltype(arg)>;

--- a/src/transfers/download.hpp
+++ b/src/transfers/download.hpp
@@ -63,7 +63,7 @@ public:
     Download &operator=(Download &&other) = default;
     Download &operator=(const Download &other) = delete;
     using DownloadResult = std::variant<Download, NoTransferSlot, AlreadyExists, RefusedRequest, Storage>;
-    static DownloadResult start_connect_download(const char *host, uint16_t port, const char *url_path, const char *destination, NotifyFilechange *notify_done);
+    static DownloadResult start_connect_download(const char *host, uint16_t port, const char *url_path, const char *destination, const char *token, const char *fingerprint, size_t fingerprint_size, NotifyFilechange *notify_done);
     DownloadStep step(uint32_t max_duration_ms);
 };
 


### PR DESCRIPTION
To transfer from the real connect, we need to provide the same set of "authentication" headers.

BFW-3188.