### PR TITLE
[BFW-5420] Feature/i2c m260 m261

### DIFF
--- a/include/marlin/Configuration_MINI_adv.h
+++ b/include/marlin/Configuration_MINI_adv.h
@@ -2012,7 +2012,7 @@
 
 // @section i2cbus
 
-//#define EXPERIMENTAL_I2CBUS
+#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS 0 // Set a value from 8 to 127 to act as a slave
 
 // @section extras

--- a/include/marlin/Configuration_MK3.5_adv.h
+++ b/include/marlin/Configuration_MK3.5_adv.h
@@ -2040,7 +2040,7 @@
 
 // @section i2cbus
 
-//#define EXPERIMENTAL_I2CBUS
+#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS 0 // Set a value from 8 to 127 to act as a slave
 
 // @section extras

--- a/include/marlin/Configuration_MK4_adv.h
+++ b/include/marlin/Configuration_MK4_adv.h
@@ -2048,7 +2048,7 @@
 
 // @section i2cbus
 
-//#define EXPERIMENTAL_I2CBUS
+#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS 0 // Set a value from 8 to 127 to act as a slave
 
 // @section extras

--- a/include/marlin/Configuration_XL_adv.h
+++ b/include/marlin/Configuration_XL_adv.h
@@ -2044,7 +2044,7 @@
 
 // @section i2cbus
 
-//#define EXPERIMENTAL_I2CBUS
+#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS 0 // Set a value from 8 to 127 to act as a slave
 
 // @section extras

--- a/lib/AddMarlin.cmake
+++ b/lib/AddMarlin.cmake
@@ -68,6 +68,7 @@ if(BOARD_IS_MASTER_BOARD)
             Marlin/Marlin/src/feature/runout.cpp
             Marlin/Marlin/src/feature/spindle_laser.cpp
             Marlin/Marlin/src/feature/touch/xpt2046.cpp
+            Marlin/Marlin/src/feature/twibus.cpp
             Marlin/Marlin/src/gcode/bedlevel/abl/G29.cpp
             Marlin/Marlin/src/gcode/bedlevel/abl/M421.cpp
             Marlin/Marlin/src/gcode/bedlevel/G26.cpp
@@ -106,6 +107,7 @@ if(BOARD_IS_MASTER_BOARD)
             Marlin/Marlin/src/gcode/control/R.cpp
             Marlin/Marlin/src/gcode/eeprom/M500-M504.cpp
             Marlin/Marlin/src/gcode/feature/advance/M900.cpp
+            Marlin/Marlin/src/gcode/feature/i2c/M260_M261.cpp
             Marlin/Marlin/src/gcode/feature/input_shaper/M593.cpp
             Marlin/Marlin/src/gcode/feature/input_shaper/M74.cpp
             Marlin/Marlin/src/gcode/feature/modular_bed/M556.cpp

--- a/lib/Marlin/Marlin/src/Marlin.cpp
+++ b/lib/Marlin/Marlin/src/Marlin.cpp
@@ -121,11 +121,6 @@
   #include "feature/dac/stepper_dac.h"
 #endif
 
-#if ENABLED(EXPERIMENTAL_I2CBUS)
-  #include "feature/twibus.h"
-  TWIBus i2c;
-#endif
-
 #if ENABLED(I2C_POSITION_ENCODERS)
   #include "feature/I2CPositionEncoder.h"
 #endif

--- a/lib/Marlin/Marlin/src/Marlin.cpp
+++ b/lib/Marlin/Marlin/src/Marlin.cpp
@@ -253,18 +253,6 @@ void setup_powerhold() {
   void enableStepperDrivers()  { SET_INPUT(STEPPER_RESET_PIN); }      // Set to input, allowing pullups to pull the pin high
 #endif
 
-#if ENABLED(EXPERIMENTAL_I2CBUS) && I2C_SLAVE_ADDRESS > 0
-
-  void i2c_on_receive(int bytes) { // just echo all bytes received to serial
-    i2c.receive(bytes);
-  }
-
-  void i2c_on_request() {          // just send dummy data for now
-    i2c.reply("Hello World!\n");
-  }
-
-#endif
-
 /**
  * Sensitive pin test for M42, M226
  */

--- a/lib/Marlin/Marlin/src/Marlin.h
+++ b/lib/Marlin/Marlin/src/Marlin.h
@@ -315,10 +315,6 @@ void manage_inactivity(const bool ignore_stepper_queue=false);
 
 #endif // !MIXING_EXTRUDER
 
-#if ENABLED(EXPERIMENTAL_I2CBUS)
-  #include "feature/twibus.h"
-#endif
-
 #if ENABLED(G38_PROBE_TARGET)
   extern uint8_t G38_move;          // Flag to tell the ISR that G38 is in progress, and the type
   extern bool G38_did_trigger;      // Flag from the ISR to indicate the endstop changed

--- a/lib/Marlin/Marlin/src/Marlin.h
+++ b/lib/Marlin/Marlin/src/Marlin.h
@@ -317,7 +317,6 @@ void manage_inactivity(const bool ignore_stepper_queue=false);
 
 #if ENABLED(EXPERIMENTAL_I2CBUS)
   #include "feature/twibus.h"
-  extern TWIBus i2c;
 #endif
 
 #if ENABLED(G38_PROBE_TARGET)

--- a/lib/Marlin/Marlin/src/feature/twibus.cpp
+++ b/lib/Marlin/Marlin/src/feature/twibus.cpp
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 
@@ -28,11 +28,24 @@
 
 #include <Wire.h>
 
+#include "../libs/hex_print.h"
+
+TWIBus i2c;
+
 TWIBus::TWIBus() {
   #if I2C_SLAVE_ADDRESS == 0
-    Wire.begin();                  // No address joins the BUS as the master
+
+    #if PINS_EXIST(I2C_SCL, I2C_SDA) && DISABLED(SOFT_I2C_EEPROM)
+      Wire.setSDA(pin_t(I2C_SDA_PIN));
+      Wire.setSCL(pin_t(I2C_SCL_PIN));
+    #endif
+
+    Wire.begin();                   // No address joins the BUS as the master
+
   #else
-    Wire.begin(I2C_SLAVE_ADDRESS); // Join the bus as a slave
+
+    Wire.begin(I2C_SLAVE_ADDRESS);  // Join the bus as a slave
+
   #endif
   reset();
 }
@@ -43,43 +56,32 @@ void TWIBus::reset() {
 }
 
 void TWIBus::address(const uint8_t adr) {
-  if (!WITHIN(adr, 8, 127)) {
+  if (!WITHIN(adr, 8, 127))
     SERIAL_ECHO_MSG("Bad I2C address (8-127)");
-  }
 
   addr = adr;
 
-  #if ENABLED(DEBUG_TWIBUS)
-    debug(PSTR("address"), adr);
-  #endif
+  debug(F("address"), adr);
 }
 
 void TWIBus::addbyte(const char c) {
   if (buffer_s >= COUNT(buffer)) return;
   buffer[buffer_s++] = c;
-  #if ENABLED(DEBUG_TWIBUS)
-    debug(PSTR("addbyte"), c);
-  #endif
+  debug(F("addbyte"), c);
 }
 
 void TWIBus::addbytes(char src[], uint8_t bytes) {
-  #if ENABLED(DEBUG_TWIBUS)
-    debug(PSTR("addbytes"), bytes);
-  #endif
+  debug(F("addbytes"), bytes);
   while (bytes--) addbyte(*src++);
 }
 
 void TWIBus::addstring(char str[]) {
-  #if ENABLED(DEBUG_TWIBUS)
-    debug(PSTR("addstring"), str);
-  #endif
+  debug(F("addstring"), str);
   while (char c = *str++) addbyte(c);
 }
 
 void TWIBus::send() {
-  #if ENABLED(DEBUG_TWIBUS)
-    debug(PSTR("send"), addr);
-  #endif
+  debug(F("send"), addr);
 
   Wire.beginTransmission(I2C_ADDRESS(addr));
   Wire.write(buffer, buffer_s);
@@ -89,50 +91,82 @@ void TWIBus::send() {
 }
 
 // static
-void TWIBus::echoprefix(uint8_t bytes, const char prefix[], uint8_t adr) {
+void TWIBus::echoprefix(uint8_t bytes, FSTR_P const pref, uint8_t adr) {
   SERIAL_ECHO_START();
-  serialprintPGM(prefix);
-  SERIAL_ECHOPAIR(": from:", adr, " bytes:", bytes, " data:");
+  SERIAL_ECHO(pref, F(": from:"), adr, F(" bytes:"), bytes, F(" data:"));
 }
 
 // static
-void TWIBus::echodata(uint8_t bytes, const char prefix[], uint8_t adr) {
-  echoprefix(bytes, prefix, adr);
-  while (bytes-- && Wire.available()) SERIAL_CHAR(Wire.read());
+void TWIBus::echodata(uint8_t bytes, FSTR_P const pref, uint8_t adr, const uint8_t style/*=0*/) {
+  union TwoBytesToInt16 { uint8_t bytes[2]; int16_t integervalue; };
+  TwoBytesToInt16 ConversionUnion;
+
+  echoprefix(bytes, pref, adr);
+
+  while (bytes-- && Wire.available()) {
+    int value = Wire.read();
+    switch (style) {
+
+      // Style 1, HEX DUMP
+      case 1:
+        SERIAL_CHAR(hex_nybble((value & 0xF0) >> 4));
+        SERIAL_CHAR(hex_nybble(value & 0x0F));
+        if (bytes) SERIAL_CHAR(' ');
+        break;
+
+      // Style 2, signed two byte integer (int16)
+      case 2:
+        if (bytes == 1)
+          ConversionUnion.bytes[1] = (uint8_t)value;
+        else if (bytes == 0) {
+          ConversionUnion.bytes[0] = (uint8_t)value;
+          // Output value in base 10 (standard decimal)
+          SERIAL_ECHO(ConversionUnion.integervalue);
+        }
+        break;
+
+      // Style 3, unsigned byte, base 10 (uint8)
+      case 3:
+        SERIAL_ECHO(value);
+        if (bytes) SERIAL_CHAR(' ');
+        break;
+
+      // Default style (zero), raw serial output
+      default:
+        // This can cause issues with some serial consoles, Pronterface is an example where things go wrong
+        SERIAL_CHAR(value);
+        break;
+    }
+  }
+
   SERIAL_EOL();
 }
 
-void TWIBus::echobuffer(const char prefix[], uint8_t adr) {
+void TWIBus::echobuffer(FSTR_P const prefix, uint8_t adr) {
   echoprefix(buffer_s, prefix, adr);
-  for (uint8_t i = 0; i < buffer_s; i++) SERIAL_CHAR(buffer[i]);
+  for (uint8_t i = 0; i < buffer_s; ++i) SERIAL_CHAR(buffer[i]);
   SERIAL_EOL();
 }
 
 bool TWIBus::request(const uint8_t bytes) {
   if (!addr) return false;
 
-  #if ENABLED(DEBUG_TWIBUS)
-    debug(PSTR("request"), bytes);
-  #endif
+  debug(F("request"), bytes);
 
   // requestFrom() is a blocking function
-  if (Wire.requestFrom(addr, bytes) == 0) {
-    #if ENABLED(DEBUG_TWIBUS)
-      debug("request fail", addr);
-    #endif
+  if (Wire.requestFrom(I2C_ADDRESS(addr), bytes) == 0) {
+    debug(F("request fail"), I2C_ADDRESS(addr));
     return false;
   }
 
   return true;
 }
 
-void TWIBus::relay(const uint8_t bytes) {
-  #if ENABLED(DEBUG_TWIBUS)
-    debug(PSTR("relay"), bytes);
-  #endif
+void TWIBus::relay(const uint8_t bytes, const uint8_t style/*=0*/) {
+  debug(F("relay"), bytes);
 
   if (request(bytes))
-    echodata(bytes, PSTR("i2c-reply"), addr);
+    echodata(bytes, F("i2c-reply"), addr, style);
 }
 
 uint8_t TWIBus::capture(char *dst, const uint8_t bytes) {
@@ -141,9 +175,7 @@ uint8_t TWIBus::capture(char *dst, const uint8_t bytes) {
   while (count < bytes && Wire.available())
     dst[count++] = Wire.read();
 
-  #if ENABLED(DEBUG_TWIBUS)
-    debug(PSTR("capture"), count);
-  #endif
+  debug(F("capture"), count);
 
   return count;
 }
@@ -156,16 +188,12 @@ void TWIBus::flush() {
 #if I2C_SLAVE_ADDRESS > 0
 
   void TWIBus::receive(uint8_t bytes) {
-    #if ENABLED(DEBUG_TWIBUS)
-      debug(PSTR("receive"), bytes);
-    #endif
-    echodata(bytes, PSTR("i2c-receive"), 0);
+    debug(F("receive"), bytes);
+    echodata(bytes, F("i2c-receive"), 0);
   }
 
   void TWIBus::reply(char str[]/*=nullptr*/) {
-    #if ENABLED(DEBUG_TWIBUS)
-      debug(PSTR("reply"), str);
-    #endif
+    debug(F("reply"), str);
 
     if (str) {
       reset();
@@ -177,23 +205,29 @@ void TWIBus::flush() {
     reset();
   }
 
+  void i2c_on_receive(int bytes) { // just echo all bytes received to serial
+    i2c.receive(bytes);
+  }
+
+  void i2c_on_request() {          // just send dummy data for now
+    i2c.reply("Hello World!\n");
+  }
+
 #endif
 
 #if ENABLED(DEBUG_TWIBUS)
 
   // static
-  void TWIBus::prefix(const char func[]) {
-    SERIAL_ECHOPGM("TWIBus::");
-    serialprintPGM(func);
-    SERIAL_ECHOPGM(": ");
+  void TWIBus::prefix(FSTR_P const func) {
+    SERIAL_ECHOPGM("TWIBus::", func, ": ");
   }
-  void TWIBus::debug(const char func[], uint32_t adr) {
+  void TWIBus::debug(FSTR_P const func, uint32_t adr) {
     if (DEBUGGING(INFO)) { prefix(func); SERIAL_ECHOLN(adr); }
   }
-  void TWIBus::debug(const char func[], char c) {
+  void TWIBus::debug(FSTR_P const func, char c) {
     if (DEBUGGING(INFO)) { prefix(func); SERIAL_ECHOLN(c); }
   }
-  void TWIBus::debug(const char func[], char str[]) {
+  void TWIBus::debug(FSTR_P const func, char str[]) {
     if (DEBUGGING(INFO)) { prefix(func); SERIAL_ECHOLN(str); }
   }
 

--- a/lib/Marlin/Marlin/src/feature/twibus.h
+++ b/lib/Marlin/Marlin/src/feature/twibus.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 #pragma once
@@ -30,6 +30,17 @@
 
 typedef void (*twiReceiveFunc_t)(int bytes);
 typedef void (*twiRequestFunc_t)();
+
+/**
+ * For a light i2c protocol that runs on two boards running Marlin see:
+ * See https://github.com/MarlinFirmware/Marlin/issues/4776#issuecomment-246262879
+ */
+#if I2C_SLAVE_ADDRESS > 0
+
+  void i2c_on_receive(int bytes); // Demo i2c onReceive handler
+  void i2c_on_request();          // Demo i2c onRequest handler
+
+#endif
 
 #define TWIBUS_BUFFER_SIZE 32
 
@@ -46,9 +57,8 @@ typedef void (*twiRequestFunc_t)();
  * for the host to interpret.
  *
  *  For more information see
- *    - http://marlinfw.org/docs/gcode/M260.html
- *    - http://marlinfw.org/docs/gcode/M261.html
- *
+ *    - https://marlinfw.org/docs/gcode/M260.html
+ *    - https://marlinfw.org/docs/gcode/M261.html
  */
 class TWIBus {
   private:
@@ -62,8 +72,7 @@ class TWIBus {
      * @brief Internal buffer
      * @details A fixed buffer. TWI commands can be no longer than this.
      */
-    char buffer[TWIBUS_BUFFER_SIZE];
-
+    uint8_t buffer[TWIBUS_BUFFER_SIZE];
 
   public:
     /**
@@ -132,7 +141,7 @@ class TWIBus {
      *
      * @param bytes the number of bytes to request
      */
-    static void echoprefix(uint8_t bytes, const char prefix[], uint8_t adr);
+    static void echoprefix(uint8_t bytes, FSTR_P const prefix, uint8_t adr);
 
     /**
      * @brief Echo data on the bus to serial
@@ -140,8 +149,9 @@ class TWIBus {
      *          to serial in a parser-friendly format.
      *
      * @param bytes the number of bytes to request
+     * @param style Output format for the bytes, 0 = Raw byte [default], 1 = Hex characters, 2 = uint16_t
      */
-    static void echodata(uint8_t bytes, const char prefix[], uint8_t adr);
+    static void echodata(uint8_t bytes, FSTR_P const prefix, uint8_t adr, const uint8_t style=0);
 
     /**
      * @brief Echo data in the buffer to serial
@@ -150,7 +160,7 @@ class TWIBus {
      *
      * @param bytes the number of bytes to request
      */
-    void echobuffer(const char prefix[], uint8_t adr);
+    void echobuffer(FSTR_P const prefix, uint8_t adr);
 
     /**
      * @brief Request data from the slave device and wait.
@@ -182,10 +192,11 @@ class TWIBus {
      * @brief Request data from the slave device, echo to serial.
      * @details Request a number of bytes from a slave device and output
      *          the returned data to serial in a parser-friendly format.
+     * @style Output format for the bytes, 0 = raw byte [default], 1 = Hex characters, 2 = uint16_t
      *
      * @param bytes the number of bytes to request
      */
-    void relay(const uint8_t bytes);
+    void relay(const uint8_t bytes, const uint8_t style=0);
 
     #if I2C_SLAVE_ADDRESS > 0
 
@@ -223,16 +234,20 @@ class TWIBus {
     #endif
 
     #if ENABLED(DEBUG_TWIBUS)
-
       /**
        * @brief Prints a debug message
        * @details Prints a simple debug message "TWIBus::function: value"
        */
-      static void prefix(const char func[]);
-      static void debug(const char func[], uint32_t adr);
-      static void debug(const char func[], char c);
-      static void debug(const char func[], char adr[]);
-      static inline void debug(const char func[], uint8_t v) { debug(func, (uint32_t)v); }
-
+      static void prefix(FSTR_P const func);
+      static void debug(FSTR_P const func, uint32_t adr);
+      static void debug(FSTR_P const func, char c);
+      static void debug(FSTR_P const func, char adr[]);
+    #else
+      static void debug(FSTR_P const, uint32_t) {}
+      static void debug(FSTR_P const, char) {}
+      static void debug(FSTR_P const, char[]) {}
     #endif
+    static void debug(FSTR_P const func, uint8_t v) { debug(func, (uint32_t)v); }
 };
+
+extern TWIBus i2c;

--- a/lib/Marlin/Marlin/src/feature/twibus.h
+++ b/lib/Marlin/Marlin/src/feature/twibus.h
@@ -22,25 +22,18 @@
 #pragma once
 
 #include "../core/macros.h"
-
+#include "i2c.hpp"
 #include <Wire.h>
+
+#ifndef I2C_ADDRESS
+  #define I2C_ADDRESS(A) uint8_t(A)
+#endif
 
 // Print debug messages with M111 S2 (Uses 236 bytes of PROGMEM)
 //#define DEBUG_TWIBUS
 
 typedef void (*twiReceiveFunc_t)(int bytes);
 typedef void (*twiRequestFunc_t)();
-
-/**
- * For a light i2c protocol that runs on two boards running Marlin see:
- * See https://github.com/MarlinFirmware/Marlin/issues/4776#issuecomment-246262879
- */
-#if I2C_SLAVE_ADDRESS > 0
-
-  void i2c_on_receive(int bytes); // Demo i2c onReceive handler
-  void i2c_on_request();          // Demo i2c onRequest handler
-
-#endif
 
 #define TWIBUS_BUFFER_SIZE 32
 
@@ -73,6 +66,32 @@ class TWIBus {
      * @details A fixed buffer. TWI commands can be no longer than this.
      */
     uint8_t buffer[TWIBUS_BUFFER_SIZE];
+
+    /**
+     * @brief Number of bytes available on read buffer
+     * @description Number of bytes in the read buffer
+     */
+    uint8_t read_buffer_available = 0;
+
+    /**
+     * @brief Next position to be read from read buffer
+     * @description Next position to be read from read buffer
+     */
+    uint8_t read_buffer_pos = 0;
+
+    /**
+     * @brief Internal read buffer
+     * @details A fixed read buffer.
+     */
+    uint8_t read_buffer[TWIBUS_BUFFER_SIZE];
+
+    bool read_buffer_has_byte();
+
+    uint8_t read_buffer_read_byte();
+
+    bool check_hal_response(i2c::Result response);
+
+    bool isRestrictedAddress(const uint8_t addr);
 
   public:
     /**
@@ -132,16 +151,9 @@ class TWIBus {
      * @details The target slave address for sending the full packet
      *
      * @param adr 7-bit integer address
+     * @return status of the request: true=success, false=fail
      */
-    void address(const uint8_t adr);
-
-    /**
-     * @brief Prefix for echo to serial
-     * @details Echo a label, length, address, and "data:"
-     *
-     * @param bytes the number of bytes to request
-     */
-    static void echoprefix(uint8_t bytes, FSTR_P const prefix, uint8_t adr);
+    bool address(const uint8_t adr);
 
     /**
      * @brief Echo data on the bus to serial
@@ -151,16 +163,7 @@ class TWIBus {
      * @param bytes the number of bytes to request
      * @param style Output format for the bytes, 0 = Raw byte [default], 1 = Hex characters, 2 = uint16_t
      */
-    static void echodata(uint8_t bytes, FSTR_P const prefix, uint8_t adr, const uint8_t style=0);
-
-    /**
-     * @brief Echo data in the buffer to serial
-     * @details Echo the entire buffer to serial
-     *          to serial in a parser-friendly format.
-     *
-     * @param bytes the number of bytes to request
-     */
-    void echobuffer(FSTR_P const prefix, uint8_t adr);
+    void echodata(uint8_t bytes, FSTR_P const prefix, uint8_t adr, const uint8_t style=0);
 
     /**
      * @brief Request data from the slave device and wait.
@@ -186,7 +189,7 @@ class TWIBus {
      * @brief Flush the i2c bus.
      * @details Get all bytes on the bus and throw them away.
      */
-    static void flush();
+    void flush();
 
     /**
      * @brief Request data from the slave device, echo to serial.
@@ -197,41 +200,6 @@ class TWIBus {
      * @param bytes the number of bytes to request
      */
     void relay(const uint8_t bytes, const uint8_t style=0);
-
-    #if I2C_SLAVE_ADDRESS > 0
-
-      /**
-       * @brief Register a slave receive handler
-       * @details Set a handler to receive data addressed to us
-       *
-       * @param handler A function to handle receiving bytes
-       */
-      inline void onReceive(const twiReceiveFunc_t handler) { Wire.onReceive(handler); }
-
-      /**
-       * @brief Register a slave request handler
-       * @details Set a handler to send data requested from us
-       *
-       * @param handler A function to handle receiving bytes
-       */
-      inline void onRequest(const twiRequestFunc_t handler) { Wire.onRequest(handler); }
-
-      /**
-       * @brief Default handler to receive
-       * @details Receive bytes sent to our slave address
-       *          and simply echo them to serial.
-       */
-      void receive(uint8_t bytes);
-
-      /**
-       * @brief Send a reply to the bus
-       * @details Send the buffer and clear it.
-       *          If a string is passed, write it into the buffer first.
-       */
-      void reply(char str[]=nullptr);
-      inline void reply(const char str[]) { reply((char*)str); }
-
-    #endif
 
     #if ENABLED(DEBUG_TWIBUS)
       /**
@@ -250,4 +218,4 @@ class TWIBus {
     static void debug(FSTR_P const func, uint8_t v) { debug(func, (uint32_t)v); }
 };
 
-extern TWIBus i2c;
+extern TWIBus twibus;

--- a/lib/Marlin/Marlin/src/gcode/feature/i2c/M260_M261.cpp
+++ b/lib/Marlin/Marlin/src/gcode/feature/i2c/M260_M261.cpp
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 
@@ -26,12 +26,12 @@
 
 #include "../../gcode.h"
 
-#include "../../../Marlin.h" // for i2c
+#include "../../../feature/twibus.h"
 
 /**
  * M260: Send data to a I2C slave device
  *
- * This is a PoC, the formating and arguments for the GCODE will
+ * This is a PoC, the formatting and arguments for the GCODE will
  * change to be more compatible, the current proposal is:
  *
  *  M260 A<slave device address base 10> ; Sets the I2C slave address the data will be sent to
@@ -42,14 +42,13 @@
  *
  *  M260 S1 ; Send the buffered data and reset the buffer
  *  M260 R1 ; Reset the buffer without sending data
- *
  */
 void GcodeSuite::M260() {
   // Set the target address
-  if (parser.seen('A')) i2c.address(parser.value_byte());
+  if (parser.seenval('A')) i2c.address(parser.value_byte());
 
   // Add a new byte to the buffer
-  if (parser.seen('B')) i2c.addbyte(parser.value_byte());
+  if (parser.seenval('B')) i2c.addbyte(parser.value_byte());
 
   // Flush the buffer to the bus
   if (parser.seen('S')) i2c.send();
@@ -61,15 +60,16 @@ void GcodeSuite::M260() {
 /**
  * M261: Request X bytes from I2C slave device
  *
- * Usage: M261 A<slave device address base 10> B<number of bytes>
+ * Usage: M261 A<slave device address base 10> B<number of bytes> S<style>
  */
 void GcodeSuite::M261() {
-  if (parser.seen('A')) i2c.address(parser.value_byte());
+  if (parser.seenval('A')) i2c.address(parser.value_byte());
 
-  uint8_t bytes = parser.byteval('B', 1);
+  const uint8_t bytes = parser.byteval('B', 1),   // Bytes to request
+                style = parser.byteval('S');      // Serial output style (ASCII, HEX etc)
 
   if (i2c.addr && bytes && bytes <= TWIBUS_BUFFER_SIZE)
-    i2c.relay(bytes);
+    i2c.relay(bytes, style);
   else
     SERIAL_ERROR_MSG("Bad i2c request");
 }

--- a/lib/Marlin/Marlin/src/gcode/feature/i2c/M260_M261.cpp
+++ b/lib/Marlin/Marlin/src/gcode/feature/i2c/M260_M261.cpp
@@ -45,16 +45,20 @@
  */
 void GcodeSuite::M260() {
   // Set the target address
-  if (parser.seenval('A')) i2c.address(parser.value_byte());
+  if (parser.seenval('A')) {
+    if (!twibus.address(parser.value_byte())) {
+      return;
+    }
+  }
 
   // Add a new byte to the buffer
-  if (parser.seenval('B')) i2c.addbyte(parser.value_byte());
+  if (parser.seenval('B')) twibus.addbyte(parser.value_byte());
 
   // Flush the buffer to the bus
-  if (parser.seen('S')) i2c.send();
+  if (parser.seen('S')) twibus.send();
 
   // Reset and rewind the buffer
-  else if (parser.seen('R')) i2c.reset();
+  else if (parser.seen('R')) twibus.reset();
 }
 
 /**
@@ -63,13 +67,17 @@ void GcodeSuite::M260() {
  * Usage: M261 A<slave device address base 10> B<number of bytes> S<style>
  */
 void GcodeSuite::M261() {
-  if (parser.seenval('A')) i2c.address(parser.value_byte());
+  if (parser.seenval('A')) {
+    if (!twibus.address(parser.value_byte())) {
+      return;
+    }
+  }
 
   const uint8_t bytes = parser.byteval('B', 1),   // Bytes to request
                 style = parser.byteval('S');      // Serial output style (ASCII, HEX etc)
 
-  if (i2c.addr && bytes && bytes <= TWIBUS_BUFFER_SIZE)
-    i2c.relay(bytes, style);
+  if (twibus.addr && bytes && bytes <= TWIBUS_BUFFER_SIZE)
+    twibus.relay(bytes, style);
   else
     SERIAL_ERROR_MSG("Bad i2c request");
 }


### PR DESCRIPTION
This adds support for the m260 m261 commands and makes it possible to control an I2C device attached to the I2C socket.

Related to https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/3711

Since I'm not used to developing c++ and even less for a firmware, please let me know if something needs to be changed to make it possible to include this change.

Please not that this change requires EXPERIMENTAL_I2CBUS to be enabled to be effective and therefore requires a custom firmware build.