### PR TITLE
gui: Add option to set timezone minutes offset & Fix wrong timezone hour offset & Add timezone dst support

### DIFF
--- a/src/gui/MItem_tools.cpp
+++ b/src/gui/MItem_tools.cpp
@@ -416,6 +416,45 @@ void MI_TIMEZONE::OnClick() {
 }
 
 /*****************************************************************************/
+// MI_TIMEZONE_MIN
+MI_TIMEZONE_MIN::MI_TIMEZONE_MIN()
+    : WI_SWITCH_t<3>(static_cast<uint8_t>(time_tools::get_timezone_minutes_offset()), _(label), nullptr, is_enabled_t::yes, is_hidden_t::no, _(str_0min), _(str_30min), _(str_45min)) {}
+
+void MI_TIMEZONE_MIN::OnChange([[maybe_unused]] size_t old_index) {
+    switch (index) {
+    case 0:
+        time_tools::set_timezone_minutes_offset(time_tools::TimeOffsetMinutes::_0min);
+        break;
+    case 1:
+        time_tools::set_timezone_minutes_offset(time_tools::TimeOffsetMinutes::_30min);
+        break;
+    case 2:
+        time_tools::set_timezone_minutes_offset(time_tools::TimeOffsetMinutes::_45min);
+        break;
+    default:
+        assert(0);
+    }
+}
+
+/*****************************************************************************/
+// MI_TIMEZONE_SUMMER
+MI_TIMEZONE_SUMMER::MI_TIMEZONE_SUMMER()
+    : WI_SWITCH_t<2>(static_cast<uint8_t>(time_tools::get_timezone_summertime_offset()), _(label), nullptr, is_enabled_t::yes, is_hidden_t::no, _(str_wintertime), _(str_summertime)) {}
+
+void MI_TIMEZONE_SUMMER::OnChange([[maybe_unused]] size_t old_index) {
+    switch (index) {
+    case 0:
+        time_tools::set_timezone_summertime_offset(time_tools::TimeOffsetSummerTime::_wintertime);
+        break;
+    case 1:
+        time_tools::set_timezone_summertime_offset(time_tools::TimeOffsetSummerTime::_summertime);
+        break;
+    default:
+        assert(0);
+    }
+}
+
+/*****************************************************************************/
 // MI_TIME_FORMAT
 MI_TIME_FORMAT::MI_TIME_FORMAT()
     : WI_SWITCH_t<2>(static_cast<uint8_t>(time_tools::get_time_format()), _(label), nullptr, is_enabled_t::yes, is_hidden_t::no, _(str_12h), _(str_24h)) {}

--- a/src/gui/MItem_tools.hpp
+++ b/src/gui/MItem_tools.hpp
@@ -236,11 +236,34 @@ public:
 };
 
 class MI_TIMEZONE : public WiSpinInt {
-    constexpr static const char *const label = N_("Time Zone Offset");
+    constexpr static const char *const label = N_("Time Zone Hour Offset");
 
 public:
     MI_TIMEZONE();
     virtual void OnClick() override;
+};
+
+class MI_TIMEZONE_MIN : public WI_SWITCH_t<3> {
+    constexpr static const char *const label = N_("Time Zone Minute Offset");
+
+    constexpr static const char *str_0min = N_("00 min");
+    constexpr static const char *str_30min = N_("30 min");
+    constexpr static const char *str_45min = N_("45 min");
+
+public:
+    MI_TIMEZONE_MIN();
+    virtual void OnChange(size_t old_index) override;
+};
+
+class MI_TIMEZONE_SUMMER : public WI_SWITCH_t<2> {
+    constexpr static const char *const label = N_("Time Zone Summertime");
+
+    constexpr static const char *str_wintertime = N_("disabled");
+    constexpr static const char *str_summertime = N_("enabled");
+
+public:
+    MI_TIMEZONE_SUMMER();
+    virtual void OnChange(size_t old_index) override;
 };
 
 class MI_TIME_FORMAT : public WI_SWITCH_t<2> {

--- a/src/gui/print_time_module.cpp
+++ b/src/gui/print_time_module.cpp
@@ -45,7 +45,9 @@ PT_t PrintTime::update_loop(PT_t screen_format, window_text_t *out_print_end, [[
 
         // Timestamp
         const int8_t timezone_diff = config_store().timezone.get();
-        const time_t local_cur_sec = curr_sec + timezone_diff * 3600;
+        const int8_t timezone_summertime = time_tools::get_current_timezone_summertime();
+        const int8_t timezone_min_diff = time_tools::get_current_timezone_minutes();
+        const time_t local_cur_sec = curr_sec + ((timezone_diff + timezone_summertime) * 3600) + (timezone_min_diff * 60);
         time_end_format = PT_t::timestamp;
         generate_timestamp_string(local_cur_sec, time_to_end);
 
@@ -119,7 +121,9 @@ bool PrintTime::print_end_time(const uint32_t time_to_end, std::span<char> buffe
     }
 
     const int8_t timezone_diff = config_store().timezone.get();
-    curr_sec += timezone_diff * 3600;
+    const int8_t timezone_summertime = time_tools::get_current_timezone_summertime();
+    const int8_t timezone_min_diff = time_tools::get_current_timezone_minutes();
+    curr_sec += ((timezone_diff + timezone_summertime) * 3600) + (timezone_min_diff * 60);
 
     print_timestamp_string_to_buffer(curr_sec, time_to_end, buffer);
     return true;

--- a/src/gui/screen_menu_lang_and_time.hpp
+++ b/src/gui/screen_menu_lang_and_time.hpp
@@ -10,7 +10,7 @@
 #include "MItem_menus.hpp"
 #include "menu_items_languages.hpp"
 
-using ScreenMenuLangAndTime__ = ScreenMenu<GuiDefaults::MenuFooter, MI_RETURN, MI_LANGUAGE, MI_TIMEZONE, MI_TIME_FORMAT
+using ScreenMenuLangAndTime__ = ScreenMenu<GuiDefaults::MenuFooter, MI_RETURN, MI_LANGUAGE, MI_TIMEZONE, MI_TIMEZONE_MIN, MI_TIMEZONE_SUMMER, MI_TIME_FORMAT
 #if PRINTER_IS_PRUSA_MINI
     ,
     MI_TIME_NOW // Mini does not show time in header, so show it here

--- a/src/gui/screen_menu_tune.hpp
+++ b/src/gui/screen_menu_tune.hpp
@@ -63,7 +63,7 @@ using ScreenMenuTune__ = ScreenMenu<EFooter::On, MI_RETURN,
 #if (!PRINTER_IS_PRUSA_MINI) || defined(_DEBUG) // Save space in MINI release
     MI_HARDWARE_TUNE,
 #endif /*(!PRINTER_IS_PRUSA_MINI) || defined(_DEBUG)*/
-    MI_TIMEZONE, MI_INFO, MI_TRIGGER_POWER_PANIC,
+    MI_TIMEZONE, MI_TIMEZONE_MIN, MI_TIMEZONE_SUMMER, MI_INFO, MI_TRIGGER_POWER_PANIC,
 
 #ifdef _DEBUG
     MI_TEST,

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -496,7 +496,8 @@ void screen_printing_data_t::start_showing_end_result() {
                 localtime_r(&print_time, &print_tm);
             });
 
-            print_tm.tm_hour += config_store().timezone.get();
+            print_tm.tm_hour += config_store().timezone.get() + time_tools::get_current_timezone_summertime();
+            print_tm.tm_min += time_tools::get_current_timezone_minutes();
 
             const time_t adjusted_print_time = mktime(&print_tm);
             localtime_r(&adjusted_print_time, &print_tm);

--- a/src/gui/time_tools.hpp
+++ b/src/gui/time_tools.hpp
@@ -11,6 +11,45 @@ enum class TimeFormat : uint8_t {
     _24h,
 };
 
+/**
+ * @brief Time zone offset in minutes.
+ * @warning Never change these values. They are stored in config_store.
+ */
+
+enum class TimeOffsetMinutes : int8_t {
+    _0min,
+    _30min,
+    _45min,
+};
+
+/**
+ * @brief Time zone summertime offset.
+ * @warning Never change these values. They are stored in config_store.
+ */
+
+/// @return current timezone offset in minutes as integer value (minutes * seconds)
+int8_t get_current_timezone_minutes();
+
+/// @param new_offset set timezone minute offset
+void set_timezone_minutes_offset(TimeOffsetMinutes new_offset);
+
+/// @return current timezone minutes offset
+TimeOffsetMinutes get_timezone_minutes_offset();
+
+enum class TimeOffsetSummerTime : int8_t {
+    _wintertime,
+    _summertime
+};
+
+/// @return current timezone summertime offset in hours
+int8_t get_current_timezone_summertime();
+
+/// @param new_offset set timezone summertime offset
+void set_timezone_summertime_offset(TimeOffsetSummerTime new_offset);
+
+/// @return current timezone summertime offset
+TimeOffsetSummerTime get_timezone_summertime_offset();
+
 /// @param new_format set time format
 void set_time_format(TimeFormat new_format);
 

--- a/src/guiapi/src/menu_spin_config_with_units.cpp
+++ b/src/guiapi/src/menu_spin_config_with_units.cpp
@@ -12,6 +12,7 @@ static constexpr const char *Celsius = "\xC2\xB0\x43"; // degree Celsius
 static constexpr const char *Percent = "%";
 static constexpr const char *None = "";
 static constexpr const char *Hour = "h";
+static constexpr const char *Minutes = "min";
 static constexpr const char *mm = "mm";
 static constexpr const char *mA = "mA";
 static constexpr const char *rpm = "rpm"; // todo should I translate it?
@@ -23,7 +24,8 @@ const SpinConfigInt SpinCnf::bed = SpinConfigInt(MenuVars::GetBedRange(), Celsiu
 const SpinConfigInt SpinCnf::printfan = SpinConfigInt(MenuVars::percent_range, Percent, spin_off_opt_t::yes);
 const SpinConfigInt SpinCnf::feedrate = SpinConfigInt(MenuVars::feedrate_range, Percent);
 const SpinConfigInt SpinCnf::flowfact = SpinConfigInt(MenuVars::flowfact_range, Percent);
-const SpinConfigInt SpinCnf::timezone_range = { { -12, 12, 1 }, Hour };
+const SpinConfigInt SpinCnf::timezone_range = { { -12, 14, 1 }, Hour };
+
 #if BOARD_IS_BUDDY
 const SpinConfigInt SpinCnf::volume_range = { { 0, 11, 1 }, None, spin_off_opt_t::yes }; // crank it up to 11
 #else

--- a/src/persistent_stores/store_instances/config_store/defaults.hpp
+++ b/src/persistent_stores/store_instances/config_store/defaults.hpp
@@ -73,6 +73,8 @@ namespace defaults {
 
     inline constexpr std::array<char, lan_hostname_max_len + 1> net_hostname { LAN_HOSTNAME_DEF };
     inline constexpr int8_t lan_timezone { 1 };
+    inline constexpr time_tools::TimeOffsetMinutes timezone_minutes { time_tools::TimeOffsetMinutes::_0min };
+    inline constexpr time_tools::TimeOffsetSummerTime timezone_summer { time_tools::TimeOffsetSummerTime::_wintertime };
     inline constexpr std::array<char, wifi_max_ssid_len + 1> wifi_ap_ssid { "" };
     inline constexpr std::array<char, wifi_max_passwd_len + 1> wifi_ap_password { "" };
 

--- a/src/persistent_stores/store_instances/config_store/store_definition.hpp
+++ b/src/persistent_stores/store_instances/config_store/store_definition.hpp
@@ -61,6 +61,8 @@ struct CurrentStore : public journal::CurrentStoreConfig<journal::Backend, backe
     StoreItem<std::array<char, lan_hostname_max_len + 1>, defaults::net_hostname, journal::hash("LAN Hostname")> lan_hostname;
 
     StoreItem<int8_t, defaults::lan_timezone, journal::hash("LAN Timezone")> timezone; // hour difference from UTC
+    StoreItem<time_tools::TimeOffsetMinutes, defaults::timezone_minutes, journal::hash("Timezone Minutes")> timezone_minutes; // minutes offset for hour difference from UTC
+    StoreItem<time_tools::TimeOffsetSummerTime, defaults::timezone_summer, journal::hash("Timezone Summertime")> timezone_summer; // Summertime hour offset
 
     // WIFI settings
     // wifi_flag & 1 -> On = 0/off = 1, lan_flag & 2 -> dhcp = 0/static = 1, wifi_flag & 0b1100 -> reserved, previously ap_sec_t security


### PR DESCRIPTION
This fixes the wrong timezone hour offset range (did include only +12 but not up to +14 hours) and also introduces a timezone minutes option to select a timezone offset in minutes (0 min, 30 min and 45 min).

This addresses the issues #3550, #1779 and #3141.

As the timezone eeprom storage value is only uint8_t, the data could be further optimized and compressed into a bitstream as it also saves space, which would be possible.

My recommendation for storing the timezone data compressed in a uint8_t:
struct tz_offset{
         uint8_t hours:4;            // 0..14 hours offset
         uint8_t mins:2;               // 0=0, 1=30, 2=45 minutes offset
         uint8_t summertime:1; // 0=wintertime, 1=summertime
         uint8_t signed:1;          // 0=negative gmt hour offset, 1=positive gmt hour offset
};

If that is wanted/needed, I can also add these needed eeprom changes as well to use a compressed structure instead.