### PR TITLE
De-escape json while parsing it.

### DIFF
--- a/lib/WUI/nhttp/file_command.cpp
+++ b/lib/WUI/nhttp/file_command.cpp
@@ -38,7 +38,7 @@ FileCommand::FileCommand(const char *fname, size_t content_length, bool can_keep
 
 handler::StatusPage FileCommand::process() {
     Command command = Command::Unknown;
-    const auto parse_result = parse_command(reinterpret_cast<const char *>(buffer.data()), buffer_used, [&](const Event &event) {
+    const auto parse_result = parse_command(reinterpret_cast<char *>(buffer.data()), buffer_used, [&](const Event &event) {
         if (event.depth != 1 || event.type != Type::String) {
             return;
         }

--- a/lib/WUI/nhttp/job_command.cpp
+++ b/lib/WUI/nhttp/job_command.cpp
@@ -63,7 +63,7 @@ StatusPage JobCommand::process() {
     Command pause_command = Command::ErrUnknownCommand;
     Command top_command = Command::ErrUnknownCommand;
 
-    const auto parse_result = parse_command(reinterpret_cast<const char *>(buffer.data()), buffer_used, [&](const Event &event) {
+    const auto parse_result = parse_command(reinterpret_cast<char *>(buffer.data()), buffer_used, [&](const Event &event) {
         if (event.depth != 1 || event.type != Type::String) {
             return;
         }

--- a/lib/WUI/nhttp/json_parser.h
+++ b/lib/WUI/nhttp/json_parser.h
@@ -14,7 +14,7 @@ enum class JsonParseResult {
 };
 
 template <class Callback>
-JsonParseResult parse_command(const char *buff, size_t size, Callback &&callback) {
+JsonParseResult parse_command(char *buff, size_t size, Callback &&callback) {
     // For technical reasons in its own function. This releases the used stack
     // before going to talk to marlin (which reportedly uses large stack too).
     jsmn_parser parser;

--- a/src/common/json_encode.c
+++ b/src/common/json_encode.c
@@ -88,3 +88,41 @@ const char *jsonify_bool(bool value) {
         return json_false;
     }
 }
+
+size_t unescape_json_i(char *in, size_t size) {
+    char *write = in;
+    char *read = in;
+    const char *end = &in[size];
+    while (read < end) {
+        if (read + 5 < end && strncmp(read, "\\u0000", 6) == 0) {
+            *write = '\0';
+            write++;
+            read += 6;
+            size -= 5;
+        } else if (*read == '\\') {
+            // to prevent escaping if the \ is the last char we should escape
+            // otherwise we would touch the input after size
+            if (read + 1 == end) {
+                *write++ = *read++;
+                break;
+            }
+            bool escaped = false;
+            for (size_t j = 0; j < sizeof special_chars / sizeof *special_chars; j++) {
+                if (*(read + 1) == special_chars[j].escape) {
+                    escaped = true;
+                    *write = special_chars[j].input;
+                    write++;
+                    read += 2;
+                    size--;
+                    break;
+                }
+            }
+            if (!escaped) {
+                *write++ = *read++;
+            }
+        } else {
+            *write++ = *read++;
+        }
+    }
+    return size;
+}

--- a/src/common/json_encode.h
+++ b/src/common/json_encode.h
@@ -33,6 +33,22 @@ extern "C" {
 #endif
 
 /**
+ * \brief de-escapes json string in place
+ *
+ * De-escaping never makes the string longer, so doing it in place
+ * is ok. If used on part of the string, it will shift only size chars
+ * and the rest will be unchanged.
+ * e.g. unescape_json_i("string\\\"bla\\t1234", 17) -> "string\"bla\t123434"
+ *
+ * \param in the input string to de-escape
+ * \param size number of chars to consoder for de-escaping
+ *
+ * \return the new size after de-escaping
+ */
+
+size_t unescape_json_i(char *in, size_t size);
+
+/**
  * \brief Returns a string representing a boolean value
  *
  * This returns a constant string representation of the boolean value, suitable

--- a/src/common/search_json.h
+++ b/src/common/search_json.h
@@ -3,6 +3,7 @@
 
 #define JSMN_HEADER
 #include <jsmn.h>
+#include "json_encode.h"
 
 #include <cassert>
 
@@ -50,8 +51,7 @@ struct Event {
     /// The value of the field (or array item). This is not present if the
     /// value is an array or object, only for primitive fields.
     ///
-    /// This is not converted in any way. That is, strings are *not* de-escaped
-    /// (at least not yet). Ints, floats or bools are not either and are passed
+    /// Strings are de-escaped. Ints, floats or bools are passed
     /// as original string values.
     std::optional<std::string_view> value;
 };
@@ -63,7 +63,7 @@ namespace impl {
     // Takes the current token to process and returns the pointer to the next yet
     // unused token. In case of error, returns nullptr.
     template <class Callback>
-    jsmntok_t *search_recursive(const char *input, jsmntok_t *token, bool emit_self, std::optional<std::string_view> key, size_t depth, Callback &&callback) {
+    jsmntok_t *search_recursive(char *input, jsmntok_t *token, bool emit_self, std::optional<std::string_view> key, size_t depth, Callback &&callback) {
         switch (token->type) {
         case JSMN_OBJECT:
         case JSMN_ARRAY: {
@@ -99,7 +99,8 @@ namespace impl {
         }
         case JSMN_STRING:
         case JSMN_PRIMITIVE: {
-            std::string_view value(input + token->start, token->end - token->start);
+            auto new_size = unescape_json_i(input + token->start, token->end - token->start);
+            std::string_view value(input + token->start, new_size);
             Event event {
                 depth,
                 token->type == JSMN_STRING ? Type::String : Type::Primitive,
@@ -127,11 +128,15 @@ namespace impl {
 /// subfields, etc (and not confuse a sub-sub-sub-field of the same name with
 /// the required one on top level).
 ///
+/// The value strings are de-escaped. The string should not be used
+/// (or used really carefuly) afterwards, because the de-escaping is done in place and
+///  messes it up. See unescape_json_i() for details on how.
+///
 /// Returns true on success, false on "broken" JSON (mostly if the top-level
 /// thing isn't an object). It does expect "structural" validity of the tokens,
 /// that is the sizes must be correct - range checking is not performed.
 template <class Callback>
-bool search(const char *input, jsmntok_t *tokens, size_t cnt, Callback &&callback) {
+bool search(char *input, jsmntok_t *tokens, size_t cnt, Callback &&callback) {
     if (cnt == 0) {
         return false;
     }

--- a/src/connect/command.cpp
+++ b/src/connect/command.cpp
@@ -108,7 +108,7 @@ Command Command::gcode_command(CommandId id, const string_view &body, SharedBuff
     };
 }
 
-Command Command::parse_json_command(CommandId id, const string_view &body, SharedBuffer::Borrow buff) {
+Command Command::parse_json_command(CommandId id, char *body, size_t body_size, SharedBuffer::Borrow buff) {
     jsmntok_t tokens[MAX_TOKENS];
 
     int parse_result;
@@ -117,7 +117,7 @@ Command Command::parse_json_command(CommandId id, const string_view &body, Share
         jsmn_parser parser;
         jsmn_init(&parser);
 
-        parse_result = jsmn_parse(&parser, body.data(), body.size(), tokens, sizeof tokens / sizeof *tokens);
+        parse_result = jsmn_parse(&parser, body, body_size, tokens, sizeof tokens / sizeof *tokens);
     } // Free the parser
 
     CommandData data = UnknownCommand {};
@@ -130,7 +130,7 @@ Command Command::parse_json_command(CommandId id, const string_view &body, Share
     bool has_path = false;
 
     // Error from jsmn_parse will lead to -1 -> converted to 0, refused by json::search as Broken.
-    const bool success = json::search(body.data(), tokens, std::max(parse_result, 0), [&](const Event &event) {
+    const bool success = json::search(body, tokens, std::max(parse_result, 0), [&](const Event &event) {
         auto is_arg = [&](const string_view name, Type type) -> bool {
             return event.depth == 2 && in_kwargs && event.type == type && event.key == name;
         };

--- a/src/connect/command.hpp
+++ b/src/connect/command.hpp
@@ -85,7 +85,7 @@ struct Command {
     // Note: Might be a "Broken" command or something like that. In both cases.
     static Command gcode_command(CommandId id, const std::string_view &body, SharedBuffer::Borrow buff);
     // The buffer is either used and embedded inside the returned command or destroyed, releasing the ownership.
-    static Command parse_json_command(CommandId id, const std::string_view &body, SharedBuffer::Borrow buff);
+    static Command parse_json_command(CommandId id, char *body, size_t body_size, SharedBuffer::Borrow buff);
 };
 
 }

--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -232,18 +232,18 @@ Connect::ServerResp Connect::handle_server_resp(Response resp) {
         };
     }
 
-    const string_view body(reinterpret_cast<const char *>(recv_buffer), pos);
-
     // Note: Anything of these can result in an "Error"-style command (Unknown,
     // Broken...). Nevertheless, we return a Command, which'll consider the
     // whole request-response pair a successful one. That's OK, because on the
     // lower-level it is - we consumed all the data and are allowed to reuse
     // the connection and all that.
     switch (resp.content_type) {
-    case ContentType::TextGcode:
+    case ContentType::TextGcode: {
+        const string_view body(reinterpret_cast<const char *>(recv_buffer), pos);
         return Command::gcode_command(command_id, body, move(*buff));
+    }
     case ContentType::ApplicationJson:
-        return Command::parse_json_command(command_id, body, move(*buff));
+        return Command::parse_json_command(command_id, reinterpret_cast<char *>(recv_buffer), pos, move(*buff));
     default:;
         // If it's unknown content type, then it's unknown command because we
         // have no idea what to do about it / how to even parse it.

--- a/tests/unit/common/json_encode_tests.cpp
+++ b/tests/unit/common/json_encode_tests.cpp
@@ -50,3 +50,73 @@ TEST_CASE("Escape len") {
     REQUIRE(jsonify_str_buffer("\n") == strlen("\\n") + 1);
     REQUIRE(jsonify_str_buffer_len("\0", 1) == strlen("\\u0000") + 1);
 }
+
+TEST_CASE("Unescape json") {
+    char json[] = R"(1\"\\a\"34\f\b5\r\n6\n\\78\t0)";
+    size_t new_size = unescape_json_i(json, strlen(json));
+
+    INFO("json: " + std::string(json));
+    const char *expected = "1\"\\a\"34\f\b5\r\n6\n\\78\t0";
+    REQUIRE(new_size == strlen(expected));
+    REQUIRE(strncmp(json, expected, strlen(expected)) == 0);
+}
+
+TEST_CASE("Unescape empty json") {
+    char json[] = "";
+    size_t new_size = unescape_json_i(json, strlen(json));
+
+    INFO("json: " + std::string(json));
+    REQUIRE(new_size == 0);
+    REQUIRE(strcmp(json, "") == 0);
+}
+
+TEST_CASE("Nothing to unescape json") {
+    char json[] = "1234567890abcdefgh";
+    size_t new_size = unescape_json_i(json, strlen(json));
+
+    INFO("json: " + std::string(json));
+    const char *expected = "1234567890abcdefgh";
+    REQUIRE(new_size == strlen(expected));
+    REQUIRE(strncmp(json, expected, strlen(expected)) == 0);
+}
+
+TEST_CASE("Unescape only part of string") {
+    char json[] = R"(\"abc\12345)";
+    size_t new_size = unescape_json_i(json, 4);
+
+    INFO("json: " + std::string(json));
+    const char *expected = R"("ab)";
+    REQUIRE(new_size == strlen(expected));
+    REQUIRE(strncmp(json, expected, strlen(expected)) == 0);
+}
+
+TEST_CASE("null unescape") {
+    char json[] = R"(abc\u00001234)";
+    size_t new_size = unescape_json_i(json, strlen(json));
+
+    INFO("json: " + std::string(json));
+    REQUIRE(new_size == 8);
+    REQUIRE(json == string_view("abc"));
+    REQUIRE(json[3] == '\0');
+    REQUIRE(strncmp(json + 4, "1234", 4) == 0);
+}
+
+TEST_CASE("not escaping the whole null sequence") {
+    char json[] = R"(abc\u0000bla)";
+    size_t new_size = unescape_json_i(json, 8);
+
+    INFO("json: " + std::string(json));
+    const char *expected = R"(abc\u000)";
+    REQUIRE(new_size == strlen(expected));
+    REQUIRE(strncmp(json, expected, strlen(expected)) == 0);
+}
+
+TEST_CASE("unescape slash char at the end") {
+    char json[] = R"(abc\"123\"a)";
+    size_t new_size = unescape_json_i(json, 9);
+
+    INFO("json: " + std::string(json));
+    const char *expected = R"(abc"123\)";
+    REQUIRE(new_size == strlen(expected));
+    REQUIRE(strncmp(json, expected, strlen(expected)) == 0);
+}

--- a/tests/unit/common/search_json_test.cpp
+++ b/tests/unit/common/search_json_test.cpp
@@ -10,7 +10,7 @@ using std::string;
 
 namespace {
 
-const constexpr char *const JSON = "{\"hello\": [1, 2, 3], \"world\":{\"nested\": nil}, \"other\":\"stuff\"}";
+static char JSON[] = "{\"hello\": [1, 2, 3], \"other\":\"stuff\", \"escaped_filename\":\"stupid\\\\_\\\"filename\\t\", \"escaped_object\":{\"name\":\"weird\\\\\\f_chars\\n\"}, \"world\":{\"nested\": nil}}";
 
 const constexpr size_t MAX_TOKENS = 60;
 
@@ -20,10 +20,14 @@ const constexpr Event expected_events[] = {
     Event { 2, Type::Primitive, nullopt, "2" },
     Event { 2, Type::Primitive, nullopt, "3" },
     Event { 1, Type::Pop, nullopt, nullopt },
+    Event { 1, Type::String, "other", "stuff" },
+    Event { 1, Type::String, "escaped_filename", "stupid\\_\"filename\t" },
+    Event { 1, Type::Object, "escaped_object", nullopt },
+    Event { 2, Type::String, "name", "weird\\\f_chars\n" },
+    Event { 1, Type::Pop, nullopt, nullopt },
     Event { 1, Type::Object, "world", nullopt },
     Event { 2, Type::Primitive, "nested", "nil" },
     Event { 1, Type::Pop, nullopt, nullopt },
-    Event { 1, Type::String, "other", "stuff" },
 };
 
 }

--- a/tests/unit/connect/CMakeLists.txt
+++ b/tests/unit/connect/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(
   ${CMAKE_CURRENT_BINARY_DIR}/http_resp_automaton.cpp
   ${CMAKE_SOURCE_DIR}/src/common/automata/core.cpp
   ${CMAKE_SOURCE_DIR}/src/common/crc32.c
+  ${CMAKE_SOURCE_DIR}/src/common/json_encode.c
   ${CMAKE_SOURCE_DIR}/src/common/http/resp_parser.cpp
   ${CMAKE_SOURCE_DIR}/src/common/http/httpc.cpp
   ${CMAKE_SOURCE_DIR}/src/common/http/socket.cpp

--- a/tests/unit/connect/command.cpp
+++ b/tests/unit/connect/command.cpp
@@ -14,11 +14,13 @@ namespace {
 SharedBuffer buffer;
 
 template <class D>
-D command_test(const string_view cmd) {
+D command_test(const char *cmd) {
     auto borrow = buffer.borrow();
+    char *cmd_str = new char[strlen(cmd) + 1];
+    strcpy(cmd_str, cmd);
     // Not claimed / left hanging by previous test.
     REQUIRE(borrow.has_value());
-    const auto command = Command::parse_json_command(13, cmd, std::move(*borrow));
+    const auto command = Command::parse_json_command(13, cmd_str, strlen(cmd_str), std::move(*borrow));
     REQUIRE(command.id == 13);
     REQUIRE(holds_alternative<D>(command.command_data));
     return get<D>(command.command_data);


### PR DESCRIPTION
It is done in place, so we save memory, but it means, that we mess up the string and it should not be used afterwards.