### PR TITLE
gcode: Add mk3 compatibility to G90 command

### DIFF
--- a/lib/Marlin/Marlin/src/gcode/gcode.h
+++ b/lib/Marlin/Marlin/src/gcode/gcode.h
@@ -323,7 +323,15 @@ public:
     return TEST(axis_relative, a);
   }
   static inline void set_relative_mode(const bool rel) {
-    axis_relative = rel ? _BV(REL_X) | _BV(REL_Y) | _BV(REL_Z) | _BV(REL_E) : 0;
+    #if ENABLED(GCODE_COMPATIBILITY_MK3)
+        if (compatibility_mode == CompatibilityMode::MK3) {
+            axis_relative = rel ? _BV(REL_X) | _BV(REL_Y) | _BV(REL_Z) : 0;
+        } else {
+            axis_relative = rel ? _BV(REL_X) | _BV(REL_Y) | _BV(REL_Z) | _BV(REL_E) : 0;
+        }
+    #else
+        axis_relative = rel ? _BV(REL_X) | _BV(REL_Y) | _BV(REL_Z) | _BV(REL_E) : 0;
+    #endif
   }
   static inline void set_e_relative() {
     CBI(axis_relative, E_MODE_ABS);


### PR DESCRIPTION
This addresses issue #3847.

When in mk3 compatibility mode, the G90 command should behave exactly as in https://github.com/prusa3d/Prusa-Firmware/blob/MK3/Firmware/Marlin_main.cpp#L5120.

However the MK4 normally does also set absolute values for the E-Axis, which the MK3 didn't do before (which is also documented), as you can see here: 
https://github.com/prusa3d/Prusa-Firmware-Buddy/blob/master/lib/Marlin/Marlin/src/gcode/gcode.h#L314

This PR adds further support for the MK3 compatibility mode by removing setting absolute values for the E-Axis for gcode G90.