### PR TITLE
doc: Bad prusa_printer_settings.ini default file

### DIFF
--- a/doc/prusa_printer_settings.ini
+++ b/doc/prusa_printer_settings.ini
@@ -51,4 +51,4 @@ psk=SuperSecretWifiPassword
 hostname = buddy-a.connect.prusa3d.com
 token = 1234567890
 port = 443
-tls = yes
+tls = true


### PR DESCRIPTION
The default prusa_printer_settings.ini example file fails on load as the tls setting expects the value to be "true" instead of "yes".

See [here](https://github.com/prusa3d/Prusa-Firmware-Buddy/blob/b3ee47aa573f4d9b4af82d7a6963f43ab37ccc08/src/connect/marlin_printer.cpp#L77-L78) for implementation details.