### PR TITLE
gcode: Fix issue on unloaded filament temperature being higher temperature than loaded filament (lower temperature)

### DIFF
--- a/src/marlin_stubs/pause/M701_2.cpp
+++ b/src/marlin_stubs/pause/M701_2.cpp
@@ -47,6 +47,11 @@ static bool load_unload(Pause::LoadType load_type, pause::Settings &rSettings) {
     float disp_temp = marlin_vars().active_hotend().display_nozzle;
     float targ_temp = Temperature::degTargetHotend(rSettings.GetExtruder());
 
+    float previous_filament_temp = config_store().get_previous_filament_temp(rSettings.GetExtruder());
+    if (previous_filament_temp > disp_temp) {
+        targ_temp = (float)((double)targ_temp + (((double)previous_filament_temp - (double)targ_temp) * 0.6));
+    }
+
     if (disp_temp > targ_temp) {
         thermalManager.setTargetHotend(disp_temp, rSettings.GetExtruder());
     }
@@ -204,6 +209,7 @@ void filament_gcodes::M70X_process_user_response(PreheatStatus::Result res, uint
         const float disp_temp = config_store().get_filament_type(target_extruder).parameters().nozzle_preheat_temperature;
         thermalManager.setTargetHotend(disp_temp, target_extruder);
         marlin_server::set_temp_to_display(disp_temp, target_extruder);
+        config_store().set_previous_filament_temp(target_extruder, disp_temp);
         break;
     }
     case PreheatStatus::Result::CooledDown:

--- a/src/persistent_stores/store_instances/config_store/store_definition.cpp
+++ b/src/persistent_stores/store_instances/config_store/store_definition.cpp
@@ -976,4 +976,14 @@ void CurrentStore::set_vent_control(VentControl state) {
 }
 #endif
 
+float CurrentStore::get_previous_filament_temp([[maybe_unused]] uint8_t index) {
+    assert(index < EXTRUDERS);
+    return config_store().filament_prev_temp.get(index);
+}
+
+void CurrentStore::set_previous_filament_temp([[maybe_unused]] uint8_t index, float temperature) {
+    assert(index < EXTRUDERS);
+    config_store().filament_prev_temp.set(index, temperature);
+}
+
 } // namespace config_store_ns

--- a/src/persistent_stores/store_instances/config_store/store_definition.hpp
+++ b/src/persistent_stores/store_instances/config_store/store_definition.hpp
@@ -370,6 +370,7 @@ struct CurrentStore
 
     /// User-defined filament ordering. Does not need to contain all the filaments - the rest will be appended to the back using the standard rules
     StoreItem<std::array<FilamentType, max_total_filament_count>, FilamentType::none, ItemFlag::user_presets, journal::hash("Filament Order")> filament_order;
+    StoreItemArray<float, float {}, journal::hash("Filament Previous Temperatures"), 8, EXTRUDERS> filament_prev_temp;
 
     StoreItem<std::bitset<max_preset_filament_type_count>, defaults::visible_preset_filament_types, ItemFlag::user_presets, journal::hash("Visible Preset Filament Types")> visible_preset_filament_types;
 
@@ -395,6 +396,8 @@ struct CurrentStore
 
     FilamentType get_filament_type(uint8_t index);
     void set_filament_type(uint8_t index, FilamentType value);
+    float get_previous_filament_temp(uint8_t index);
+    void set_previous_filament_temp(uint8_t index, float temperature);
 
     // Note: hash is kept for backwards compatibility
     StoreItem<bool, false, ItemFlag::features, journal::hash("Heatup Bed")> filament_change_preheat_all;


### PR DESCRIPTION
This PR adds a configuration store to remember the past filament and does compare if the temperature is lower than the filament that has been unloaded before, and if, does set the last filament temperature only for loading until purging has finished, thus preventing the nozzle to clog.

Fix is related to issue #3585, #3083 and #1821