### PR TITLE
gui: Add PCTG and NGEN to the filament types

### DIFF
--- a/src/common/client_response.hpp
+++ b/src/common/client_response.hpp
@@ -438,7 +438,7 @@ class ClientResponses {
 #if PRINTER_IS_PRUSA_iX
             Response::PETG_NH,
 #endif
-            Response::ASA, Response::ABS, Response::PC, Response::FLEX, Response::HIPS, Response::PP, Response::PVB, Response::PA, Response::PCTG }, // UserTempSelection
+            Response::ASA, Response::ABS, Response::PC, Response::FLEX, Response::HIPS, Response::PP, Response::PVB, Response::PA, Response::PCTG, Response::NGEN }, // UserTempSelection
     };
     static_assert(std::size(ClientResponses::PreheatResponses) == CountPhases<PhasesPreheat>());
 

--- a/src/common/client_response.hpp
+++ b/src/common/client_response.hpp
@@ -438,7 +438,7 @@ class ClientResponses {
 #if PRINTER_IS_PRUSA_iX
             Response::PETG_NH,
 #endif
-            Response::ASA, Response::ABS, Response::PC, Response::FLEX, Response::HIPS, Response::PP, Response::PVB, Response::PA }, // UserTempSelection
+            Response::ASA, Response::ABS, Response::PC, Response::FLEX, Response::HIPS, Response::PP, Response::PVB, Response::PA, Response::PCTG }, // UserTempSelection
     };
     static_assert(std::size(ClientResponses::PreheatResponses) == CountPhases<PhasesPreheat>());
 

--- a/src/common/client_response_texts.cpp
+++ b/src/common/client_response_texts.cpp
@@ -49,6 +49,7 @@ const std::array<BtnResource, ftrstd::to_underlying(Response::_count)> BtnRespon
     std::make_pair( "PLA",                  &img::spool_58x58 ),        // PLA filament, do not translate
     std::make_pair( "PP",                   &img::spool_58x58 ),        // PP filament, do not translate
     std::make_pair( "PCTG",                 &img::spool_58x58 ),        // PCTG filament, do not translate
+    std::make_pair( "NGEN",                 &img::spool_58x58 ),        // NGEN filament, do not translate
     std::make_pair( "Print",                &img::print_58x58 ),        // Print
     std::make_pair( N_("PRUSA STOCK"),      nullptr ),                  // PrusaStock
     std::make_pair(

--- a/src/common/client_response_texts.cpp
+++ b/src/common/client_response_texts.cpp
@@ -48,6 +48,7 @@ const std::array<BtnResource, ftrstd::to_underlying(Response::_count)> BtnRespon
     std::make_pair( "PETG_NH",              &img::spool_58x58 ),        // PETG_NH
     std::make_pair( "PLA",                  &img::spool_58x58 ),        // PLA filament, do not translate
     std::make_pair( "PP",                   &img::spool_58x58 ),        // PP filament, do not translate
+    std::make_pair( "PCTG",                 &img::spool_58x58 ),        // PCTG filament, do not translate
     std::make_pair( "Print",                &img::print_58x58 ),        // Print
     std::make_pair( N_("PRUSA STOCK"),      nullptr ),                  // PrusaStock
     std::make_pair(

--- a/src/common/filament.cpp
+++ b/src/common/filament.cpp
@@ -27,6 +27,7 @@ const filament::Description filaments[size_t(filament::Type::_last) + 1] = {
     { BtnResponse::GetText(Response::PP), 240, 170, 100, Response::PP },
     { BtnResponse::GetText(Response::PA), 285, 170, 100, Response::PA },
     { BtnResponse::GetText(Response::PCTG), 260, 170, 100, Response::PCTG },
+    { BtnResponse::GetText(Response::NGEN), 240, 170, 90, Response::NGEN },
 #if HAS_LOADCELL()
     { BtnResponse::GetText(Response::FLEX), 240, 170, 50, Response::FLEX },
 #else

--- a/src/common/filament.cpp
+++ b/src/common/filament.cpp
@@ -26,6 +26,7 @@ const filament::Description filaments[size_t(filament::Type::_last) + 1] = {
     { BtnResponse::GetText(Response::HIPS), 220, 170, 100, Response::HIPS },
     { BtnResponse::GetText(Response::PP), 240, 170, 100, Response::PP },
     { BtnResponse::GetText(Response::PA), 285, 170, 100, Response::PA },
+    { BtnResponse::GetText(Response::PCTG), 260, 170, 100, Response::PCTG },
 #if HAS_LOADCELL()
     { BtnResponse::GetText(Response::FLEX), 240, 170, 50, Response::FLEX },
 #else

--- a/src/common/filament.hpp
+++ b/src/common/filament.hpp
@@ -28,7 +28,8 @@ enum class Type : uint8_t {
     PP,
     FLEX,
     PA,
-    _last = PA
+    PCTG,
+    _last = PCTG
 };
 
 constexpr Type default_type = Type::PLA;

--- a/src/common/filament.hpp
+++ b/src/common/filament.hpp
@@ -29,7 +29,8 @@ enum class Type : uint8_t {
     FLEX,
     PA,
     PCTG,
-    _last = PCTG
+    NGEN,
+    _last = NGEN
 };
 
 constexpr Type default_type = Type::PLA;

--- a/src/common/general_response.hpp
+++ b/src/common/general_response.hpp
@@ -49,6 +49,7 @@ enum class Response : uint8_t {
     PETG_NH, // PETG without heating bed
     PLA,
     PP,
+    PCTG,
     Print,
     PrusaStock,
     Purge_more,

--- a/src/common/general_response.hpp
+++ b/src/common/general_response.hpp
@@ -50,6 +50,7 @@ enum class Response : uint8_t {
     PLA,
     PP,
     PCTG,
+    NGEN,
     Print,
     PrusaStock,
     Purge_more,

--- a/src/gui/dialogs/window_dlg_preheat.hpp
+++ b/src/gui/dialogs/window_dlg_preheat.hpp
@@ -66,6 +66,7 @@ protected:
                           MI_Filament<filament::Type::HIPS>,    \
                           MI_Filament<filament::Type::PP>,      \
                           MI_Filament<filament::Type::PA>,      \
+                          MI_Filament<filament::Type::PCTG>,    \
                           MI_Filament<filament::Type::FLEX>
 #else
     #define ALL_FILAMENTS MI_Filament<filament::Type::PLA>,  \
@@ -77,6 +78,7 @@ protected:
                           MI_Filament<filament::Type::HIPS>, \
                           MI_Filament<filament::Type::PP>,   \
                           MI_Filament<filament::Type::PA>,   \
+                          MI_Filament<filament::Type::PCTG>, \
                           MI_Filament<filament::Type::FLEX>
 #endif
 

--- a/src/gui/dialogs/window_dlg_preheat.hpp
+++ b/src/gui/dialogs/window_dlg_preheat.hpp
@@ -67,6 +67,7 @@ protected:
                           MI_Filament<filament::Type::PP>,      \
                           MI_Filament<filament::Type::PA>,      \
                           MI_Filament<filament::Type::PCTG>,    \
+                          MI_Filament<filament::Type::NGEN>,    \
                           MI_Filament<filament::Type::FLEX>
 #else
     #define ALL_FILAMENTS MI_Filament<filament::Type::PLA>,  \
@@ -79,6 +80,7 @@ protected:
                           MI_Filament<filament::Type::PP>,   \
                           MI_Filament<filament::Type::PA>,   \
                           MI_Filament<filament::Type::PCTG>, \
+                          MI_Filament<filament::Type::NGEN>, \
                           MI_Filament<filament::Type::FLEX>
 #endif
 


### PR DESCRIPTION
Add PCTG as new material to the filament types as requested in issue #3589.
Add NGEN as new material to the filament types as requested in issue #3633 and listed in [Prusa Filament Reference](https://help.prusa3d.com/de/article/ngen_167174).