### PR TITLE
mmu2: Prevent possible buffer overflow in ProtocolLogic::LogRequestMsg

### DIFF
--- a/lib/Marlin/Marlin/src/feature/prusa/MMU2/protocol_logic.cpp
+++ b/lib/Marlin/Marlin/src/feature/prusa/MMU2/protocol_logic.cpp
@@ -759,6 +759,7 @@ void ProtocolLogic::LogRequestMsg(const uint8_t *txbuff, uint8_t size) {
         MMU2::LogRequestMsg(tmp);
     }
     strncpy(lastMsg, tmp, rqs);
+    lastMsg[rqs - 1] = '\0';
 }
 
 void ProtocolLogic::LogError(const char *reason_P) {

--- a/tests/unit/lib/Marlin/MMU2/stubs/mmu2_log.cpp
+++ b/tests/unit/lib/Marlin/MMU2/stubs/mmu2_log.cpp
@@ -1,5 +1,6 @@
 #define PROGMEM /**/
 #include <mmu2_log.h>
+#include "protocol.h"
 #include "stub_interfaces.h"
 
 MarlinLogSim marlinLogSim;
@@ -13,9 +14,11 @@ void LogEchoEvent_P(const char *msg_P) {
 }
 
 void LogRequestMsg(const char *msg) {
+    REQUIRE((strlen(msg) + 1) < (uint8_t)mp::Protocol::MaxRequestSize() + 1);
     marlinLogSim.log.push_back(msg);
 }
 void LogResponseMsg(const char *msg) {
+    REQUIRE((strlen(msg) + 1) < (uint8_t)mp::Protocol::MaxResponseSize() + 1);
     marlinLogSim.log.push_back(msg);
 }
 


### PR DESCRIPTION
**ProtocolLogic::LogRequestMsg**
The txbuff size in ProtocolLogic::LogRequestMsg could be larger than the modules::protocol::Protocol::MaxRequestSize. In that scenario, if the size of the txbuff is larger than the MaxRequestSize, the later on initialized tmp buffer with size of MaxRequestSize can be overwritten, leading to a buffer overflow.

In order to prevent a possible buffer overflow, the size of txbuff being used shall not be larger than the MaxRequestSize.

**MMU2::rx_str_P**
If the rx_buffer is filled and the content of the rx_buffer isn't null-terminated, the strlen can lead to a possible overflow of the rx_buffer as more bytes are being read into the rxbuffer via mmuSerial.read().