### PR TITLE
serial: Indicate gcode cmd length longer than allowed.

### DIFF
--- a/lib/Marlin/Marlin/src/core/language.h
+++ b/lib/Marlin/Marlin/src/core/language.h
@@ -70,6 +70,7 @@
 #define MSG_STATS                           "Stats: "
 #define MSG_FILE_SAVED                      "Done saving file."
 #define MSG_ERR_LINE_NO                     "Line Number is not Last Line Number+1, Last Line: "
+#define MSG_ERR_LINE_LENGTH                 "Line exceeds max buffer length. Last Line: "
 #define MSG_ERR_CHECKSUM_MISMATCH           "checksum mismatch, Last Line: "
 #define MSG_ERR_NO_CHECKSUM                 "No Checksum with line number, Last Line: "
 #define MSG_FILE_PRINTED                    "Done printing file"

--- a/lib/Marlin/Marlin/src/gcode/queue.cpp
+++ b/lib/Marlin/Marlin/src/gcode/queue.cpp
@@ -350,6 +350,7 @@ FORCE_INLINE bool is_M29(const char * const cmd) {  // matches "M29" & "M29 ", b
  */
 void GCodeQueue::get_serial_commands() {
   static char serial_line_buffer[NUM_SERIAL][MAX_CMD_SIZE];
+  static bool serial_line_too_long[NUM_SERIAL] = { false };
   static bool serial_comment_mode[NUM_SERIAL] = { false }
               #if ENABLED(PAREN_COMMENTS)
                 // #error dead code found by automatic analyses (see BFW-5461)
@@ -383,6 +384,8 @@ void GCodeQueue::get_serial_commands() {
        * If the character ends the line
        */
       if (serial_char == '\n' || serial_char == '\r') {
+        const bool line_too_long = serial_line_too_long[i];
+        serial_line_too_long[i] = false;
 
         // Start with comment mode off
         serial_comment_mode[i] = false;
@@ -393,6 +396,9 @@ void GCodeQueue::get_serial_commands() {
 
         // Skip empty lines and comments
         if (!serial_count[i]) { thermalManager.manage_heater(); continue; }
+
+        if (line_too_long)
+          return gcode_line_error(PSTR(MSG_ERR_LINE_LENGTH), i);
 
         serial_line_buffer[i][serial_count[i]] = 0;       // Terminate string
         serial_count[i] = 0;                              // Reset buffer
@@ -458,7 +464,8 @@ void GCodeQueue::get_serial_commands() {
       }
       else if (serial_count[i] >= MAX_CMD_SIZE - 1) {
         // Keep fetching, but ignore normal characters beyond the max length
-        // The command will be injected when EOL is reached
+        // The error is reported once EOL is reached, after the whole line is drained.
+        serial_line_too_long[i] = true;
       }
       else if (serial_char == '\\') {  // Handle escapes
         // if we have one more character, copy it over


### PR DESCRIPTION
Refers to issue #4123.

If a gcode command being sent via serial is longer than the MAX_CMD_SIZE and the gcode command does contain a checksum, the checksum given in the command may no longer be part of the command buffer and thus leads to a checksum error although the checksum is valid.

This code adds an error if the command length exceeds the cmd buffer size and thus ensures that the checksum no longer is validated.