### PR TITLE
configuration: Increase max temperature for MINI printer

### DIFF
--- a/include/marlin/Configuration_MINI.h
+++ b/include/marlin/Configuration_MINI.h
@@ -397,7 +397,7 @@
 // Above this temperature the heater will be switched off.
 // This can protect components from overheating, but NOT from shorts and failures.
 // (Use MINTEMP for thermistor short/failure protection.)
-#define HEATER_0_MAXTEMP 290
+#define HEATER_0_MAXTEMP 295
 #define HEATER_1_MAXTEMP 275
 #define HEATER_2_MAXTEMP 275
 #define HEATER_3_MAXTEMP 275


### PR DESCRIPTION
Increase the Max Temp for Prusa Mini in order to reach nozzle temp of 280°C, related to issue #3489 and #3605.

See discussion about this PR here: #3613 