### PR TITLE
gcode: M104.1, add support for P and Q options

### DIFF
--- a/src/marlin_stubs/M104_1.cpp
+++ b/src/marlin_stubs/M104_1.cpp
@@ -5,6 +5,7 @@
 #include <marlin_vars.hpp>
 #include <Marlin/src/gcode/parser.h>
 #include <gcode/gcode.h>
+#include "../../module/planner.h"
 
 #ifdef PRINT_CHECKING_Q_CMDS
 
@@ -34,6 +35,14 @@ void PrusaGcodeSuite::M104_1() {
 
     // If we should start preheating, simply process this command as if it was standard M104 (otherwise do nothing)
     if (should_start_preheating) {
+        millis_t dwell_ms = 0;
+        if (parser.seen('P')) {
+            dwell_ms = parser.ulongval('P');
+        } else if (parser.seen('Q')) {
+            dwell_ms = parser.ulongval('Q');
+        }
+        planner.synchronize();
+        GcodeSuite::dwell(dwell_ms);
         GcodeSuite::M104();
     }
 }


### PR DESCRIPTION
This commit makes sure that M104 isn't run immediately on preheating, but in fact given options P and Q are referred to for adding a dwell and waiting for heating up instead.

Refers to issue #4115 (issue #4116 / issue #4117)

