### PR TITLE
Initial stale issue workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Mark stale issues
+
+on:
+  schedule:
+  # 1:30 AM on MON/THU
+  - cron: "30 1 * * 1,2,3,4"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Don't ever mark PRs as stale.
+        days-before-pr-stale: -1
+        stale-issue-message: 'This issue has been flagged as stale because it has been open for 60 days with no activity. The issue will be closed in 7 days unless someone removes the "stale" label or adds a comment.'
+        close-issue-message: 'This issue has been closed due to lack of recent activity. Please consider opening a new one if needed.' 
+        # Don't act on things assigned to a milestone or assigned to someone. 
+        exempt-all-milestones: true
+        exempt-all-assignees: true
+        enable-statistics: true
+        # Disable this and change the operations per run back to 30 when this goes live.
+        debug-only: false
+        operations-per-run: 200
+        stale-issue-label: 'stale-issue'
+        stale-pr-label: 'stale-pr'
+        ascending: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues
 
 on:
   schedule:
-  # 1:30 AM on MON/THU
+  # 1:30 AM on MON/TUE/WED/THU
   - cron: "30 1 * * 1,2,3,4"
 
 jobs:
@@ -17,8 +17,8 @@ jobs:
         # Don't ever mark PRs as stale.
         days-before-pr-stale: -1
         stale-issue-message: 'This issue has been flagged as stale because it has been open for 60 days with no activity. The issue will be closed in 7 days unless someone removes the "stale" label or adds a comment.'
-        close-issue-message: 'This issue has been closed due to lack of recent activity. Please consider opening a new one if needed.' 
-        # Don't act on things assigned to a milestone or assigned to someone. 
+        close-issue-message: 'This issue has been closed due to lack of recent activity. Please consider opening a new one if needed.'
+        # Don't act on things assigned to a milestone or assigned to someone.
         exempt-all-milestones: true
         exempt-all-assignees: true
         enable-statistics: true


### PR DESCRIPTION
Use same settings as we have in the 8-bit firmware see [here](https://github.com/prusa3d/Prusa-Firmware/blob/MK3/.github/workflows/stale.yml)

- Does not touch PRs
- Issues tagged stale-issue after 60 days
- Closed after a further 7 days without activity
- Anything with an assignee or milestone assigned is not touched
- Runs at 1:30 on Monday/Tuesday/Wednesday/Thursday