### PR TITLE
[BFW-7620]gcode: Add gcode M27 auto report support

### DIFF
--- a/lib/Marlin/Marlin/src/gcode/gcode.h
+++ b/lib/Marlin/Marlin/src/gcode/gcode.h
@@ -273,6 +273,13 @@ struct G28Flags {
   bool throw_homing_failed = true;
 };
 
+#if ENABLED(SDSUPPORT) || ENABLED(SDCARD_GCODES)
+namespace M27_handler {
+  extern uint32_t sd_auto_report_delay;
+  void print_sd_status();
+} // namespace M27_handler
+#endif
+
 class GcodeSuite {
 public:
 

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -809,6 +809,15 @@ void safely_unload_filament_from_nozzle_to_mmu() {
 }
 #endif
 
+void print_sd_report() {
+    static uint32_t last_sd_report = 0;
+    uint32_t current_time = ticks_s();
+    if (M27_handler::sd_auto_report_delay && (current_time - last_sd_report) >= M27_handler::sd_auto_report_delay) {
+        M27_handler::print_sd_status();
+        last_sd_report = current_time;
+    }
+}
+
 void server_update_vars() {
     uint32_t tick = ticks_ms();
     if ((tick - server.last_update) > MARLIN_UPDATE_PERIOD) {
@@ -956,6 +965,10 @@ static void cycle() {
     }
 
     print_fan_spd();
+
+#if ENABLED(SDSUPPORT) || ENABLED(SDCARD_GCODES)
+    print_sd_report();
+#endif
 
 #if HAS_TOOLCHANGER()
     // Check if tool didn't fall off

--- a/src/marlin_stubs/sdcard/M20-M30_M32-M34.cpp
+++ b/src/marlin_stubs/sdcard/M20-M30_M32-M34.cpp
@@ -124,6 +124,19 @@ void GcodeSuite::M26() {
     }
 }
 
+uint32_t M27_handler::sd_auto_report_delay = 0;
+
+void M27_handler::print_sd_status() {
+    if (marlin_server::is_printing_state(marlin_vars().print_state.get())) {
+        SERIAL_ECHOPGM(MSG_SD_PRINTING_BYTE);
+        SERIAL_ECHO(marlin_vars().media_position.get());
+        SERIAL_CHAR('/');
+        SERIAL_ECHOLN(marlin_vars().media_size_estimate.get());
+    } else {
+        SERIAL_ECHOLNPGM(MSG_SD_NOT_PRINTING);
+    }
+}
+
 /**
  *### M27 - Report SD print status on serial port <a href="https://reprap.org/wiki/G-code#M27:_Report_SD_print_status">M27: Report SD print status</a>
  *
@@ -137,7 +150,9 @@ void GcodeSuite::M26() {
  *
  */
 void GcodeSuite::M27() {
-    if (parser.seen('C')) {
+    if (parser.seen('S')) {
+        M27_handler::sd_auto_report_delay = parser.byteval('S');
+    } else if (parser.seen('C')) {
         SERIAL_ECHOPGM("Current file: ");
         SERIAL_ECHOLN(marlin_vars().media_SFN_path.get_ptr());
 
@@ -147,7 +162,7 @@ void GcodeSuite::M27() {
         SERIAL_CHAR('/');
         SERIAL_ECHOLN(marlin_vars().media_size_estimate.get());
     } else {
-        SERIAL_ECHOLNPGM(MSG_SD_NOT_PRINTING);
+        M27_handler::print_sd_status();
     }
 }
 


### PR DESCRIPTION
This addresses issue #3737 with a missing auto report functionality for gcode M27 (SD card print status).