### PR TITLE
configuration: Disable z being enabled all the time on MK4/MK3.5

### DIFF
--- a/include/marlin/Configuration_MK3.5_adv.h
+++ b/include/marlin/Configuration_MK3.5_adv.h
@@ -543,7 +543,7 @@
 #define DEFAULT_STEPPER_DEACTIVE_TIME 120
 #define DISABLE_INACTIVE_X true
 #define DISABLE_INACTIVE_Y true
-#define DISABLE_INACTIVE_Z false // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIVE_Z true // set to false if the nozzle will fall down on your printed part when print has finished.
 #define DISABLE_INACTIVE_E true
 
 #define Z_ALWAYS_ON // Keep Z motors enabled all the time (Calls enable_Z(); in Marlin.cpp in setup)

--- a/include/marlin/Configuration_MK4_adv.h
+++ b/include/marlin/Configuration_MK4_adv.h
@@ -543,7 +543,7 @@
 #define DEFAULT_STEPPER_DEACTIVE_TIME 120
 #define DISABLE_INACTIVE_X true
 #define DISABLE_INACTIVE_Y true
-#define DISABLE_INACTIVE_Z false // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIVE_Z true // set to false if the nozzle will fall down on your printed part when print has finished.
 #define DISABLE_INACTIVE_E true
 
 #define Z_ALWAYS_ON // Keep Z motors enabled all the time (Calls enable_Z(); in Marlin.cpp in setup)


### PR DESCRIPTION
The setting DISABLE_INACTIVE_Z being false means that at the end of the print, the Z axis cannot be disabled and stays enabled. However that behaviour is only valid for printers where the bed itself or the extruder on the z axis are so heavy that they could move down just by its weight AND if the slicer would disable the Z extruder via M84 gcode. This isn't the case for regular MK3.5 and MK4. As stated correctly in issue #3387 for the MINI this setting is already true as it should be on MK3.5 and MK4 as well.