### PR TITLE
safety_timer: Fix safetytimer reset on setting ms interval

### DIFF
--- a/src/marlin_stubs/feature/safety_timer.cpp
+++ b/src/marlin_stubs/feature/safety_timer.cpp
@@ -28,7 +28,7 @@ void SafetyTimer::ReInit() {
 
 void SafetyTimer::SetInterval(millis_t ms) {
     interval = ms;
-    last_reset = ms;
+    last_reset = millis();
 }
 
 SafetyTimer::expired_t SafetyTimer::Loop() {


### PR DESCRIPTION
Refers to issue #3741.  On setting a new SafetyTimer interval, it should not set the interval time but instead the current time millisecond value, similar to the ReInit function.