### PR TITLE
Fix M260 & M261 for MINI

### DIFF
--- a/include/device/stm32f4/device/peripherals.h
+++ b/include/device/stm32f4/device/peripherals.h
@@ -237,6 +237,7 @@ extern TIM_HandleTypeDef htim14;
     #define i2c_eeprom      1
     #define i2c_usbc        -1
     #define i2c_touch       -1
+    #define i2c_gcode       1
     #define i2c_io_extender -1
     #define spi_flash       3
     #define spi_lcd         2
@@ -247,6 +248,7 @@ extern TIM_HandleTypeDef htim14;
 #elif BOARD_IS_XBUDDY
     #define i2c_eeprom        2
     #define i2c_usbc          2
+    #define i2c_gcode         2
     #define i2c_io_extender   -1
     #define spi_flash         5
     #define spi_lcd           6
@@ -266,6 +268,7 @@ extern TIM_HandleTypeDef htim14;
     #define i2c_eeprom         2
     #define i2c_usbc           1
     #define i2c_touch          3
+    #define i2c_gcode          2
     #define i2c_io_extender    2
     #define spi_flash          5
     #define spi_lcd            6
@@ -286,7 +289,7 @@ extern TIM_HandleTypeDef htim14;
     #define spi_led spi_extconn
 #endif
 
-#define HAS_I2CN(n) ((n == i2c_eeprom) || (n == i2c_touch) || (n == i2c_usbc) || (n == i2c_io_extender))
+#define HAS_I2CN(n) ((n == i2c_eeprom) || (n == i2c_touch) || (n == i2c_usbc) || (n == i2c_gcode) || (n == i2c_io_extender))
 
 //
 // Other

--- a/lib/Marlin/Marlin/src/feature/twibus.cpp
+++ b/lib/Marlin/Marlin/src/feature/twibus.cpp
@@ -115,7 +115,7 @@ void TWIBus::addstring(char str[]) {
 void TWIBus::send() {
   debug(F("send"), addr);
   
-  i2c::Result ret = i2c::Transmit(hi2c2, addr << 1, buffer, buffer_s, 100);
+  i2c::Result ret = i2c::Transmit(I2C_HANDLE_FOR(gcode), addr << 1, buffer, buffer_s, 100);
   reset();
 
   check_hal_response(ret);
@@ -199,7 +199,7 @@ bool TWIBus::request(const uint8_t bytes) {
 
   flush();
 
-  i2c::Result ret = i2c::Receive(hi2c2, addr << 1 | 0x1, read_buffer, bytes, 100);
+  i2c::Result ret = i2c::Receive(I2C_HANDLE_FOR(gcode), addr << 1 | 0x1, read_buffer, bytes, 100);
 
   if (!check_hal_response(ret)) {
     return false;


### PR DESCRIPTION
BFW-5397

MINI does not have hi2c2 interface, so we have to diferentiate between interfaces based on the printer.