### PR TITLE
serial_printing: Add support for printcore

### DIFF
--- a/src/common/serial_printing.cpp
+++ b/src/common/serial_printing.cpp
@@ -11,17 +11,23 @@ void SerialPrinting::print_loop() {
 
 void SerialPrinting::abort() {
     marlin_server::enqueue_gcode("M118 A1 action:cancel");
+    // Send ";@cancel" to let printcore know we have stopped the print
+    marlin_server::enqueue_gcode("\n;@cancel");
 }
 
 void SerialPrinting::resume() {
     last_serial_indicator_ms = ticks_ms();
     GCodeQueue::pause_serial_commands = false;
     marlin_server::enqueue_gcode("M118 A1 action:resume");
+    // Send ";@resume" to let printcore know we have resumed the print
+    marlin_server::enqueue_gcode("\n;@resume");
 }
 
 void SerialPrinting::pause() {
     GCodeQueue::pause_serial_commands = false;
     marlin_server::enqueue_gcode("M118 A1 action:pause");
+    // Send ";@pause" to let printcore know we have paused the print
+    marlin_server::enqueue_gcode("\n;@pause");
 }
 
 bool SerialPrinting::has_serial_timeouted() {


### PR DESCRIPTION
In case Printcore was run and the user interacted by stopping the print, the printer started homing but then continued to print.

In order to give a backchannel to connected tools, the commands ";@cancel", ";@resume" and ";@pause" are being send.
A newline in front is required as printcore scans for this text at the beginning of a line.

This PR should only be merged AFTER https://github.com/kliment/Printrun/pull/1413 has been accepted and merged.