### PR TITLE
Link: Deduplicate slashes in url

### DIFF
--- a/lib/WUI/link_content/prusa_link_api.cpp
+++ b/lib/WUI/link_content/prusa_link_api.cpp
@@ -8,6 +8,7 @@
 #include "../nhttp/send_json.h"
 #include "../wui_api.h"
 
+#include <common/path_utils.h>
 #include <transfers/monitor.hpp>
 #include <cstring>
 #include <cstdio>
@@ -98,6 +99,9 @@ namespace {
             size_t fname_real_len = strlen(fname_real);
             memmove(filename, fname_real, fname_real_len);
             filename[fname_real_len] = '\0';
+            // Slicer sometimes produces duplicate slashes in the URL and
+            // this may confuse eg. marlin.
+            dedup_slashes(filename);
             return nullopt;
         } else {
             return StatusPage(Status::NotFound, parser);

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -49,6 +49,7 @@ if(BOARD MATCHES ".*BUDDY")
             non_file_printing_counter.cpp
             odometer.cpp
             otp.c
+            path_utils.c
             PersistentStorage.cpp
             Pin.cpp
             print_processor.cpp

--- a/src/common/path_utils.c
+++ b/src/common/path_utils.c
@@ -1,0 +1,16 @@
+#include "path_utils.h"
+
+#include <stdbool.h>
+
+void dedup_slashes(char *filename) {
+    char *write = filename;
+    bool previous_slash = false;
+    while (*filename) {
+        char c = *filename++;
+        if (c != '/' || !previous_slash) {
+            *write++ = c;
+        }
+        previous_slash = (c == '/');
+    }
+    *write = '\0';
+}

--- a/src/common/path_utils.h
+++ b/src/common/path_utils.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Deduplicates successive slashes from a path, in-place.
+void dedup_slashes(char *filename);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/unit/common/CMakeLists.txt
+++ b/tests/unit/common/CMakeLists.txt
@@ -97,6 +97,12 @@ target_include_directories(
   json_tests PUBLIC ${CMAKE_SOURCE_DIR}/src/common ${CMAKE_SOURCE_DIR}/lib/jsmn
   )
 
+add_executable(
+  path_utils_tests ${CMAKE_SOURCE_DIR}/src/common/path_utils.c
+                   ${CMAKE_CURRENT_SOURCE_DIR}/path_utils.cpp
+  )
+target_include_directories(path_utils_tests PUBLIC ${CMAKE_SOURCE_DIR}/src/common)
+
 add_catch_test(support_utils_tests)
 add_catch_test(variant8_tests)
 add_catch_test(str_utils_tests)
@@ -110,3 +116,4 @@ add_catch_test(algorithm_scale_tests)
 add_catch_test(median_tests)
 add_catch_test(url_decode_tests)
 add_catch_test(json_tests)
+add_catch_test(path_utils_tests)

--- a/tests/unit/common/path_utils.cpp
+++ b/tests/unit/common/path_utils.cpp
@@ -1,0 +1,24 @@
+#include <path_utils.h>
+
+#include <catch2/catch.hpp>
+#include <string_view>
+
+using std::string_view;
+
+TEST_CASE("Dedup slashes") {
+    char with_slashes[] = "//hello/world////extra/sl/ashes/";
+    dedup_slashes(with_slashes);
+    REQUIRE(string_view("/hello/world/extra/sl/ashes/") == with_slashes);
+}
+
+TEST_CASE("Dedup empty slashes") {
+    char empty[] = "";
+    dedup_slashes(empty);
+    REQUIRE(string_view("") == empty);
+}
+
+TEST_CASE("Dedup without dup slashes") {
+    char without_slashes[] = "well/whatever/ok";
+    dedup_slashes(without_slashes);
+    REQUIRE(string_view("well/whatever/ok") == without_slashes);
+}


### PR DESCRIPTION
We've seen some confusion of the printer with upload from newer slicers that use the PUT method and happen to put duplicate slashes in the URL. It is suspected this is related and hoped to resolve the issue.