### PR TITLE
connect: Support resuming encrypted transfers

### DIFF
--- a/lib/WUI/nhttp/headers.cpp
+++ b/lib/WUI/nhttp/headers.cpp
@@ -22,6 +22,7 @@ namespace {
         { Status::Ok, "OK" },
         { Status::Created, "Created" },
         { Status::NoContent, "No Content" },
+        { Status::PartialContent, "Partial Content" },
         { Status::NotModified, "Not Modified" },
         { Status::BadRequest, "Bad Request" },
         { Status::Forbidden, "Forbidden" },

--- a/src/common/http/types.h
+++ b/src/common/http/types.h
@@ -104,6 +104,7 @@ enum Status {
     Ok = 200,
     Created = 201,
     NoContent = 204,
+    PartialContent = 206,
     NotModified = 304,
     BadRequest = 400,
     Unauthorized = 401,

--- a/src/connect/planner.cpp
+++ b/src/connect/planner.cpp
@@ -12,9 +12,12 @@
 
 using http::HeaderOut;
 using std::holds_alternative;
+using std::is_same_v;
+using std::make_tuple;
 using std::min;
 using std::nullopt;
 using std::optional;
+using std::tuple;
 using std::unique_ptr;
 using std::visit;
 using transfers::Decryptor;
@@ -58,6 +61,8 @@ namespace {
     // window. Safety measure, as it may be related to that specific event and
     // we would never recover if the failure is repeateble with it.
     const constexpr uint8_t GIVE_UP_AFTER_ATTEMPTS = 5;
+
+    const constexpr uint8_t MAX_DOWNLOAD_RETRIES = 5;
 
     optional<Duration> since(optional<Timestamp> past_event) {
         // optional::transform would be nice, but it's C++23
@@ -128,17 +133,41 @@ namespace {
         return nullptr;
     }
 
-    Download::DownloadResult init_download(Printer &printer, const Printer::Config &config, const StartConnectDownload &download) {
+    tuple<const char *, uint16_t> host_and_port(const Printer::Config &config, optional<uint16_t> port_override) {
         uint16_t port = config.port;
         if (port == 443 && config.tls) {
             // Go from encrypted to the unencrypted port automatically.
             port = 80;
         }
-        if (download.port.has_value()) {
+        if (port_override.has_value()) {
             // Manual override always takes precedence.
-            port = *download.port;
+            port = *port_override;
         }
         const char *host = config.host;
+
+        return make_tuple(host, port);
+    }
+
+    constexpr const char *const enc_prefix = "/f/";
+    constexpr const char *const enc_suffix = "/raw";
+    const size_t enc_prefix_len = strlen(enc_prefix);
+    const size_t enc_suffix_len = strlen(enc_suffix);
+    const size_t iv_len = 2 /* Binary->hex conversion*/ * StartConnectDownload::Encrypted::BLOCK_SIZE;
+    const size_t enc_url_len = enc_prefix_len + enc_suffix_len + iv_len + 1;
+
+    void make_enc_url(char *buffer /* assumed to be at least enc_url_len large */, const Decryptor::Block &iv) {
+        strcpy(buffer, enc_prefix);
+
+        for (size_t i = 0; i < iv.size(); i++) {
+            sprintf(buffer + enc_prefix_len + 2 * i, "%02hhx", iv[i]);
+        }
+
+        buffer[enc_prefix_len + 2 * iv.size()] = '\0';
+        strcat(buffer, enc_suffix);
+    }
+
+    Download::DownloadResult init_download(Printer &printer, const Printer::Config &config, const StartConnectDownload &download) {
+        const auto [host, port] = host_and_port(config, download.port);
 
         char *path = nullptr;
         HeaderOut *extra_hdrs = nullptr;
@@ -167,20 +196,8 @@ namespace {
             extra_hdrs[1] = { "Token", token, nullopt };
             extra_hdrs[2] = { nullptr, nullptr, nullopt };
         } else if (auto *encrypted = get_if<StartConnectDownload::Encrypted>(&download.details); encrypted != nullptr) {
-            const char *prefix = "/f/";
-            const size_t prefix_len = strlen(prefix);
-            const char *suffix = "/raw";
-            const size_t suffix_len = strlen(suffix);
-            const size_t buffer_len = prefix_len + 2 * encrypted->iv.size() + suffix_len + 1;
-            path = reinterpret_cast<char *>(alloca(buffer_len));
-            strcpy(path, prefix);
-
-            for (size_t i = 0; i < encrypted->iv.size(); i++) {
-                sprintf(path + prefix_len + 2 * i, "%02hhx", encrypted->iv[i]);
-            }
-
-            path[prefix_len + 2 * encrypted->iv.size()] = '\0';
-            strcat(path, suffix);
+            path = reinterpret_cast<char *>(alloca(enc_url_len));
+            make_enc_url(path, encrypted->iv);
             decryptor = make_unique<Decryptor>(encrypted->key, encrypted->iv, encrypted->orig_size);
         } else {
             assert(0);
@@ -243,8 +260,9 @@ Sleep Planner::sleep(Duration amount) {
     // "passively" watching what is or is not being transferred and the event
     // is generated after the fact anyway. No reason to block downloading for
     // that.
-    Download *down = download.has_value() ? &*download : nullptr;
-    return Sleep(amount, cmd, down);
+    bool recover_download = download.has_value() ? download->need_retry : false;
+    Download *down = download.has_value() ? &download->download : nullptr;
+    return Sleep(amount, cmd, down, recover_download);
 }
 
 Action Planner::next_action() {
@@ -548,21 +566,28 @@ void Planner::command(const Command &command, const StartConnectDownload &downlo
 
     visit([&](auto &&arg) {
         using T = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_same_v<T, transfers::Download>) {
+        if constexpr (is_same_v<T, transfers::Download>) {
             // If there was another download, it wouldn't have succeeded
             // because it wouldn't acquire the transfer slot.
             assert(!this->download.has_value());
 
-            this->download = std::move(arg);
+            this->download = ResumableDownload { std::move(arg) };
+            this->download->port = download.port;
+            if (auto *enc = get_if<StartConnectDownload::Encrypted>(&download.details); enc != nullptr) {
+                this->download->orig_size = enc->orig_size;
+                this->download->orig_iv = enc->iv;
+                // TODO: Alternatively, do we want to allow more retries on larger files? Something like 3 + size / 1MB?
+                this->download->allowed_retries = MAX_DOWNLOAD_RETRIES;
+            }
             planned_event = Event { EventType::Finished, command.id };
             transfer_start_cmd = command.id;
-        } else if constexpr (std::is_same_v<T, transfers::NoTransferSlot>) {
+        } else if constexpr (is_same_v<T, transfers::NoTransferSlot>) {
             planned_event = Event { EventType::Rejected, command.id, nullopt, nullopt, nullopt, "Another transfer in progress" };
-        } else if constexpr (std::is_same_v<T, transfers::AlreadyExists>) {
+        } else if constexpr (is_same_v<T, transfers::AlreadyExists>) {
             planned_event = Event { EventType::Rejected, command.id, nullopt, nullopt, nullopt, "File already exists" };
-        } else if constexpr (std::is_same_v<T, transfers::RefusedRequest>) {
+        } else if constexpr (is_same_v<T, transfers::RefusedRequest>) {
             planned_event = Event { EventType::Rejected, command.id, nullopt, nullopt, nullopt, "Failed to download" };
-        } else if constexpr (std::is_same_v<T, transfers::Storage>) {
+        } else if constexpr (is_same_v<T, transfers::Storage>) {
             planned_event = Event { EventType::Rejected, command.id, nullopt, nullopt, nullopt, arg.msg };
         } else {
             static_assert(always_false_v<T>, "non-exhaustive visitor!");
@@ -690,17 +715,60 @@ void Planner::background_done(BackgroundResult result) {
     background_command.reset();
 }
 
-void Planner::download_done() {
+void Planner::download_done(DownloadStep result) {
     // Similar reasons as with background_done
     assert(download.has_value());
-    // We do _not_ set the event here. We do so in watching the transfer.
-    //
-    // But we make sure the observed_transfer is set even if there was no
-    // next_event in the meantime or if it was short-circuited.
+    if (result == DownloadStep::FailedNetwork && download->allowed_retries > 0) {
+        assert(!download->need_retry);
+        download->allowed_retries--;
+        download->need_retry = true;
+    } else {
+        // We do _not_ set the event here. We do so in watching the transfer.
+        //
+        // But we make sure the observed_transfer is set even if there was no
+        // next_event in the meantime or if it was short-circuited.
 
-    observed_transfer = Monitor::instance.id();
-    assert(observed_transfer.has_value()); // Because download still holds the slot.
-    download.reset();
+        observed_transfer = Monitor::instance.id();
+        assert(observed_transfer.has_value()); // Because download still holds the slot.
+        download.reset();
+    }
+}
+
+void Planner::recover_download() {
+    assert(download.has_value());
+    assert(download->need_retry);
+    download->need_retry = false;
+    uint32_t position = download->download.position();
+
+    const auto [config, config_changed] = printer.config(false);
+    const auto [host, port] = host_and_port(config, download->port);
+
+    char url[enc_url_len];
+    make_enc_url(url, download->orig_iv);
+
+    char range[6 /* bytes = */ + 10 /* 2^32 in text */ + 1 /* - */ + 1 /* \0 */];
+    snprintf(range, sizeof range, "bytes=%" PRIu32 "-", position);
+    HeaderOut hdrs[2] = {
+        { "Range", range, nullopt },
+        { nullptr, nullptr, nullopt },
+    };
+
+    const auto result = download->download.recover_encrypted_connect_download(host, port, url, hdrs, download->orig_iv, download->orig_size);
+    visit([&](auto &&arg) {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (is_same_v<T, transfers::Continued> || is_same_v<T, transfers::FromStart>) {
+            // Everything is fine!
+        } else if constexpr (is_same_v<T, transfers::Storage>) {
+            // This is not recoverable, abort the download.
+            download_done(DownloadStep::FailedOther);
+        } else if constexpr (is_same_v<T, transfers::RefusedRequest>) {
+            // Something network related. Do more retries later.
+            download_done(DownloadStep::FailedNetwork);
+        } else {
+            static_assert(always_false_v<T>, "non-exhaustive visitor!");
+        }
+    },
+        result);
 }
 
 }

--- a/src/connect/planner.hpp
+++ b/src/connect/planner.hpp
@@ -137,11 +137,30 @@ private:
     Tracked file_changes;
     // Tracking of ongoing transfers.
     std::optional<transfers::TransferId> observed_transfer;
+
+    // We are able to resume _encrypted_ downloads.
+    //
+    // In theory, we could also try to recover plain-text ones. But they need a
+    // lot more info for that to work, and we won't be using them in practice
+    // (likely someone may be using them on a private copy of Connect, but that
+    // will likely happen on a local network that should be reliable, not on
+    // the wide broken internet).
+    //
+    // In case of a plain-text download, we simply set the number of allowed
+    // retries to 0 to "disable" them.
+    struct ResumableDownload {
+        transfers::Download download;
+        uint32_t orig_size = 0;
+        std::optional<uint16_t> port;
+        transfers::Decryptor::Block orig_iv;
+        bool need_retry = false;
+        uint8_t allowed_retries = 0;
+    };
     // A download running in background.
     //
     // As we may have a background _task_ and a download at the same time, we
     // need to have variables for both.
-    std::optional<transfers::Download> download;
+    std::optional<ResumableDownload> download;
 
     std::optional<CommandId> transfer_start_cmd = std::nullopt;
     std::optional<CommandId> print_start_cmd = std::nullopt;
@@ -178,7 +197,8 @@ public:
 
     // Only for Success/Failure.
     void background_done(BackgroundResult result);
-    void download_done();
+    void download_done(transfers::DownloadStep result);
+    void recover_download();
 
     // ID of a command being executed in the background, if any.
     std::optional<CommandId> background_command_id() const;

--- a/src/connect/sleep.cpp
+++ b/src/connect/sleep.cpp
@@ -33,7 +33,7 @@ Timestamp now() {
 }
 
 Sleep Sleep::idle() {
-    return Sleep(IDLE_WAIT, nullptr, nullptr);
+    return Sleep(IDLE_WAIT, nullptr, nullptr, false);
 }
 
 void Sleep::perform(Printer &printer, Planner &planner) {
@@ -111,13 +111,22 @@ void Sleep::perform(Printer &printer, Planner &planner) {
             need_download = false;
             assert(download != nullptr);
 
+            if (recover_download) {
+                planner.recover_download();
+                // An attempt to recover can actually "kill" the download
+                // completely. Therefore, just bail out and let the outer loop
+                // figure everything out.
+                return;
+            }
+
             switch (auto result = download->step(max_step_time); result) {
             case DownloadStep::Continue:
                 // Go for another iteration (now or during next sleep).
                 break;
+            case DownloadStep::FailedNetwork:
+            case DownloadStep::FailedOther:
             case DownloadStep::Finished:
-            case DownloadStep::Failed:
-                planner.download_done();
+                planner.download_done(result);
                 download = nullptr;
                 // Something likely changed as a result of the download
                 // being done, let the outer loop deal with that.

--- a/src/connect/sleep.hpp
+++ b/src/connect/sleep.hpp
@@ -28,6 +28,7 @@ private:
     // We would prefer optional<&T>, but that doesn't exist in C++.
     BackgroundCmd *background_cmd;
     transfers::Download *download;
+    bool recover_download;
 
 #ifdef UNITTESTS
 public:
@@ -37,9 +38,10 @@ private:
     Duration milliseconds;
 
 public:
-    Sleep(Duration duration, BackgroundCmd *cmd, transfers::Download *download)
+    Sleep(Duration duration, BackgroundCmd *cmd, transfers::Download *download, bool recover_download)
         : background_cmd(cmd)
         , download(download)
+        , recover_download(recover_download)
         , milliseconds(duration) {}
     static Sleep idle();
     /// Sleeps up to the given time, processing any background tasks if possible.

--- a/src/transfers/decrypt.cpp
+++ b/src/transfers/decrypt.cpp
@@ -71,4 +71,10 @@ uint32_t Decryptor::decrypt(uint8_t *buffer, uint32_t input_size) {
     return output_size;
 }
 
+void Decryptor::reset(const Block &iv, uint32_t orig_size) {
+    this->iv = iv;
+    this->size_left = orig_size;
+    leftover_size = 0;
+}
+
 }

--- a/src/transfers/decrypt.hpp
+++ b/src/transfers/decrypt.hpp
@@ -52,6 +52,8 @@ public:
     // * Pass the data in through that buffer, specifying the amount of data available.
     // * Process the amount returned from the function.
     uint32_t decrypt(uint8_t *data, uint32_t size);
+    // Reset the decryption, start again from the beginning.
+    void reset(const Block &iv, uint32_t size);
 };
 
 }

--- a/src/transfers/download.cpp
+++ b/src/transfers/download.cpp
@@ -14,6 +14,7 @@ using http::HeaderOut;
 using http::HttpClient;
 using http::Response;
 using http::ResponseBody;
+using http::SocketConnectionFactory;
 using http::Status;
 using std::get;
 using std::get_if;
@@ -21,6 +22,7 @@ using std::make_unique;
 using std::move;
 using std::nullopt;
 using std::optional;
+using std::tuple;
 using std::unique_ptr;
 
 namespace {
@@ -50,6 +52,25 @@ bool write_chunk(const uint8_t *data, size_t size, FILE *f) {
     // can't be split up.
     auto written = fwrite(data, size, 1, f);
     return written == 1;
+}
+
+optional<tuple<unique_ptr<SocketConnectionFactory>, Response>> send_request(const char *host, uint16_t port, const char *url_path, const HeaderOut *extra_hdrs) {
+    // 3 seconds timeout.
+    //
+    // Will be used only for the blocking operations, timeouts on the body are
+    // handled separately in our code with combination of poll / tracking of
+    // time.
+    unique_ptr<SocketConnectionFactory> factory(make_unique<http::SocketConnectionFactory>(host, port, 3000));
+    HttpClient client(*factory.get());
+    GetRequest request(url_path, extra_hdrs);
+
+    auto resp_any = client.send(request);
+
+    if (auto *resp = get_if<Response>(&resp_any); resp != nullptr) {
+        return make_tuple(move(factory), move(*resp));
+    } else {
+        return nullopt;
+    }
 }
 
 }
@@ -102,30 +123,21 @@ Download::DownloadResult Download::start_connect_download(const char *host, uint
         return AlreadyExists {};
     }
 
-    // 3 seconds timeout.
-    //
-    // Will be used only for the blocking operations, timeouts on the body are
-    // handled separately in our code with combination of poll / tracking of
-    // time.
-    ConnFactory factory(make_unique<http::SocketConnectionFactory>(host, port, 3000));
-    HttpClient client(*factory.get());
-    GetRequest request(url_path, extra_hdrs);
+    if (auto resp_any = send_request(host, port, url_path, extra_hdrs); resp_any.has_value()) {
+        auto [factory, resp] = move(*resp_any);
 
-    auto resp_any = client.send(request);
-
-    if (auto *resp = get_if<Response>(&resp_any); resp != nullptr) {
-        if (resp->status != Status::Ok) {
+        if (resp.status != Status::Ok) {
             return RefusedRequest {};
         }
 
-        auto slot = Monitor::instance.allocate(Monitor::Type::Connect, destination, resp->content_length());
+        auto slot = Monitor::instance.allocate(Monitor::Type::Connect, destination, resp.content_length());
         if (!slot.has_value()) {
             return NoTransferSlot {};
         }
 
         const size_t transfer_idx = next_transfer_idx();
         const auto fname = transfer_name(transfer_idx);
-        auto preallocated = file_preallocate(fname.begin(), resp->content_length());
+        auto preallocated = file_preallocate(fname.begin(), resp.content_length());
         if (auto *err = get_if<const char *>(&preallocated); err != nullptr) {
             return Storage { *err };
         }
@@ -141,23 +153,68 @@ Download::DownloadResult Download::start_connect_download(const char *host, uint
         // create the decryptor and then proceed on processing the body.
 
         auto file = move(get<unique_file_ptr>(preallocated));
-        auto [initial_chunk, initial_chunk_size, body] = resp->into_body();
+        auto [initial_chunk, initial_chunk_size, body] = resp.into_body();
+
+        auto download = Download(move(factory), move(body), move(*slot), move(file), transfer_idx, move(decryptor), notify_done);
 
         if (initial_chunk_size > 0) {
-            size_t size = initial_chunk_size;
-            if (decryptor.get() != nullptr) {
-                size = decryptor->decrypt(initial_chunk, size);
-            }
-            if (!write_chunk(initial_chunk, size, file.get())) {
+            if (!download.process(initial_chunk, initial_chunk_size)) {
                 return Storage { "Can't write to the file" };
             }
-            slot->progress(initial_chunk_size);
         }
 
-        return Download(move(factory), move(body), move(*slot), move(file), transfer_idx, move(decryptor), notify_done);
+        return move(download);
     } else {
         return RefusedRequest {};
     }
+}
+
+Download::RecoverResult Download::recover_encrypted_connect_download(const char *host, uint16_t port, const char *url_path, const http::HeaderOut *extra_hdrs, const Decryptor::Block &reset_iv, uint32_t reset_size) {
+    // Close anything related to the previous attempt first, before allocating anything new.
+    conn_factory.reset();
+
+    RecoverResult result = Continued {};
+
+    if (auto resp_any = send_request(host, port, url_path, extra_hdrs); resp_any.has_value()) {
+        auto [factory, resp] = move(*resp_any);
+
+        switch (resp.status) {
+        case Status::Ok:
+            rewind(dest_file.get());
+            slot.reset_progress();
+            decryptor->reset(reset_iv, reset_size);
+            result = FromStart {};
+            // No break
+        case Status::PartialContent: {
+            auto [initial_chunk, initial_chunk_size, body] = resp.into_body();
+
+            if (initial_chunk_size > 0) {
+                if (!process(initial_chunk, initial_chunk_size)) {
+                    return Storage { "Can't write to the file" };
+                }
+            }
+            response = move(body);
+            conn_factory = move(factory);
+            return result;
+        }
+        default:
+            return RefusedRequest {};
+        }
+    } else {
+        return RefusedRequest {};
+    }
+}
+
+bool Download::process(uint8_t *data, size_t size) {
+    size_t orig_size = size;
+    if (decryptor.get() != nullptr) {
+        size = decryptor->decrypt(data, size);
+    }
+    if (!write_chunk(data, size, dest_file.get())) {
+        return false;
+    }
+    slot.progress(orig_size);
+    return true;
 }
 
 DownloadStep Download::step(uint32_t max_duration_ms) {
@@ -187,7 +244,7 @@ DownloadStep Download::step(uint32_t max_duration_ms) {
                     // At least try cleaning the temp file up.
                     // (no error handling here, we have no backup plan there).
                     remove(fname.begin());
-                    return DownloadStep::Failed;
+                    return DownloadStep::FailedOther;
                 } else {
                     if (notify_done != nullptr) {
                         notify_done->notify_filechange(status->destination);
@@ -198,15 +255,10 @@ DownloadStep Download::step(uint32_t max_duration_ms) {
             slot.done(Monitor::Outcome::Finished);
             return DownloadStep::Finished;
         } else {
-            size_t size = *amt;
-            if (decryptor.get() != nullptr) {
-                size = decryptor->decrypt(buffer, size);
-            }
-            if (!write_chunk(buffer, size, dest_file.get())) {
-                return DownloadStep::Failed;
+            if (!process(buffer, *amt)) {
+                return DownloadStep::FailedOther;
             }
 
-            slot.progress(*amt);
             last_activity = ticks_ms();
             return DownloadStep::Continue;
         }
@@ -215,14 +267,21 @@ DownloadStep Download::step(uint32_t max_duration_ms) {
         if (err == Error::Timeout) {
             auto now = ticks_ms();
             if (now - last_activity >= DOWNLOAD_INACTIVITY_LIMIT) {
-                return DownloadStep::Failed;
+                return DownloadStep::FailedNetwork;
             } else {
                 return DownloadStep::Continue;
             }
         } else {
-            return DownloadStep::Failed;
+            return DownloadStep::FailedNetwork;
         }
     }
+}
+
+uint32_t Download::position() const {
+    auto status = Monitor::instance.status();
+    // We hold the slot, so we must be able to get the status.
+    assert(status.has_value());
+    return status->transferred;
 }
 
 }

--- a/src/transfers/monitor.cpp
+++ b/src/transfers/monitor.cpp
@@ -62,6 +62,11 @@ void Monitor::Slot::progress(size_t additional_bytes) {
     owner.transferred += additional_bytes;
 }
 
+void Monitor::Slot::reset_progress() {
+    Lock lock(owner.main_mutex);
+    owner.transferred = 0;
+}
+
 void Monitor::Slot::done(Outcome outcome) {
     Lock lock(owner.history_mutex);
 

--- a/src/transfers/monitor.hpp
+++ b/src/transfers/monitor.hpp
@@ -188,6 +188,8 @@ public:
         ///
         /// This is the increment, not the accumulated total.
         void progress(size_t add_bytes);
+        // Damn. We have to start over from the beginning...
+        void reset_progress();
 
         bool is_stopped();
         /// The transfer is done.


### PR DESCRIPTION
If the transfer fails, be able to recover with the Range header (and, if not supported by the server, just starting from the beginning).

BFW-3502.