### PR TITLE
[BFW-6223] gui: Fix invalid display of "static" due to WI_SWITCH initialization in MI_NET_IP

### DIFF
--- a/src/gui/MItem_network.cpp
+++ b/src/gui/MItem_network.cpp
@@ -176,12 +176,12 @@ MI_NET_IP::MI_NET_IP(NetDeviceID device_id)
     : WI_SWITCH_t(0, string_view_utf8::MakeCPUFLASH(label), nullptr, is_enabled_t::yes, is_hidden_t::no, string_view_utf8::MakeCPUFLASH(str_DHCP), string_view_utf8::MakeCPUFLASH(str_static))
     , device_id(device_id) //
 {
-    index = netdev_get_ip_obtained_type(this->device_id());
+    this->SetIndex(netdev_get_ip_obtained_type(this->device_id()));
 }
 
 void MI_NET_IP::OnChange([[maybe_unused]] size_t old_index) {
     const auto dev_id = device_id();
-    if (index == NETDEV_STATIC) {
+    if (this->GetIndex() == NETDEV_STATIC) {
         netdev_set_static(dev_id);
     } else {
         netdev_set_dhcp(dev_id);


### PR DESCRIPTION
This resolves issue #3155.

When setting the network ip address from "DHCP" to "static", on next reentry of Ethernet Settings -> LAN, the text "stat" is only being displayed. This is due to the default index on WI_SWITCH_t being 0 (DHCP). On setting the index, it should normally recalculate the string length to be 6 instead of 4, but due to the index already being set to 1 changeExtentionWidth is never run.

The problem is within a nasty bug as WI_SWITCH index should never be exposed public and MI_NET_IP didn't define index, thus leading to WI_SWITCH index being used as a global and not as a local variable. By defining a private index variable in WI_SWITCH, this problem is resolved.

!! **I strongly recommend to replace the public "index" variable of WI_SWITCH to be defined as private as there is already a function to set the index called "SetIndex" in WI_SWITCH to prevent similar issues in the future** !!
