### PR TITLE
gui: Fix max temp error message showing min temp instead

### DIFF
--- a/lib/Marlin/Marlin/src/module/temperature.cpp
+++ b/lib/Marlin/Marlin/src/module/temperature.cpp
@@ -884,7 +884,7 @@ void Temperature::max_temp_error(const heater_ind_t heater) {
   #if HAS_TEMP_HEATBREAK
     //we have multiple heartbreak thermistors and they have always the highest ID
     if(heater >= H_HEATBREAK_E0){
-        _temp_error(heater, PSTR(MSG_T_MINTEMP), GET_TEXT(MSG_ERR_MAXTEMP_HEATBREAK));
+        _temp_error(heater, PSTR(MSG_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP_HEATBREAK));
     }
   #endif
   _temp_error(heater, PSTR(MSG_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP));


### PR DESCRIPTION
This fixes a wrong message header which should be MSG_T_MAXTEMP for max_temp_error instead of MSG_T_MINTEMP. Kudos to @Zappes for finding this issue.

Reported in https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/3757.