### PR TITLE
[BFW-5652] mmu3: skip unloading filament on early abort

### DIFF
--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -482,6 +482,9 @@ void print_fan_spd() {
 /// can do this since this will be only called at the end of the print or when aborting.
 /// So it shouldn't overwrite any important gcodes.
 void safely_unload_filament_from_nozzle_to_mmu() {
+    if (MMU2::WhereIsFilament() == MMU2::FilamentState::NOT_PRESENT) {
+        return; // no filament loaded, nothing to do
+    }
     const auto original_temp = thermalManager.degTargetHotend(active_extruder);
     enqueue_gcode("M702 W2");
     enqueue_gcode_printf("M104 S%i", original_temp);


### PR DESCRIPTION
checks if filament is loaded before queuing M702

fixes #3955