### PR TITLE
selftest: BUG 3480: Fix inconsistent failures on XL Fan Test

### DIFF
--- a/src/common/selftest/selftest_XL.cpp
+++ b/src/common/selftest/selftest_XL.cpp
@@ -60,8 +60,11 @@ static consteval SelftestFansConfig make_fan_config(uint8_t index) {
             ///@note Datasheet says 5900 +-10%, but that is without any fan shroud.
             ///  Blocked fan increases its RPMs over 7000.
             ///  With XL shroud the values can be 6200 - 6600 depending on fan shroud version.
+            ///  Altitude of installed printer impacts fan speed.  Users are seeing values
+            ///  closer to the 7000 rpm in certain circumstances.   Concern with self test should
+            ///  be a fan that isn't spinning fast enough, not a fan that is spinning rapidly.
             .rpm_min = 5300,
-            .rpm_max = 6799,
+            .rpm_max = 7000,
         },
         .heatbreak_fan = {
             .rpm_min = 6800,

--- a/src/common/selftest/selftest_XL.cpp
+++ b/src/common/selftest/selftest_XL.cpp
@@ -59,15 +59,12 @@ static consteval SelftestFansConfig make_fan_config(uint8_t index) {
         .print_fan = {
             ///@note Datasheet says 5900 +-10%, but that is without any fan shroud.
             ///  Blocked fan increases its RPMs over 7000.
-            ///  With XL shroud the values can be 6200 - 6600 depending on fan shroud version.
-            ///  Altitude of installed printer impacts fan speed.  Users are seeing values
-            ///  closer to the 7000 rpm in certain circumstances.   Concern with self test should
-            ///  be a fan that isn't spinning fast enough, not a fan that is spinning rapidly.
+            ///  With XL shroud the values can be 6200 - 6900 depending on fan shroud version.
             .rpm_min = 5300,
-            .rpm_max = 7000,
+            .rpm_max = 6899,
         },
         .heatbreak_fan = {
-            .rpm_min = 6800,
+            .rpm_min = 6900,
             .rpm_max = 8700,
         },
     };


### PR DESCRIPTION
Increasing the max on the XL print fan speed.   Several users pushing over 6799 RPM causing failure, me included.   The print fan and heatbreak fan appear to be linked with an assertion which is unfortunate because I can certainly confirm that in my case the maximum on the print fan is insufficient and requires disassembly of the print shroud to pass which is inconvenient.

Because of the assertion, I only increased by 100 RPM - but there are reports in the wild, especially in high altitude situations, of the fans going over 7,000 RPM with the shroud in place. 

The assertion appears to be in place so that the "fans switched" check works correctly...  but this may need to further be updated to only raise a message if the reports are outside of a specific range where this is a sure conclusion - because the appropriate value for the print fan should probably be increased to 7k+ RPM to compensate for shroud and altitude which would certainly overlap the minimum for the heatbreak.  Will perform some more testing to get some realistic values.

For now, I am just trying to correct this for a majority of users I have seen in the wild, who are only slightly exceeding the print fan maximum.