### PR TITLE
gcode: M115 displays wrong firmware info for MK3.5 / Use printer model for machine type and add XL improvements

### DIFF
--- a/src/marlin_stubs/host/M115.cpp
+++ b/src/marlin_stubs/host/M115.cpp
@@ -24,6 +24,11 @@
 #include <option/has_modularbed.h>
 #include <option/has_dwarf.h>
 #include <option/has_mmu2.h>
+#include <option/has_toolchanger.h>
+
+#if HAS_TOOLCHANGER()
+    #include "../../module/prusa/toolchanger.h"
+#endif
 
 #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
 static void cap_line(PGM_P const name, bool ena = false) {
@@ -43,7 +48,7 @@ void GcodeSuite::M115() {
     SERIAL_ECHOPGM("FIRMWARE_NAME:Prusa-Firmware-Buddy ");
     SERIAL_ECHOPGM(project_version_full);
     SERIAL_ECHOPGM(" (Github) SOURCE_CODE_URL:https://github.com/prusa3d/Prusa-Firmware-Buddy");
-    SERIAL_ECHOPGM(" PROTOCOL_VERSION:" PROTOCOL_VERSION " MACHINE_TYPE:" PRINTER_MODEL);
+    SERIAL_ECHOPGM(" PROTOCOL_VERSION:" PROTOCOL_VERSION " MACHINE_TYPE:Prusa-" PRINTER_MODEL);
 
     uint8_t extruder_count = 0;
 #if HAS_MMU2()
@@ -51,7 +56,7 @@ void GcodeSuite::M115() {
     // As only physical extruders are reported here, we hardcode the value to 1
     extruder_count = 1;
 #elif HAS_TOOLCHANGER()
-    extruder_count = PrusaToolChangerUtils::get_num_enabled_tools();
+    extruder_count = prusa_toolchanger.get_num_enabled_tools();
 #else
     extruder_count = EXTRUDERS;
 #endif


### PR DESCRIPTION
This fixes the wrong firmware identification for gcode M115 on MK3.5. Addresses issue #3747.