### PR TITLE
fix: correct typo in http 500 error text

### DIFF
--- a/lib/WUI/nhttp/headers.cpp
+++ b/lib/WUI/nhttp/headers.cpp
@@ -40,7 +40,7 @@ namespace {
         { Status::UnprocessableEntity, "Unprocessable Entity" },
         { Status::TooManyRequests, "Too Many Requests" },
         { Status::RequestHeaderFieldsTooLarge, "Request Header Fields Too Large" },
-        { Status::InternalServerError, "Infernal Server Error" },
+        { Status::InternalServerError, "Internal Server Error" },
         { Status::NotImplemented, "Not Implemented" },
         { Status::ServiceTemporarilyUnavailable, "Service Temporarily Unavailable" },
         { Status::GatewayTimeout, "Gateway Timeout" },


### PR DESCRIPTION
I noticed a small typo on the HTTP 500 error. It should be [500 Internal Server Error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500)

Instead, it responds with "Infernal" server error.

![image](https://github.com/prusa3d/Prusa-Firmware-Buddy/assets/8048702/cc072a1b-0911-41ab-8892-13b806347ce7)
