### PR TITLE
Fix float compare issue in M74

### DIFF
--- a/lib/Marlin/Marlin/src/gcode/feature/input_shaper/M74.cpp
+++ b/lib/Marlin/Marlin/src/gcode/feature/input_shaper/M74.cpp
@@ -48,7 +48,7 @@ void GcodeSuite::M74() {
 
     if (parser.seen('W')) {
         const float m = parser.value_float();
-        if (m > 0) {
+        if (m > 0.f) {
             params.mass = m;
         } else {
             SERIAL_ECHO_MSG("?Mass (W) must be greater than 0");


### PR DESCRIPTION
This fixes a int versus float comparison error that will print "Mass (W) must be greater than 0" on a value < 0.49_.
The value m, being float, should be compared against a float value instead. This PR is related to issue #3592.