### PR TITLE
gcode: m23 send serial msg on file select for octoprint / add missing M32 gcode cmd

### DIFF
--- a/src/marlin_stubs/sdcard/M20-M30_M32-M34.cpp
+++ b/src/marlin_stubs/sdcard/M20-M30_M32-M34.cpp
@@ -39,6 +39,8 @@ void GcodeSuite::M23() {
         }
     }
     marlin_vars()->media_SFN_path.set(parser.string_arg);
+    // Do not remove. Used by third party tools to detect that a file has been selected
+    SERIAL_ECHOLNPGM(MSG_SD_FILE_SELECTED);
 }
 
 // M24 - Start/resume SD print
@@ -92,7 +94,8 @@ void GcodeSuite::M30() {
 
 // M32 - Select file and start SD print
 void GcodeSuite::M32() {
-    // TODO
+    M23();
+    M24();
 }
 
 //


### PR DESCRIPTION
This addresses issue #3748 and adds a serial message that the file has been selected for octoprint.
Also implements missing m32 gcode command.