### PR TITLE
gcode: Add string argument for cmd M0

### DIFF
--- a/src/gui/dialogs/window_dlg_quickpause.cpp
+++ b/src/gui/dialogs/window_dlg_quickpause.cpp
@@ -11,7 +11,7 @@
 
 constexpr static const char quick_pause_txt[] = N_("Waiting for the user. Press \"Resume\" once the printer is ready.");
 
-DialogQuickPause::DialogQuickPause(fsm::BaseData)
+DialogQuickPause::DialogQuickPause(fsm::BaseData data)
     : AddSuperWindow<IDialogMarlin>(GuiDefaults::RectScreenBody)
     , icon(this, GuiDefaults::MessageIconRect, &img::warning_48x48)
     , text(this, GuiDefaults::MessageTextRect, is_multiline::yes, is_closed_on_click_t::yes, _(quick_pause_txt))
@@ -24,5 +24,12 @@ DialogQuickPause::DialogQuickPause(fsm::BaseData)
         marlin_vars()->media_LFN.copy_to(buff, FILE_NAME_BUFFER_LEN, lock);
         gcode_name.SetText(_(buff));
     }
+
+    const char *msg;
+    memcpy(&msg, (uint32_t *)data.GetData().data(), sizeof(uint32_t));
+    if (msg) {
+        text.SetText(string_view_utf8::MakeRAM((const uint8_t *)msg));
+    }
+
     CaptureNormalWindow(radio);
 }

--- a/src/marlin_stubs/M0.cpp
+++ b/src/marlin_stubs/M0.cpp
@@ -13,8 +13,16 @@
  * Add parameter logic from "M0_M1.cpp" if you need it
  */
 void PrusaGcodeSuite::M0() {
+    fsm::PhaseData data = {};
+    const char *msg_ptr;
+    if (parser.string_arg) {
+        msg_ptr = parser.string_arg;
+    } else {
+        msg_ptr = nullptr;
+    }
+    memcpy(&data[0], &msg_ptr, sizeof(uint32_t));
 
-    FSM_HOLDER_WITH_DATA__LOGGING(QuickPause, PhasesQuickPause::QuickPaused, fsm::PhaseData());
+    FSM_HOLDER_WITH_DATA__LOGGING(QuickPause, PhasesQuickPause::QuickPaused, data);
     planner.synchronize();
 
     while (marlin_server::ClientResponseHandler::GetResponseFromPhase(PhasesQuickPause::QuickPaused) == Response::_none) {


### PR DESCRIPTION
This adds a custom message for gcode command M0. Resolves issue #3775.

Example: `M0 This is a test msg !`

![m0_msg](https://github.com/prusa3d/Prusa-Firmware-Buddy/assets/6317772/6b3c3c44-3172-41fd-99e3-816c6118c2ce)

