### PR TITLE
Fix serialprintPGM parameter from mac to mac_buffer in command M46

### DIFF
--- a/src/marlin_stubs/host/M46.cpp
+++ b/src/marlin_stubs/host/M46.cpp
@@ -15,6 +15,6 @@ void GcodeSuite::M46() {
         char mac_buffer[19] = { 0 };
         get_MAC_address(&mac, netdev_get_active_id());
         snprintf(mac_buffer, sizeof(mac_buffer), "%s\n", mac);
-        serialprintPGM(mac);
+        serialprintPGM(mac_buffer);
     }
 }


### PR DESCRIPTION
This adds a missing newline to mac output on M46 command and fixes a minor issue with commit https://github.com/prusa3d/Prusa-Firmware-Buddy/commit/afc04399d8160c322a1ea8bfa18e8704bf4485c4