### PR TITLE
ini_parser: Remove inline comment parsing on ini handler for values

### DIFF
--- a/lib/inih/ini.c
+++ b/lib/inih/ini.c
@@ -199,11 +199,6 @@ int ini_parse_stream(ini_reader reader, void* stream, ini_handler handler,
                 *end = '\0';
                 name = rstrip(start);
                 value = end + 1;
-#if INI_ALLOW_INLINE_COMMENTS
-                end = find_chars_or_comment(value, NULL);
-                if (*end)
-                    *end = '\0';
-#endif
                 value = lskip(value);
                 rstrip(value);
                 value = unquote(value);


### PR DESCRIPTION
On rare occations when parsing the prusa_printer_settings.ini, a value after = is being interpreted as inline comment, although it shouldn't, leading to an invalid null termination of a value value string.

For example:
`field = #value`

The parser does only treat an inline comment as comment if a whitespace is followed by a hashtag char. In this case, field and value aren't treated as one, but as two lines. it is setting a nulltermination at "=" for parsing the field and then parses the value as " #value", assuming that an inline comment has occured.

By removing this inline comment check when parsing the value fields, we can rule out this problem.

Related to issue #4162, can relate to #2325 as well.