### PR TITLE
espif: Fix usage of different types for firmware version parameter

### DIFF
--- a/lib/WUI/espif.cpp
+++ b/lib/WUI/espif.cpp
@@ -98,10 +98,10 @@ enum MessageType {
 
 #if PRINTER_IS_PRUSA_XL
 // ESP32 FW version
-static const uint32_t SUPPORTED_FW_VERSION = 10;
+static constexpr uint8_t SUPPORTED_FW_VERSION = 10;
 #else
 // ESP8266 FW version
-static const uint32_t SUPPORTED_FW_VERSION = 10;
+static constexpr uint8_t SUPPORTED_FW_VERSION = 10;
 #endif
 
 // NIC state
@@ -386,7 +386,7 @@ static void process_mac(uint8_t *data, struct netif *netif) {
 
     ESPIFOperatingMode old = ESPIF_WAIT_INIT;
     if (esp_operating_mode.compare_exchange_strong(old, ESPIF_NEED_AP)) {
-        uint16_t version = fw_version.load();
+        const uint8_t version = fw_version.load();
         if (version != SUPPORTED_FW_VERSION) {
             log_warning(ESPIF, "Firmware version mismatch: %d != %d", version, SUPPORTED_FW_VERSION);
             esp_operating_mode = ESPIF_WRONG_FW;


### PR DESCRIPTION
The reported and temporary stored firmware version of the esp8266 module is uint8_t, however it is converted to an uint16_t value and then compared against an hardcoded uint32_t value. Although it doesn't really cause trouble, in order to prevent a mixture of types in future updates, this should be addressed.