### PR TITLE
[BFW-5918] gui: don't remove trailing zeroes of the Footer's axis value

### DIFF
--- a/src/gui/footer/footer_item_axis.hpp
+++ b/src/gui/footer/footer_item_axis.hpp
@@ -31,11 +31,6 @@ string_view_utf8 FooterItemAxisPos<AXIS>::static_makeViewIntoBuff(float value) {
 
     if (printed_chars < 1) {
         buff[0] = '\0';
-    } else if (size_t(printed_chars) < buff.size()) {
-        // Remove repeated trailing zeroes after the decimal point
-        while (((--printed_chars) > 2) && (buff[printed_chars] == '0') && (buff[printed_chars - 1] != '.')) {
-            buff[printed_chars] = '\0';
-        }
     }
     return string_view_utf8::MakeRAM((const uint8_t *)buff.data());
 }
@@ -68,11 +63,6 @@ string_view_utf8 FooterItemAxisCurrPos<AXIS>::static_makeViewIntoBuff(float valu
 
     if (printed_chars < 1) {
         buff[0] = '\0';
-    } else if (size_t(printed_chars) < buff.size()) {
-        // Remove repeated trailing zeroes after the decimal point
-        while (((--printed_chars) > 2) && (buff[printed_chars] == '0') && (buff[printed_chars - 1] != '.')) {
-            buff[printed_chars] = '\0';
-        }
     }
     return string_view_utf8::MakeRAM((const uint8_t *)buff.data());
 }

--- a/src/gui/footer/footer_item_live_z.cpp
+++ b/src/gui/footer/footer_item_live_z.cpp
@@ -25,11 +25,6 @@ string_view_utf8 FooterItemLiveZ::static_makeView(int value) {
 
     if (printed_chars < 1) {
         buff[0] = '\0';
-    } else if (size_t(printed_chars) < buff.size()) {
-        // dont want it to erase last in 0.0, -1.0, -2.0
-        while ((--printed_chars) > 2 && buff[printed_chars] == '0' && buff[printed_chars - 1] != '.') {
-            buff[printed_chars] = '\0';
-        }
     }
 
     return string_view_utf8::MakeRAM((const uint8_t *)buff.data());


### PR DESCRIPTION
This PR implements the enhancement I proposed in #4042 . I confirmed it works as expected on my Prusa MK4.
I set `master` as the base branch since other PRs do this. Please switch this if necessary. Thank you!

# Changes
- `src/gui/footer/footer_item_axis.hpp`, `footer_item_live_z.cpp`: else-if blocks are removed to stop removing trailing zeroes after the decimal point.

# Fixes
- Added `setuptools` to the Holly's dependency
   - Since Python 3.12.3, venv won't pre-install setuptools
   - I used Python 3.12.3 to build the firmware and suffered an error due to the lack of it