### PR TITLE
zaxis:Decrease first layer calibration live-z from -2000 to -3000

### DIFF
--- a/src/gui/footer/footer_item_live_z.cpp
+++ b/src/gui/footer/footer_item_live_z.cpp
@@ -19,7 +19,7 @@ int FooterItemLiveZ::static_readValue() {
 
 string_view_utf8 FooterItemLiveZ::static_makeView(int value) {
     static std::array<char, 7> buff; //"-2" - "0", longest "-0.001"
-    int value_clamped = std::clamp(value, -2000, 0);
+    int value_clamped = std::clamp(value, -3000, 0);
 
     int printed_chars = snprintf(buff.data(), buff.size(), "%i.%.3u", value_clamped / 1000, std::abs(value_clamped) % 1000);
 


### PR DESCRIPTION
This fixes issue #4081. Allows the value for the live z-axis calibration to be decreased to -3000 instead of just -2000 in order to allow to setup third-party extruders like the Revo 3D on MK 3.5.