### PR TITLE
[BFW-5927] Removed "Plenk"

### DIFF
--- a/src/lang/po/de/Prusa-Firmware-Buddy_de.po
+++ b/src/lang/po/de/Prusa-Firmware-Buddy_de.po
@@ -7577,7 +7577,7 @@ msgid ""
 "Welcome to the Original Prusa MINI setup wizard. Would you like to continue?"
 msgstr ""
 "Willkommen zum Original Prusa MINI Einrichtungsassistent\n"
-"Fortfahren ?"
+"Fortfahren?"
 
 #: src/gui/wizard/selftest_frame_fsensor.cpp:98
 msgid ""


### PR DESCRIPTION
Spaces/Blanks ("[Plank](https://de.m.wikipedia.org/wiki/Plenk)") before punctuation marks are grammatically incorrect in German