### PR TITLE
[BFW-5934] PrusaLink: Differentiate user authentication password from generated api-key (REST API)

### DIFF
--- a/doc/prusa_printer_settings.ini
+++ b/doc/prusa_printer_settings.ini
@@ -52,3 +52,8 @@ hostname = buddy-a.connect.prusa3d.com
 token = 1234567890
 port = 443
 tls = true
+
+# Password length is limited to 15 chars
+[prusalink]
+apikey=Key1337sp34k
+psw=UserSecretCode

--- a/lib/WUI/http_lifetime.cpp
+++ b/lib/WUI/http_lifetime.cpp
@@ -45,7 +45,8 @@ private:
 
 public:
     virtual const Selector *const *selectors() const override { return selectors_array; }
-    virtual const char *get_password() const override { return wui_get_password(); }
+    virtual const char *get_apikey() const override { return wui_get_apikey(); }
+    virtual const char *get_user_password() const override { return wui_get_user_password(); }
     virtual altcp_pcb *listener_alloc() const override {
         /*
          * We know we are in the part where ALTCP is turned off. That means the

--- a/lib/WUI/nhttp/req_parser.cpp
+++ b/lib/WUI/nhttp/req_parser.cpp
@@ -223,7 +223,7 @@ Step RequestParser::step(string_view input, bool terminated_by_client, uint8_t *
         return Step { 0, 0, Continue() };
     }
 
-    api_key = server->get_password();
+    api_key = server->get_apikey();
     if (api_key && api_key[0] == '\0') {
         // An empty password means "login disabled".
         // (can be a result of generator failure)
@@ -385,7 +385,7 @@ namespace {
 bool RequestParser::check_digest_auth(uint64_t nonce_to_use) const {
     if (auto digest_params = get_if<DigestAuthParams>(&auth_status)) {
 
-        const char *pass = server->get_password();
+        const char *pass = server->get_user_password();
         if (pass == nullptr || pass[0] == '\0') {
             // Login disabled
             return false;

--- a/lib/WUI/nhttp/server.h
+++ b/lib/WUI/nhttp/server.h
@@ -70,7 +70,8 @@ public:
      *   deleting the old one is a data race/UB. We need to find a solution,
      *   but for now, changing the key is very rare and happens in-place.
      */
-    virtual const char *get_password() const = 0;
+    virtual const char *get_apikey() const = 0;
+    virtual const char *get_user_password() const = 0;
     /**
      * \brief Allocate the listener socket.
      */
@@ -433,8 +434,12 @@ public:
         return defs.selectors();
     }
 
-    const char *get_password() const {
-        return defs.get_password();
+    const char *get_user_password() const {
+        return defs.get_user_password();
+    }
+
+    const char *get_apikey() const {
+        return defs.get_apikey();
     }
 
     void inject_transfer(altcp_pcb *conn, pbuf *data, uint16_t data_offset, splice::Transfer *transfer, size_t expected_data);

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -127,7 +127,21 @@ void add_time_to_timestamp(int32_t secs_to_add, struct tm *timestamp);
 /// @brief Authorization password for PrusaLink
 ///
 /// @return Return a password
-const char *wui_get_password();
+const char *wui_get_user_password();
+void wui_store_user_password(char *, uint32_t);
+
+////////////////////////////////////////////////////////////////////////////
+/// @brief Load PrusaLink api-key and/or user password from settings
+///
+/// @return Return flags for fields found (0x01 if apikey, 0x02 if psw)
+uint8_t wui_load_ini_file();
+
+////////////////////////////////////////////////////////////////////////////
+/// @brief Header "X-Api-Key: " for PrusaLink
+///
+/// @return Return an apikey
+const char *wui_get_apikey();
+void wui_store_apikey(char *, uint32_t);
 
 ////////////////////////////////////////////////////////////////////////////
 /// @brief Generate authorization password for PrusaLink
@@ -135,8 +149,6 @@ const char *wui_get_password();
 /// @param[out] buffer password buffer
 /// @param[in] length Size of the buffer
 void wui_generate_password(char *, uint32_t);
-
-void wui_store_password(char *, uint32_t);
 
 #ifdef __cplusplus
 enum class StartPrintResult {

--- a/src/gui/MItem_menus.cpp
+++ b/src/gui/MItem_menus.cpp
@@ -389,6 +389,10 @@ void MI_LOAD_SETTINGS::click(IWindowMenu & /*window_menu*/) {
     }
     build_message(msg_builder, _("Network"), network_settings_loaded);
 
+    // Ignore return flags -- no action necessary
+    (void)wui_load_ini_file();
+
+// FIXME: Error handling
 #if BUDDY_ENABLE_CONNECT()
     build_message(msg_builder, _("Connect"), connect_client::MarlinPrinter::load_cfg_from_ini());
 #endif

--- a/src/gui/screen_prusa_link.hpp
+++ b/src/gui/screen_prusa_link.hpp
@@ -14,7 +14,7 @@
 // ----------------------------------------------------------------
 // GUI Prusa Link Password regenerate
 class MI_PL_REGENERATE_PASSWORD : public IWindowMenuItem {
-    constexpr static const char *const label = N_("Generate Password");
+    constexpr static const char *const label = N_("Update Keys");
 
 public:
     MI_PL_REGENERATE_PASSWORD();
@@ -56,6 +56,35 @@ public:
     MI_PL_PASSWORD_VALUE();
 
     void update_explicit();
+
+protected:
+    void click(IWindowMenu &menu) override;
+};
+
+class MI_PL_APIKEY_LABEL : public IWindowMenuItem {
+    constexpr static const char *const label = N_("Api-Key");
+
+public:
+    MI_PL_APIKEY_LABEL();
+
+protected:
+    virtual void click([[maybe_unused]] IWindowMenu &window_menu) override {}
+};
+
+class MI_PL_APIKEY_VALUE : public WiInfo<config_store_ns::pl_password_size> {
+#if HAS_MINI_DISPLAY()
+    constexpr static const char *const label = N_("");
+#else
+    constexpr static const char *const label = N_("Api-Key");
+#endif
+
+public:
+    MI_PL_APIKEY_VALUE();
+
+    void update_explicit();
+
+protected:
+    void click(IWindowMenu &menu) override;
 };
 
 class MI_PL_USER : public IWiInfo {
@@ -78,6 +107,10 @@ using ScreenMenuPrusaLink_ = ScreenMenu<EFooter::Off, MI_RETURN, MI_PL_ENABLED, 
     MI_PL_PASSWORD_LABEL,
 #endif
     MI_PL_PASSWORD_VALUE,
+#if HAS_MINI_DISPLAY()
+    MI_PL_APIKEY_LABEL,
+#endif
+    MI_PL_APIKEY_VALUE,
     MI_IP4_ADDR,
     MI_HOSTNAME,
     MI_PL_REGENERATE_PASSWORD,

--- a/src/persistent_stores/store_instances/config_store/defaults.hpp
+++ b/src/persistent_stores/store_instances/config_store/defaults.hpp
@@ -120,6 +120,7 @@ namespace defaults {
 
     inline constexpr uint32_t footer_draw_type { footer::ItemDrawCnf::get_default() };
     inline constexpr std::array<char, pl_password_size> prusalink_password { "" };
+    inline constexpr std::array<char, pl_password_size> prusalink_user_password { "" };
 
     inline constexpr std::array<char, connect_host_size + 1> connect_host { "buddy-a.\x01\x01" }; // "Compressed" - this means buddy-a.connect.prusa3d.com.
     inline constexpr std::array<char, connect_token_size + 1> connect_token { "" };

--- a/src/persistent_stores/store_instances/config_store/store_definition.hpp
+++ b/src/persistent_stores/store_instances/config_store/store_definition.hpp
@@ -144,6 +144,7 @@ struct CurrentStore
     StoreItem<uint8_t, 0, journal::hash("Active NetDev")> active_netdev; // active network device
     StoreItem<bool, true, journal::hash("PrusaLink Enabled")> prusalink_enabled;
     StoreItem<std::array<char, pl_password_size>, defaults::prusalink_password, journal::hash("PrusaLink Password")> prusalink_password;
+    StoreItem<std::array<char, pl_password_size>, defaults::prusalink_user_password, journal::hash("PrusaLink User Password")> prusalink_user_password;
 
     StoreItem<bool, false, journal::hash("USB MSC Enabled")> usb_msc_enabled;
 

--- a/tests/unit/lib/WUI/nhttp/req_parser_tests.cpp
+++ b/tests/unit/lib/WUI/nhttp/req_parser_tests.cpp
@@ -15,7 +15,8 @@ using nhttp::handler::Selector;
 class EmptyServerDefs : public ServerDefs {
 public:
     virtual const Selector *const *selectors() const override { return {}; }
-    virtual const char *get_password() const override { return ""; }
+    virtual const char *get_user_password() const override { return ""; }
+    virtual const char *get_apikey() const override { return ""; }
     virtual altcp_pcb *listener_alloc() const override { return {}; }
 };
 

--- a/tests/unit/lib/WUI/nhttp/server_tests.cpp
+++ b/tests/unit/lib/WUI/nhttp/server_tests.cpp
@@ -230,7 +230,8 @@ public:
     MockServerDefs(vector<shared_ptr<ConnInfo>> &conn_infos)
         : infos(conn_infos) {}
     virtual const Selector *const *selectors() const override { return selectors_array; }
-    virtual const char *get_password() const override { return password.c_str(); }
+    virtual const char *get_user_password() const override { return password.c_str(); }
+    virtual const char *get_apikey() const override { return password.c_str(); }
     virtual altcp_pcb *listener_alloc() const override {
         auto conn = new_conn();
         return altcp_listen(conn);


### PR DESCRIPTION
Following some discussions here (#3559, #3213, #3161 and others #222) and in the [forum](https://forum.prusa3d.com/forum/english-forum-original-prusa-i3-mk4-hardware-firmware-and-software-help/mk4-ui-issue-prusalink-authentication-issues/#post-663752), I propose the attached PR to make a new WebUI authentication password separate from the randomly generated X-API-KEY for the PrusaLink REST API. Support for this change includes:
* Add the ability to set the user-password and api-key via a new [prusalink] section in the `prusa_printer_settings.ini` file.
* REST API uses legacy password,  renamed to api-key.
* WebUI authentication uses new User Password.
* Display user-password on PrusaLink menu.
* Change `Generate Password` to `Update Keys` and re-read settings if available.
* Fallback to legacy behavior (both passwords are the same random value).
* Persist new password in EEPROM
* Add ability to edit passwords in V6.1 firmware using DialogTextInput screen.

Note: PrusaSlicer (tested) works with either key by user selection.