### PR TITLE
Fix double preview screen after gcode upload.

### DIFF
--- a/lib/WUI/wui_api.cpp
+++ b/lib/WUI/wui_api.cpp
@@ -39,7 +39,6 @@ extern RTC_HandleTypeDef hrtc;
 bool sntp_time_init = false;
 static char wui_media_LFN[FILE_NAME_BUFFER_LEN]; // static buffer for gcode file name
 static char wui_media_SFN_path[FILE_PATH_BUFFER_LEN];
-static std::atomic<uint32_t> uploaded_gcodes;
 static std::atomic<uint32_t> modified_gcodes;
 
 // example of simple callback automatically sending print response (click on print button) in preview fsm
@@ -326,10 +325,6 @@ void add_time_to_timestamp(int32_t secs_to_add, struct tm *timestamp) {
     localtime_r(&current_time, timestamp);
 }
 
-uint32_t wui_gcodes_uploaded() {
-    return uploaded_gcodes;
-}
-
 uint32_t wui_gcodes_mods() {
     return modified_gcodes;
 }
@@ -365,9 +360,7 @@ StartPrintResult wui_start_print(char *filename, bool autostart_if_able) {
 bool wui_uploaded_gcode(char *filename, bool start_print) {
     StartPrintResult res = wui_start_print(filename, start_print);
     wui_gcode_modified();
-    if (res == StartPrintResult::Uploaded) {
-        uploaded_gcodes++;
-    }
+
     return (res != StartPrintResult::Failed);
 }
 

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -184,17 +184,6 @@ StartPrintResult wui_start_print(char *filename, bool autostart_if_able);
 ///   the print was not possible to start.
 bool wui_uploaded_gcode(char *path, bool start_print);
 
-////////////////////////////////////////////////////////////////////////////
-/// @brief Return the number of gcodes uploaded since boot.
-///
-/// May be used to check if a file was uploaded since last check.
-/// Guaranteed to start at 0, but may wrap around (unlikely).
-///
-/// @warning Gcodes that were immediately printed after upload do not count.
-///
-/// Thread safe.
-uint32_t wui_gcodes_uploaded();
-
 /// Number of gcode modifications - uploaded, deleted, ...
 ///
 /// Similar purpose as with wui_gcodes_uploaded (to watch for something

--- a/src/gui/screen_home.cpp
+++ b/src/gui/screen_home.cpp
@@ -60,7 +60,6 @@ const char *labels[7] = {
 };
 
 bool screen_home_data_t::usbWasAlreadyInserted = false;
-uint32_t screen_home_data_t::lastUploadCount = 0;
 
 screen_home_data_t::screen_home_data_t()
     : AddSuperWindow<screen_t>()
@@ -215,7 +214,7 @@ void screen_home_data_t::windowEvent(EventLock /*has private ctor*/, window_t *s
                 return;
             } else {
                 // on esp update, can use one click print
-                if (GuiMediaEventsHandler::ConsumeOneClickPrinting() || moreGcodesUploaded()) {
+                if (GuiMediaEventsHandler::ConsumeOneClickPrinting()) {
 
                     // we are using marlin variables for filename and filepath buffers
                     marlin_vars_t *vars = marlin_vars();
@@ -296,13 +295,6 @@ void screen_home_data_t::printBtnDis() {
     w_buttons[0].Disable(); // cant't be focused
     w_buttons[0].Invalidate();
     w_labels[0].SetText(_(labels[labelNoUSBId]));
-}
-
-bool screen_home_data_t::moreGcodesUploaded() {
-    const uint32_t total = wui_gcodes_uploaded();
-    const bool result = total != lastUploadCount;
-    lastUploadCount = total;
-    return result;
 }
 
 void screen_home_data_t::InitState(screen_init_variant var) {

--- a/src/gui/screen_home.hpp
+++ b/src/gui/screen_home.hpp
@@ -12,9 +12,8 @@ public:
 
 private:
     static bool usbWasAlreadyInserted; // usb inserted at least once
-    static uint32_t lastUploadCount;
-    static bool ever_been_opened; //set by ctor
-    static bool try_esp_flash;    // we try this maximum once
+    static bool ever_been_opened;      //set by ctor
+    static bool try_esp_flash;         // we try this maximum once
 
     bool usbInserted;
     bool event_in_progress;
@@ -45,7 +44,6 @@ private:
 
     void printBtnEna();
     void printBtnDis();
-    bool moreGcodesUploaded();
 
     static bool find_latest_gcode(char *fpath, int fpath_len, char *fname, int fname_len);
 


### PR DESCRIPTION
There were two seperate mechanisms by which the preview screen was triggered after uploading gcode, so there were two preview screens. This deletes one of them, so there si only one.

BFW-3350