### PR TITLE
Fix buffer overflow in error_buffer variable in DialogConnectReg

### DIFF
--- a/src/gui/dialogs/DialogConnectReg.hpp
+++ b/src/gui/dialogs/DialogConnectReg.hpp
@@ -12,7 +12,7 @@ class DialogConnectRegister : public AddSuperWindow<IDialog> {
 private:
     char attempt_buffer[30];
     char detail_buffer[70];
-    char error_buffer[80];
+    char error_buffer[90];
 
     // TODO: Doesn't fit
     constexpr static const char *const headerLabel = N_("PRUSA CONNECT");


### PR DESCRIPTION
This fixes a buffer overflow happening due to copying 85 bytes into a error_buffer array of only 80 bytes by enlarging the array to 90 bytes (including possible memory alignment) :

```
[907/1085] Building CXX object CMakeFiles/firmware.dir/src/gui/dialogs/DialogConnectReg.cpp.obj
Prusa-Firmware-Buddy/src/gui/dialogs/DialogConnectReg.cpp: In member function 'virtual void DialogConnectRegister::windowEvent(EventLock, window_t*, GUI_event_t, void*)':
Prusa-Firmware-Buddy/src/gui/dialogs/DialogConnectReg.cpp:177:66: warning: '%s' directive output may be truncated writing up to 14 bytes into a region of size between 10 and 79 [-Wformat-truncation=]
  177 |                 snprintf(error_buffer, sizeof(error_buffer), "%s %s", error_help_buffer, err_buffer);
      |                                                                  ^~
/home/bjk/Prusa-Firmware-Buddy/src/gui/dialogs/DialogConnectReg.cpp:177:25: note: 'snprintf' output between 2 and 85 bytes into a destination of size 80
  177 |                 snprintf(error_buffer, sizeof(error_buffer), "%s %s", error_help_buffer, err_buffer);
      |                 ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```