### PR TITLE
gcode: Update M20 to fit common marlin behaviour

### DIFF
--- a/src/marlin_stubs/host/M115.cpp
+++ b/src/marlin_stubs/host/M115.cpp
@@ -218,6 +218,9 @@ void GcodeSuite::M115() {
     #endif
     );
 
+    // PARSE FILES ON USB (M20)
+    cap_line(PSTR("EXTENDED_M20"), true);
+
 #endif // EXTENDED_CAPABILITIES_REPORT
 }
 


### PR DESCRIPTION
This addresses the issue #3054.

It improves the gcode M20 to:
1. Support listing of subdirectories and files
2. Differentiate between directories and files
3. Adds support for timestamp ("T") and long filenames ("L") to match the marlin firmware behaviour