### PR TITLE
[BFW-5926] Enable DNS for sntp and set default to prusa3d.pool.ntp.org

### DIFF
--- a/lib/WUI/sntp/sntp_client.c
+++ b/lib/WUI/sntp/sntp_client.c
@@ -3,17 +3,10 @@
 #include "netdev.h"
 #include "tcpip.h"
 
-static ip_addr_t ntp_server; // testing ntp server located in Prague
 static uint32_t sntp_running = 0; // describes if sntp is currently running or not
 void sntp_client_init(void) {
     sntp_setoperatingmode(SNTP_OPMODE_POLL);
 
-    /* TODO: enable DNS for ntp.pool.org as default sntp server*/
-
-    // TMP: ip of Czech CESNET NTP server tak.cesnet.cz
-    if (ipaddr_aton("195.113.144.238", &ntp_server)) {
-        sntp_setserver(0, &ntp_server);
-    }
     sntp_init();
 }
 

--- a/lib/WUI/sntp/sntp_opts.h
+++ b/lib/WUI/sntp/sntp_opts.h
@@ -78,7 +78,8 @@
  * \#define SNTP_SERVER_ADDRESS "pool.ntp.org"
  */
 #if !defined SNTP_SERVER_DNS || defined __DOXYGEN__
-    #define SNTP_SERVER_DNS 0
+    #define SNTP_SERVER_DNS     1
+    #define SNTP_SERVER_ADDRESS "prusa3d.pool.ntp.org"
 #endif
 
 /**


### PR DESCRIPTION
This PR changes the default behavior of the SNTP client to use DNS name resolution for an NTP server target. The main advantage is load-balancing servers by using NTP server pools (eg: `pool.ntp.org`) which rotate addresses periodically via DNS. Another reason is the DNS query response from the pool is distributed by geography of requester as well.

I think this change and #3679 are complimentary - both are desired.

Ref: https://www.ntppool.org/