### PR TITLE
connect: Add timeouts to TLS connections

### DIFF
--- a/lib/Middlewares/Third_Party/mbedtls/include/mbedtls/net_sockets.h
+++ b/lib/Middlewares/Third_Party/mbedtls/include/mbedtls/net_sockets.h
@@ -98,6 +98,7 @@ extern "C" {
 typedef struct mbedtls_net_context
 {
     int fd;             /**< The underlying file descriptor                 */
+    uint8_t timeout_s;
 }
 mbedtls_net_context;
 

--- a/src/common/http/socket.cpp
+++ b/src/common/http/socket.cpp
@@ -69,11 +69,6 @@ std::optional<Error> socket_con::connection(const char *host, uint16_t port) {
     if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) == -1) {
         return Error::SetSockOpt;
     }
-    /*
-    if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, NULL, 0) == -1) {
-        return Error::SetSockOpt;
-    }
-    */
 
     int error;
     struct addrinfo hints;

--- a/src/connect/tls/tls.cpp
+++ b/src/connect/tls/tls.cpp
@@ -10,6 +10,7 @@ namespace connect_client {
 tls::tls(uint8_t timeout_s)
     : http::Connection(timeout_s) {
     mbedtls_net_init(&net_context);
+    net_context.timeout_s = timeout_s;
     mbedtls_ssl_init(&ssl_context);
     mbedtls_ssl_config_init(&ssl_config);
 }


### PR DESCRIPTION
Somehow, TLS connections were lacking timeouts on them, which resulted in the connect task completely getting stuck forever if internet access was lost at the wrong moment.

BFW-3475.