### PR TITLE
common: Fix nozzle diameter check (Float vs. Double issue)

### DIFF
--- a/lib/WUI/link_content/basic_gets.cpp
+++ b/lib/WUI/link_content/basic_gets.cpp
@@ -185,7 +185,7 @@ JsonResult get_printer(size_t resume_point, JsonOutput &output) {
 JsonResult get_version(size_t resume_point, JsonOutput &output) {
     char hostname[ETH_HOSTNAME_LEN + 1];
     netdev_get_hostname(netdev_get_active_id(), hostname, sizeof hostname);
-    auto nozzle_diameter = config_store().get_nozzle_diameter(0);
+    float nozzle_diameter = config_store().get_nozzle_diameter(0);
 
     // Keep the indentation of the JSON in here!
     // clang-format off
@@ -210,7 +210,7 @@ JsonResult get_version(size_t resume_point, JsonOutput &output) {
 JsonResult get_info(size_t resume_point, JsonOutput &output) {
     char hostname[ETH_HOSTNAME_LEN + 1];
     netdev_get_hostname(netdev_get_active_id(), hostname, sizeof hostname);
-    auto nozzle_diameter = config_store().get_nozzle_diameter(0);
+    float nozzle_diameter = config_store().get_nozzle_diameter(0);
     auto mmu2_enabled =
 #if HAS_MMU2()
         config_store().mmu2_enabled.get();

--- a/src/common/gcode/gcode_info.cpp
+++ b/src/common/gcode/gcode_info.cpp
@@ -220,8 +220,8 @@ void GCodeInfo::EvaluateToolsValid() {
         if (per_extruder_info[e].nozzle_diameter.has_value()) {
             auto do_nozzle_check = [&](uint8_t hotend) {
                 assert(hotend < HOTENDS);
-                float nozzle_diameter_distance = per_extruder_info[e].nozzle_diameter.value() - config_store().get_nozzle_diameter(hotend);
-                if (nozzle_diameter_distance > 0.001f || nozzle_diameter_distance < -0.001f) {
+                float nozzle_diameter_distance = std::abs(per_extruder_info[e].nozzle_diameter.value() - config_store().get_nozzle_diameter(hotend));
+                if (nozzle_diameter_distance > 0.001f) {
                     valid_printer_settings.wrong_nozzle_diameter.fail();
                 }
             };

--- a/src/common/marlin_print_preview.cpp
+++ b/src/common/marlin_print_preview.cpp
@@ -166,8 +166,8 @@ auto PrintPreview::check_tools_mapping_validity(const ToolMapper &mapper, const 
             return true;
         }
 
-        float nozzle_diameter_distance = gcode.get_extruder_info(gcode_tool).nozzle_diameter.value() - get_nozzle_diameter(physical_extruder);
-        if (nozzle_diameter_distance > 0.001f || nozzle_diameter_distance < -0.001f) {
+        float nozzle_diameter_distance = std::abs(static_cast<float>(gcode.get_extruder_info(gcode_tool).nozzle_diameter.value()) - static_cast<float>(get_nozzle_diameter(physical_extruder)));
+        if (nozzle_diameter_distance > 0.001f) {
             return false;
         }
 

--- a/src/gui/screen_tools_mapping.cpp
+++ b/src/gui/screen_tools_mapping.cpp
@@ -144,11 +144,11 @@ void disable_radio(RadioButton &radio) {
     radio.Invalidate();
 }
 
-double get_nozzle_diameter([[maybe_unused]] size_t idx) {
+float get_nozzle_diameter([[maybe_unused]] size_t idx) {
 #if HAS_TOOLCHANGER()
-    return static_cast<double>(config_store().get_nozzle_diameter(idx));
+    return static_cast<float>(config_store().get_nozzle_diameter(idx));
 #elif HAS_MMU2()
-    return static_cast<double>(config_store().get_nozzle_diameter(0));
+    return static_cast<float>(config_store().get_nozzle_diameter(0));
 #endif
 }
 
@@ -162,7 +162,7 @@ void print_right_tool_into_buffer(size_t idx, std::array<std::array<char, ToolsM
 
     if (drawing_nozzles) {
         const auto cur_strlen = strlen(text_buffers[idx].data());
-        snprintf(text_buffers[idx].data() + cur_strlen, ToolsMappingBody::max_item_text_width - cur_strlen, " %-4.2f", get_nozzle_diameter(idx));
+        snprintf(text_buffers[idx].data() + cur_strlen, ToolsMappingBody::max_item_text_width - cur_strlen, " %-4.2f", static_cast<double>(get_nozzle_diameter(idx)));
     }
 }
 
@@ -268,8 +268,8 @@ bool all_nozzles_same(GCodeInfo &gcode_info) {
     bool initialized { false };
 
     auto nozzles_are_matching = [](float lhs, float rhs) {
-        float nozzle_diameter_distance = lhs - rhs;
-        return !(nozzle_diameter_distance > 0.001f || nozzle_diameter_distance < -0.001f);
+        float nozzle_diameter_distance = std::abs(lhs - rhs);
+        return nozzle_diameter_distance <= 0.001f;
     };
     // check gcodes
     EXTRUDER_LOOP() {


### PR DESCRIPTION
This PR simplifies the code for comparing the nozzle diameter (positive or negative) and also addresses an issue with 
`double get_nozzle_diameter([[maybe_unused]] size_t idx)`, whereas the nozzle_diameter is float being substracted from get_nozzle_diameter being double (not float) [here](https://github.com/prusa3d/Prusa-Firmware-Buddy/blob/4bea923810302d654b932291ba324eaedff072fc/src/gui/screen_tools_mapping.cpp#L302).
Related to issue #3656.