### PR TITLE
connect: Properly placed transfer_id

### DIFF
--- a/tests/unit/connect/render.cpp
+++ b/tests/unit/connect/render.cpp
@@ -253,7 +253,6 @@ TEST_CASE("Render") {
         // clang-format off
         e << "{"
             "\"data\":{"
-                "\"transfer_id\":" << *id << ","
                 "\"size\":1024,"
                 "\"transferred\":0,"
                 "\"progress\":0.0,"
@@ -307,7 +306,6 @@ TEST_CASE("Render") {
         // clang-format off
         e << "{"
             "\"data\":{"
-                "\"transfer_id\":" << *id << ","
                 "\"size\":1024,"
                 "\"transferred\":0,"
                 "\"progress\":0.0,"


### PR DESCRIPTION
* Placing it in the `data` section has been deprecated.
* All occurrences are in the root of the event, even though for some events it's about a past transfer and for some it's for ongoing transfer.

BFW-3409.