### PR TITLE
connect: Randomize the transfer-id

### DIFF
--- a/lib/WUI/random.cpp
+++ b/lib/WUI/random.cpp
@@ -1,8 +1,8 @@
-#include <device/peripherals.h>
 #include "random.h"
 
-bool random32bit(uint32_t *random) {
+#include <device/peripherals.h>
 
+bool random32bit(uint32_t *random) {
     if (HAL_RNG_GenerateRandomNumber(&hrng, random) != HAL_OK) {
         return false;
     }

--- a/lib/WUI/random.h
+++ b/lib/WUI/random.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <stdbool.h>
 #include <cstdint>
 
 // simple wrapper around HAL_RNG_GenerateRandomNumber,

--- a/src/transfers/monitor.hpp
+++ b/src/transfers/monitor.hpp
@@ -208,7 +208,7 @@ private:
     // A bit of care needs to be employed when dealing with them, to avoid
     // races, etc.
     std::atomic<bool> transfer_active = false;
-    std::atomic<TransferId> current_id;
+    std::atomic<TransferId> current_id = 0;
 
     // Transfer related
     bool used = false;
@@ -227,8 +227,6 @@ private:
     std::array<Outcome, HISTORY_MAX_LEN> history;
 
 public:
-    Monitor();
-
     std::optional<Slot> allocate(Type type, const char *dest, size_t expected_size, bool print_after_upload = false);
 
     /// Request the status of currently running transfer.

--- a/tests/unit/connect/missing_functions.cpp
+++ b/tests/unit/connect/missing_functions.cpp
@@ -15,3 +15,8 @@ void get_LFN(char *lfn, size_t lfn_size, char *path) {
 bool f_gcode_get_next_comment_assignment(FILE *, char *, int, char *, int) {
     return false;
 }
+
+bool random32bit(uint32_t *output) {
+    *output = random();
+    return true;
+}

--- a/tests/unit/lib/WUI/nhttp/random_mock.cpp
+++ b/tests/unit/lib/WUI/nhttp/random_mock.cpp
@@ -1,4 +1,4 @@
-#include <random.h>
+#include <cstdint>
 
 bool random32bit(uint32_t *random) {
     *random = 0xaaaaaaaa;

--- a/tests/unit/transfers/CMakeLists.txt
+++ b/tests/unit/transfers/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(
   transfers_tests
   ${CMAKE_SOURCE_DIR}/src/transfers/monitor.cpp ${CMAKE_SOURCE_DIR}/tests/stubs/strlcpy.c
-  ${CMAKE_SOURCE_DIR}/tests/stubs/fake_freertos_mutex.cpp monitor.cpp missing_functions.c
+  ${CMAKE_SOURCE_DIR}/tests/stubs/fake_freertos_mutex.cpp monitor.cpp missing_functions.cpp
   )
 target_include_directories(
   transfers_tests PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/src/common

--- a/tests/unit/transfers/missing_functions.c
+++ b/tests/unit/transfers/missing_functions.c
@@ -1,9 +1,0 @@
-#include <stdint.h>
-
-uint32_t ticks_ms() {
-    return 0;
-}
-
-uint32_t ticks_s() {
-    return 0;
-}

--- a/tests/unit/transfers/missing_functions.cpp
+++ b/tests/unit/transfers/missing_functions.cpp
@@ -1,0 +1,18 @@
+#include <cstdint>
+#include <cstdlib>
+
+extern "C" {
+
+uint32_t ticks_ms() {
+    return 0;
+}
+
+uint32_t ticks_s() {
+    return 0;
+}
+}
+
+bool random32bit(uint32_t *output) {
+    *output = random();
+    return true;
+}


### PR DESCRIPTION
Make sure the initial transfer ID is random on start. Like, really random, not just random-looking, but always the same.

BFW-3306.