### PR TITLE
gui: "Settings->System->Load settings from File": Provide Feedback

### DIFF
--- a/src/common/str_utils.cpp
+++ b/src/common/str_utils.cpp
@@ -261,6 +261,22 @@ void StringBuilder::append_string(const char *str) {
     *current_pos_ = '\0';
 }
 
+void StringBuilder::append_string_view(string_view_utf8 str) {
+
+    while (true) {
+        if (is_problem()) {
+            return;
+        }
+
+        char b = str.getbyte();
+        if (b == '\0') {
+            return;
+        }
+
+        append_char(b);
+    }
+}
+
 void StringBuilder::append_printf(const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);

--- a/src/common/str_utils.hpp
+++ b/src/common/str_utils.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <algorithm>
 #include <assert.h>
+#include "../lang/string_view_utf8.hpp"
 
 inline constexpr char CHAR_SPACE = ' ';
 inline constexpr char CHAR_NBSP = '\xA0'; /// Non Breaking Space
@@ -383,6 +384,8 @@ public:
     void append_char(char ch);
 
     void append_string(const char *str);
+
+    void append_string_view(string_view_utf8 str);
 
     /// Appends text to the builder, using vsnprintf under the hood.
     void append_printf(const char *fmt, ...);

--- a/src/lang/string_view_utf8.hpp
+++ b/src/lang/string_view_utf8.hpp
@@ -145,6 +145,11 @@ public:
         , s(0xff) {}
     ~string_view_utf8() = default;
 
+    /// @returns one uint8_t from the input data
+    uint8_t getbyte() {
+        return getbyte(attrs);
+    }
+
     /// @returns one UTF-8 character from the input data
     /// and advances internal pointers (in derived classes) to the next one
     unichar getUtf8Char() {


### PR DESCRIPTION
This PR will add user feedback to the function "Settings->System->Load settings from File".
There was no feedback given and users cannot see if their "prusa_printer_settings.ini" failed or not.

![load_settings](https://github.com/prusa3d/Prusa-Firmware-Buddy/assets/6317772/f8c8c9c1-8810-4ce1-80de-f667a638d9fc)

