### PR TITLE
[BFW-5429] utils: Fix missing virtualenv on running python build script

### DIFF
--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -225,6 +225,9 @@ def get_dependency_directory(dependency) -> Path:
 
 def switch_to_venv_if_nedded():
     if not running_in_venv and os.environ.get('BUDDY_NO_VIRTUALENV') != '1':
+        if not os.path.exists(".venv"):
+            print('Creating needed virtual environment in .venv')
+            os.system(sys.executable + ' -m venv .venv')
         print('Switching to Buddy\'s virtual environment.', file=sys.stderr)
         print(
             'You can disable this by setting the BUDDY_NO_VIRTUALENV=1 env. variable.',


### PR DESCRIPTION
This fixes the issue on running the python build script with a missing .venv folder containing a virtual environment setup as addressed in issue #3579.