### PR TITLE
gcode: Add option to set/show filament color and filament type for filament change using M600 command

### DIFF
--- a/src/common/filament.hpp
+++ b/src/common/filament.hpp
@@ -31,6 +31,50 @@ enum class Type : uint8_t {
     _last = PA
 };
 
+struct ColorIndex {
+    const char *name;
+    uint32_t color;
+};
+
+enum class ColorName : uint32_t {
+    NONE = 0,
+    BLACK,
+    BLUE,
+    GREEN,
+    BROWN,
+    PURPLE,
+    GRAY,
+    TERRACOTTA,
+    SILVER,
+    GOLD,
+    RED,
+    PINK,
+    ORANGE,
+    TRANSPARENT,
+    YELLOW,
+    WHITE,
+    _last = WHITE
+};
+
+const ColorIndex colortable[size_t(filament::ColorName::_last) + 1] = {
+    { "NONE", 0 },
+    { "BLACK", 0x000000 },
+    { "BLUE", 0x0000FF },
+    { "GREEN", 0x00FF00 },
+    { "BROWN", 0x800000 },
+    { "PURPLE", 0x800080 },
+    { "GRAY", 0x999999 },
+    { "TERRACOTTA", 0xB87F6A },
+    { "SILVER", 0xC0C0C0 },
+    { "GOLD", 0xD4AF37 },
+    { "RED", 0xFF0000 },
+    { "PINK", 0xFF007F },
+    { "ORANGE", 0xFF8000 },
+    { "TRANSPARENT", 0xF0F0F0 },
+    { "YELLOW", 0xFFFF00 },
+    { "WHITE", 0xFFFFFF }
+};
+
 constexpr Type default_type = Type::PLA;
 constexpr float cold_nozzle = 50.f;
 constexpr float cold_bed = 45.f;
@@ -51,6 +95,17 @@ struct Colour {
 
     int to_int() const {
         return red << 16 | green << 8 | blue;
+    }
+
+    static Colour from_string(char *name) {
+        // first name is not valid ("---")
+        size_t name_len = strlen(name);
+        for (size_t i = size_t(ColorName::NONE) + 1; i <= size_t(ColorName::_last); ++i) {
+            if ((strlen(colortable[i].name) == name_len) && (!strncmp(name, colortable[i].name, name_len))) {
+                return from_int(colortable[i].color);
+            }
+        }
+        return from_int(atoi(name));
     }
 
     static Colour from_int(int value) {

--- a/src/marlin_stubs/pause/M600.cpp
+++ b/src/marlin_stubs/pause/M600.cpp
@@ -124,7 +124,6 @@ void M600_execute(xyz_pos_t park_point, int8_t target_extruder,
     std::optional<filament::Type> filament_type, pause::Settings::CalledFrom);
 
 void M600_manual() {
-    char filamenttype[16] = { '\0' };
     char colourtype[16] = { '\0' };
 
     auto filament_to_be_loaded = filament::Type::NONE;
@@ -143,16 +142,27 @@ void M600_manual() {
         }
     }
 
-    if (parser.seenval('C')) {
+    if (parser.seen('C')) {
         const char *colourtype_ptr = nullptr;
-        if ((colourtype_ptr = strstr(parser.string_arg, " C")) != nullptr) {
-            if (*(colourtype_ptr + 2) == '"' || *(colourtype_ptr + 2) == ' ') {
-                colourtype_ptr++;
-            }
-            if (*(colourtype_ptr + 2)) {
-                strncpy(colourtype, colourtype_ptr + 2, sizeof(colourtype));
+        if ((colourtype_ptr = strstr(parser.string_arg, "C\"")) != nullptr) {
+            text_begin = strchr(colourtype_ptr, '"');
+            if (text_begin) {
+                ++text_begin;
+                strlcpy(colourtype, text_begin, sizeof(colourtype));
                 for (char *fn = colourtype; *fn; ++fn) {
-                    if (*fn == '"' || *fn == ' ') {
+                    if (*fn == '"') {
+                        *fn = '\0';
+                        break;
+                    }
+                }
+            }
+        } else if ((colourtype_ptr = strstr(parser.string_arg, "C ")) != nullptr) {
+            text_begin = strchr(colourtype_ptr, ' ');
+            if (text_begin) {
+                ++text_begin;
+                strlcpy(colourtype, text_begin, sizeof(colourtype));
+                for (char *fn = colourtype; *fn; ++fn) {
+                    if (*fn == ' ') {
                         *fn = '\0';
                         break;
                     }
@@ -201,7 +211,7 @@ void M600_manual() {
         parser.seen('U') ? std::make_optional(parser.value_axis_units(E_AXIS)) : std::nullopt,
         parser.seen('L') ? std::make_optional(parser.value_axis_units(E_AXIS)) : std::nullopt,
         parser.seen('E') ? std::make_optional(std::abs(parser.value_axis_units(E_AXIS))) : std::nullopt,
-        parser.seen('C') ? std::make_optional(filament::Colour::from_string(filamenttype)) : std::nullopt,
+        parser.seen('C') ? std::make_optional(filament::Colour::from_string(colourtype)) : std::nullopt,
         parser.seen('S') ? std::make_optional(filament_to_be_loaded) : std::nullopt,
         pause::Settings::CalledFrom::Pause);
 }


### PR DESCRIPTION
Although it was already prepared in the firmware, setting a color to show the filament color on filament change on gcode command M600 was missing and instead a std::nullptr was hardcoded. 

Hereby an option "C" is added to the M600 command in order to set a color value which is being displayed on filament change in form of a spool color.

Example usage would be "M600 C 65280", which corresponds to the RGB value of 0x00FF00, which translates to a green color.

Also an option "T" was added to the M600 command to allow changing the filament type on filament change, which also was prepared but not yet added.
Example usage would be `M600 S"PLA" C"RED"` or `M600 S"PLA" C 16711680`.