### PR TITLE
[BFW-5038] gui: Add option to automatically cooldown after filament unload

### DIFF
--- a/src/gui/MItem_filament.cpp
+++ b/src/gui/MItem_filament.cpp
@@ -174,3 +174,18 @@ void MI_PURGE::click(IWindowMenu &) {
 void MI_PURGE::Loop() {
     set_enabled(any_tool_has_filament());
 }
+
+/*****************************************************************************/
+// MI_AUTO_COOLDOWN
+/*****************************************************************************/
+bool MI_AUTO_COOLDOWN::init_index() const {
+    return config_store().auto_cooldown_enabled.get();
+}
+
+void MI_AUTO_COOLDOWN::OnChange(size_t old_index) {
+    if (old_index) {
+        config_store().auto_cooldown_enabled.set(false);
+    } else {
+        config_store().auto_cooldown_enabled.set(true);
+    }
+}

--- a/src/gui/MItem_filament.hpp
+++ b/src/gui/MItem_filament.hpp
@@ -3,6 +3,7 @@
  * @brief menu items for filament menu
  */
 #pragma once
+#include "WindowMenuItems.hpp"
 
 #include <i_window_menu_item.hpp>
 #include <i18n.h>
@@ -52,4 +53,26 @@ public:
     virtual void click(IWindowMenu &) override;
 
     void Loop() final;
+};
+
+class MI_COOLDOWN : public IWindowMenuItem {
+    static constexpr const char *const label = N_("Cooldown");
+
+public:
+    MI_COOLDOWN();
+
+protected:
+    virtual void click(IWindowMenu & /*window_menu*/) override;
+};
+
+class MI_AUTO_COOLDOWN : public WI_ICON_SWITCH_OFF_ON_t {
+    constexpr static const char *const label = N_("Cooldown after unload");
+    bool init_index() const;
+
+public:
+    MI_AUTO_COOLDOWN()
+        : WI_ICON_SWITCH_OFF_ON_t(init_index(), _(label), nullptr, is_enabled_t::yes, is_hidden_t::no) {}
+
+protected:
+    virtual void OnChange(size_t old_index) override;
 };

--- a/src/gui/screen_menu_temperature.hpp
+++ b/src/gui/screen_menu_temperature.hpp
@@ -53,6 +53,7 @@ using ScreenBase = ScreenMenu<
     MI_XBUDDY_EXTENSION_COOLING_FANS_CONTROL_MAX,
     MI_XBE_FILTRATION_FAN,
 #endif
+    MI_AUTO_COOLDOWN,
     MI_COOLDOWN>;
 
 } // namespace screen_menu_temperature

--- a/src/marlin_stubs/pause/M701_2.cpp
+++ b/src/marlin_stubs/pause/M701_2.cpp
@@ -216,6 +216,13 @@ void filament_gcodes::M70X_process_user_response(PreheatStatus::Result res, Virt
         thermalManager.set_fan_speed(0, 0);
         break;
     case PreheatStatus::Result::DoneNoFilament:
+        if (config_store().auto_cooldown_enabled.get()) {
+            thermalManager.setTargetHotend(0, 0);
+            thermalManager.setTargetBed(0);
+            marlin_server::set_temp_to_display(0, 0);
+            thermalManager.set_fan_speed(0, 0);
+        }
+        break;
     case PreheatStatus::Result::Aborted:
     case PreheatStatus::Result::Error:
     case PreheatStatus::Result::DidNotFinish: // cannot happen

--- a/src/persistent_stores/store_instances/config_store/store_definition.hpp
+++ b/src/persistent_stores/store_instances/config_store/store_definition.hpp
@@ -753,6 +753,8 @@ struct CurrentStore
     StoreItem<bool, input_shaper::weight_adjust_enabled_default, ItemFlag::calibrations, journal::hash("Input Shaper Weight Adjust Y Enabled V2")> input_shaper_weight_adjust_y_enabled;
     StoreItem<input_shaper::WeightAdjustConfig, input_shaper::weight_adjust_y_default, ItemFlag::calibrations, journal::hash("Input Shaper Weight Adjust Y Config")> input_shaper_weight_adjust_y_config;
 
+    StoreItem<bool, false, journal::hash("Enable auto cooldown on unload")> auto_cooldown_enabled;
+
     input_shaper::Config get_input_shaper_config();
     void set_input_shaper_config(const input_shaper::Config &);
 


### PR DESCRIPTION
This solves the issue #3691 and #3754 and adds a feature to automatically run cooldown after the filament was unloaded.

![image](https://github.com/prusa3d/Prusa-Firmware-Buddy/assets/6317772/30bfb1ce-a645-42f9-afb1-952a8fe35ec3)
