### PR TITLE
Added `info_subtitle_text` for basic print status after prints are cancelled or complete

### DIFF
--- a/src/gui/dialogs/print_progress.cpp
+++ b/src/gui/dialogs/print_progress.cpp
@@ -25,6 +25,7 @@ PrintProgress::PrintProgress(window_t *parent)
     , estime_label(this, Rect16(22, 260, 140, 16), is_multiline::no)
     , estime_value(this, Rect16(22, 280, 200, 22), is_multiline::no)
     , info_text(this, Rect16(22, 265, 300, 30), is_multiline::no)
+    , info_subtitle_text(this, Rect16(22, 295, 300, 30), is_multiline::no)
     , input_shaper_text(this, Rect16(Width() - 200, Height() - 20, 195, 16), is_multiline::no)
     , progress_bar(this, Rect16(Width() - (Width() - GuiDefaults::ProgressThumbnailRect.Width()), 0, Width() - GuiDefaults::ProgressThumbnailRect.Width(), GuiDefaults::ProgressThumbnailRect.Height()))
     , progress_num(this, Rect16(Width() - 145, GuiDefaults::ProgressThumbnailRect.Height() + 5, 130, Height() - GuiDefaults::ProgressThumbnailRect.Height() - 25))
@@ -38,6 +39,11 @@ PrintProgress::PrintProgress(window_t *parent)
     info_text.SetAlignment(Align_t::LeftCenter());
     info_text.SetText(_(finish_print_text));
     info_text.Hide();
+
+    info_subtitle_text.set_font(resource_font(IDR_FNT_SMALL));
+    info_subtitle_text.SetPadding({ 0, 0, 0, 0 });
+    info_subtitle_text.SetAlignment(Align_t::LeftCenter());
+    info_subtitle_text.Hide();
 
     input_shaper_text.set_font(resource_font(IDR_FNT_SMALL));
     input_shaper_text.SetAlignment(Align_t::RightTop());
@@ -90,6 +96,8 @@ void PrintProgress::UpdateTexts() {
         estime_value.Hide();
         info_text.SetText(_(stop_print_text));
         info_text.Show();
+        PrintProgress::updateEsTime();
+        info_subtitle_text.Show();
         mode = ProgressMode_t::END_PREVIEW;
         break;
     case ProgressMode_t::FINISHED_INIT:
@@ -97,6 +105,8 @@ void PrintProgress::UpdateTexts() {
         estime_value.Hide();
         info_text.SetText(_(finish_print_text));
         info_text.Show();
+        PrintProgress::updateEsTime();
+        info_subtitle_text.Show();
         thumbnail.redrawWhole(); // thumbnaill will be invalidated by hiding estime_label above, we need to force it to redraw entirely
         thumbnail.Invalidate();
         mode = ProgressMode_t::END_PREVIEW;
@@ -122,7 +132,7 @@ void PrintProgress::updateLoop(visibility_changed_t visibility_changed) {
 }
 
 void PrintProgress::updateEsTime() {
-    PT_t time_format = print_time.update_loop(time_end_format, &estime_value); // cannot return init
+    PT_t time_format = print_time.update_loop(time_end_format, &estime_value, &info_subtitle_text); // cannot return init
 
     if (time_format != time_end_format) {
         switch (time_format) {

--- a/src/gui/dialogs/print_progress.hpp
+++ b/src/gui/dialogs/print_progress.hpp
@@ -27,6 +27,7 @@ class PrintProgress : public AddSuperWindow<DialogTimed> {
     window_text_t estime_label;
     window_text_t estime_value;
     window_text_t info_text;
+    window_text_t info_subtitle_text;
     window_text_t input_shaper_text;
     WindowPrintVerticalProgress progress_bar;
     WindowNumbPrintProgress progress_num;

--- a/src/gui/print_time_module.cpp
+++ b/src/gui/print_time_module.cpp
@@ -49,7 +49,6 @@ PT_t PrintTime::update_loop(PT_t screen_format, window_text_t *out_print_end, [[
     out_print_end->Invalidate();
     last_time_to_end = time_to_end;
 
-#if defined(USE_ST7789)
     if (out_print_dur) {
         const time_t rawtime = (time_t)marlin_vars()->print_duration;
         if (rawtime != last_print_duration) {
@@ -57,7 +56,7 @@ PT_t PrintTime::update_loop(PT_t screen_format, window_text_t *out_print_end, [[
             out_print_dur->SetText(string_view_utf8::MakeRAM((const uint8_t *)text_time_dur.data()));
         }
     }
-#endif // USE_ST7789
+
     return time_end_format;
 }
 


### PR DESCRIPTION
`info_subtitle_text` was added for when a print completes or is cancelled, we can add simple information regarding the print such as print duration, and material used.

This commit will only utilize it for print duration, but it fits being able to support material used later in time.

Added a photo to show what it looks like presently. 
![image](https://github.com/prusa3d/Prusa-Firmware-Buddy/assets/24532951/c4d2ea3d-67fa-4a96-a3b9-a093b7ebc8d7)
