### PR TITLE
Fix timezone to reflect correct timezone range from -12 to 14 

### DIFF
--- a/src/guiapi/src/menu_spin_config_with_units.cpp
+++ b/src/guiapi/src/menu_spin_config_with_units.cpp
@@ -23,7 +23,7 @@ const SpinConfigInt SpinCnf::bed = SpinConfigInt(MenuVars::GetBedRange(), Celsiu
 const SpinConfigInt SpinCnf::printfan = SpinConfigInt(MenuVars::percent_range, Percent, spin_off_opt_t::yes);
 const SpinConfigInt SpinCnf::feedrate = SpinConfigInt(MenuVars::feedrate_range, Percent);
 const SpinConfigInt SpinCnf::flowfact = SpinConfigInt(MenuVars::flowfact_range, Percent);
-const SpinConfigInt SpinCnf::timezone_range = { { -12, 12, 1 }, Hour };
+const SpinConfigInt SpinCnf::timezone_range = { { -12, 14, 1 }, Hour };
 #if BOARD_IS_BUDDY
 const SpinConfigInt SpinCnf::volume_range = { { 0, 11, 1 }, None, spin_off_opt_t::yes }; // crank it up to 11
 #else


### PR DESCRIPTION
Fix timezone to reflect correct timezone range from -12 to 14 as already defined in "src/guiapi/src/menu_spin_config_basic.cpp".

This fix resolves issue #3550.