### PR TITLE
Increase the lines searched for PNG image

### DIFF
--- a/src/common/gcode/gcode_reader_plaintext.cpp
+++ b/src/common/gcode/gcode_reader_plaintext.cpp
@@ -26,7 +26,7 @@ bool PlainGcodeReader::stream_gcode_start(uint32_t offset) {
 }
 bool PlainGcodeReader::stream_thumbnail_start(uint16_t expected_width, uint16_t expected_height, ImgType expected_type, bool allow_larger) {
     // search for begining of thumbnail in file
-    static const size_t MAX_SEARCH_LINES = 2048;
+    static const size_t MAX_SEARCH_LINES = 4096;
     // We want to do simple scan through beginning of file, so we use gcode stream for that, it doesn't skip towards end of file like metadata stream
     if (!stream_gcode_start()) {
         return false;


### PR DESCRIPTION
Only effects plaintext gcode. The new QOI images make it necessary to look further into the gcode to find the PNG image for display in Prusalink (and maybe Prusaconnect? I've not used it so not sure).

Currently, if you have a plaintext gcode file with the default gcode thumbnails (for MK4 that means: 16x16/QOI, 313x173/QOI, 440x240/QOI, 480x240/QOI, 640x480/PNG) Prusalink can't load the thumbnail, because the printer fails to send it.

This fixes https://github.com/prusa3d/Prusa-Link-Web/issues/475