### PR TITLE
[BFW-6709] WI_SWITCH_t : Ensure that variable "index" is private, preventing use outside the derived class

### DIFF
--- a/src/gui/MItem_crash.cpp
+++ b/src/gui/MItem_crash.cpp
@@ -81,7 +81,7 @@ MI_CRASH_SENSITIVITY_XY::MI_CRASH_SENSITIVITY_XY()
     : MenuItemSwitch(_(label), crash_sensitivity_items, stdext::index_of(crash_sensitivity_item_values, crash_s.get_sensitivity().x)) {}
 
 void MI_CRASH_SENSITIVITY_XY::OnChange([[maybe_unused]] size_t old_index) {
-    const int32_t sensitivity = crash_sensitivity_item_values[index];
+    const int32_t sensitivity = crash_sensitivity_item_values[this->get_index()];
     crash_s.set_sensitivity({ .x = sensitivity, .y = sensitivity });
 }
     #else

--- a/src/gui/MItem_experimental_tools.cpp
+++ b/src/gui/MItem_experimental_tools.cpp
@@ -114,7 +114,7 @@ MI_DIRECTION_X::MI_DIRECTION_X()
     : WiSwitchDirection(has_wrong_x(), NOTRAN(label)) {}
 
 void MI_DIRECTION_X::Store() {
-    index == 1 ? set_wrong_direction_x() : set_PRUSA_direction_x();
+    GetIndex() == 1 ? set_wrong_direction_x() : set_PRUSA_direction_x();
 }
 
 /*****************************************************************************/
@@ -123,7 +123,7 @@ MI_DIRECTION_Y::MI_DIRECTION_Y()
     : WiSwitchDirection(has_wrong_y(), NOTRAN(label)) {}
 
 void MI_DIRECTION_Y::Store() {
-    index == 1 ? set_wrong_direction_y() : set_PRUSA_direction_y();
+    GetIndex() == 1 ? set_wrong_direction_y() : set_PRUSA_direction_y();
 }
 
 /*****************************************************************************/
@@ -132,7 +132,7 @@ MI_DIRECTION_Z::MI_DIRECTION_Z()
     : WiSwitchDirection(has_wrong_z(), NOTRAN(label)) {}
 
 void MI_DIRECTION_Z::Store() {
-    index == 1 ? set_wrong_direction_z() : set_PRUSA_direction_z();
+    GetIndex() == 1 ? set_wrong_direction_z() : set_PRUSA_direction_z();
 }
 
 /*****************************************************************************/
@@ -141,7 +141,7 @@ MI_DIRECTION_E::MI_DIRECTION_E()
     : WiSwitchDirection(has_wrong_e(), NOTRAN(label)) {}
 
 void MI_DIRECTION_E::Store() {
-    index == 1 ? set_wrong_direction_e() : set_PRUSA_direction_e();
+    GetIndex() == 1 ? set_wrong_direction_e() : set_PRUSA_direction_e();
 }
 
 /*****************************************************************************/

--- a/src/gui/MItem_experimental_tools.cpp
+++ b/src/gui/MItem_experimental_tools.cpp
@@ -114,7 +114,7 @@ MI_DIRECTION_X::MI_DIRECTION_X()
     : WiSwitchDirection(has_wrong_x(), NOTRAN(label)) {}
 
 void MI_DIRECTION_X::Store() {
-    GetIndex() == 1 ? set_wrong_direction_x() : set_PRUSA_direction_x();
+    get_index() == 1 ? set_wrong_direction_x() : set_PRUSA_direction_x();
 }
 
 /*****************************************************************************/
@@ -123,7 +123,7 @@ MI_DIRECTION_Y::MI_DIRECTION_Y()
     : WiSwitchDirection(has_wrong_y(), NOTRAN(label)) {}
 
 void MI_DIRECTION_Y::Store() {
-    GetIndex() == 1 ? set_wrong_direction_y() : set_PRUSA_direction_y();
+    get_index() == 1 ? set_wrong_direction_y() : set_PRUSA_direction_y();
 }
 
 /*****************************************************************************/
@@ -132,7 +132,7 @@ MI_DIRECTION_Z::MI_DIRECTION_Z()
     : WiSwitchDirection(has_wrong_z(), NOTRAN(label)) {}
 
 void MI_DIRECTION_Z::Store() {
-    GetIndex() == 1 ? set_wrong_direction_z() : set_PRUSA_direction_z();
+    get_index() == 1 ? set_wrong_direction_z() : set_PRUSA_direction_z();
 }
 
 /*****************************************************************************/
@@ -141,7 +141,7 @@ MI_DIRECTION_E::MI_DIRECTION_E()
     : WiSwitchDirection(has_wrong_e(), NOTRAN(label)) {}
 
 void MI_DIRECTION_E::Store() {
-    GetIndex() == 1 ? set_wrong_direction_e() : set_PRUSA_direction_e();
+    get_index() == 1 ? set_wrong_direction_e() : set_PRUSA_direction_e();
 }
 
 /*****************************************************************************/

--- a/src/gui/MItem_hardware.cpp
+++ b/src/gui/MItem_hardware.cpp
@@ -27,7 +27,7 @@ MI_HARDWARE_CHECK::MI_HARDWARE_CHECK(HWCheckType check_type)
 {}
 
 void MI_HARDWARE_CHECK::OnChange([[maybe_unused]] size_t old_index) {
-    config_store().visit_hw_check(check_type, [set = static_cast<HWCheckSeverity>(index)](auto &item) { item.set(set); });
+    config_store().visit_hw_check(check_type, [set = static_cast<HWCheckSeverity>(this->GetIndex())](auto &item) { item.set(set); });
 }
 
 MI_HARDWARE_G_CODE_CHECKS::MI_HARDWARE_G_CODE_CHECKS()

--- a/src/gui/MItem_hardware.cpp
+++ b/src/gui/MItem_hardware.cpp
@@ -27,7 +27,7 @@ MI_HARDWARE_CHECK::MI_HARDWARE_CHECK(HWCheckType check_type)
 {}
 
 void MI_HARDWARE_CHECK::OnChange([[maybe_unused]] size_t old_index) {
-    config_store().visit_hw_check(check_type, [set = static_cast<HWCheckSeverity>(this->GetIndex())](auto &item) { item.set(set); });
+    config_store().visit_hw_check(check_type, [set = static_cast<HWCheckSeverity>(this->get_index())](auto &item) { item.set(set); });
 }
 
 MI_HARDWARE_G_CODE_CHECKS::MI_HARDWARE_G_CODE_CHECKS()

--- a/src/gui/MItem_mmu.cpp
+++ b/src/gui/MItem_mmu.cpp
@@ -230,7 +230,7 @@ void MI_MMU_ENABLE::OnChange(size_t old_index) {
         // logical_sensors.extruder is not synchronized, but in this case it it OK
         if (!is_fsensor_working_state(FSensors_instance().sensor_state(LogicalFilamentSensor::extruder))) {
             MsgBoxWarning(_("Can't enable MMU: calibrate and enable the printer's filament sensor first."), Responses_Ok);
-            SetIndex(old_index);
+            set_index(old_index);
             return;
         }
 
@@ -288,15 +288,15 @@ MI_MMU_NEXTRUDER_REWORK::MI_MMU_NEXTRUDER_REWORK()
         config_store().is_mmu_rework.get()) {}
 
 void MI_MMU_NEXTRUDER_REWORK::OnChange([[maybe_unused]] size_t old_index) {
-    if (!flip_mmu_rework(GetIndex() == 0)) {
-        SetIndex(old_index); // revert the index change of the toggle in case the user aborted the dialog
+    if (!flip_mmu_rework(get_index() == 0)) {
+        set_index(old_index); // revert the index change of the toggle in case the user aborted the dialog
         return;
     }
 
     // Enabling MMU rework hides the FS_Autoload option from the menu - BFW-4290
     // However the request was that the autoload "stays active"
     // So we have to make sure that it's on when you activate the rework
-    if (GetIndex()) {
+    if (get_index()) {
         marlin_client::set_fs_autoload(true);
         config_store().fs_autoload_enabled.set(true);
     }

--- a/src/gui/MItem_mmu.cpp
+++ b/src/gui/MItem_mmu.cpp
@@ -288,7 +288,7 @@ MI_MMU_NEXTRUDER_REWORK::MI_MMU_NEXTRUDER_REWORK()
         config_store().is_mmu_rework.get()) {}
 
 void MI_MMU_NEXTRUDER_REWORK::OnChange([[maybe_unused]] size_t old_index) {
-    if (!flip_mmu_rework(index == 0)) {
+    if (!flip_mmu_rework(GetIndex() == 0)) {
         SetIndex(old_index); // revert the index change of the toggle in case the user aborted the dialog
         return;
     }
@@ -296,7 +296,7 @@ void MI_MMU_NEXTRUDER_REWORK::OnChange([[maybe_unused]] size_t old_index) {
     // Enabling MMU rework hides the FS_Autoload option from the menu - BFW-4290
     // However the request was that the autoload "stays active"
     // So we have to make sure that it's on when you activate the rework
-    if (index) {
+    if (GetIndex()) {
         marlin_client::set_fs_autoload(true);
         config_store().fs_autoload_enabled.set(true);
     }

--- a/src/gui/MItem_network.cpp
+++ b/src/gui/MItem_network.cpp
@@ -127,7 +127,7 @@ MI_NET_INTERFACE_t::MI_NET_INTERFACE_t()
 }
 
 void MI_NET_INTERFACE_t::OnChange([[maybe_unused]] size_t old_index) {
-    netdev_set_active_id(this->index);
+    netdev_set_active_id(this->GetIndex());
 }
 
 MI_HOSTNAME::MI_HOSTNAME()

--- a/src/gui/MItem_network.cpp
+++ b/src/gui/MItem_network.cpp
@@ -127,7 +127,7 @@ MI_NET_INTERFACE_t::MI_NET_INTERFACE_t()
 }
 
 void MI_NET_INTERFACE_t::OnChange([[maybe_unused]] size_t old_index) {
-    netdev_set_active_id(this->GetIndex());
+    netdev_set_active_id(this->get_index());
 }
 
 MI_HOSTNAME::MI_HOSTNAME()
@@ -186,12 +186,12 @@ MI_NET_IP::MI_NET_IP(NetDeviceID device_id)
     , device_id(device_id) //
 {
     set_translate_items(false);
-    this->SetIndex(netdev_get_ip_obtained_type(this->device_id()));
+    this->set_index(netdev_get_ip_obtained_type(this->device_id()));
 }
 
 void MI_NET_IP::OnChange([[maybe_unused]] size_t old_index) {
     const auto dev_id = device_id();
-    if (this->GetIndex() == NETDEV_STATIC) {
+    if (this->get_index() == NETDEV_STATIC) {
         netdev_set_static(dev_id);
     } else {
         netdev_set_dhcp(dev_id);

--- a/src/gui/MItem_tools.cpp
+++ b/src/gui/MItem_tools.cpp
@@ -471,7 +471,7 @@ MI_SOUND_MODE::MI_SOUND_MODE()
 }
 
 void MI_SOUND_MODE::OnChange(size_t /*old_index*/) {
-    Sound_SetMode(static_cast<eSOUND_MODE>(index));
+    Sound_SetMode(static_cast<eSOUND_MODE>(GetIndex()));
 }
 
 /*****************************************************************************/
@@ -537,7 +537,7 @@ MI_TIMEZONE_MIN::MI_TIMEZONE_MIN()
 }
 
 void MI_TIMEZONE_MIN::OnChange([[maybe_unused]] size_t old_index) {
-    config_store().timezone_minutes.set(static_cast<time_tools::TimezoneOffsetMinutes>(index));
+    config_store().timezone_minutes.set(static_cast<time_tools::TimezoneOffsetMinutes>(GetIndex()));
 }
 
 /*****************************************************************************/
@@ -546,7 +546,7 @@ MI_TIMEZONE_SUMMER::MI_TIMEZONE_SUMMER()
     : WI_ICON_SWITCH_OFF_ON_t(static_cast<uint8_t>(config_store().timezone_summer.get()), _(label), nullptr, is_enabled_t::yes, is_hidden_t::no) {}
 
 void MI_TIMEZONE_SUMMER::OnChange([[maybe_unused]] size_t old_index) {
-    config_store().timezone_summer.set(static_cast<time_tools::TimezoneOffsetSummerTime>(index));
+    config_store().timezone_summer.set(static_cast<time_tools::TimezoneOffsetSummerTime>(GetIndex()));
 }
 
 /*****************************************************************************/
@@ -563,7 +563,7 @@ MI_TIME_FORMAT::MI_TIME_FORMAT()
 }
 
 void MI_TIME_FORMAT::OnChange([[maybe_unused]] size_t old_index) {
-    config_store().time_format.set(static_cast<time_tools::TimeFormat>(index));
+    config_store().time_format.set(static_cast<time_tools::TimeFormat>(GetIndex()));
 }
 
 /*****************************************************************************/

--- a/src/gui/MItem_tools.cpp
+++ b/src/gui/MItem_tools.cpp
@@ -123,15 +123,15 @@ MI_FILAMENT_SENSOR::MI_FILAMENT_SENSOR()
 }
 
 void MI_FILAMENT_SENSOR::update() {
-    SetIndex(config_store().fsensor_enabled.get());
+    set_index(config_store().fsensor_enabled.get());
 }
 
 void MI_FILAMENT_SENSOR::OnChange(size_t old_index) {
     // Enabling/disabling FS can generate gcodes (I'm looking at you, MMU!).
     // Fail the action if there's no space in the queue.
     if (!gui_check_space_in_gcode_queue_with_msg()) {
-        // SetIndex doesn't call OnChange
-        SetIndex(old_index);
+        // set_index doesn't call OnChange
+        set_index(old_index);
         return;
     }
 
@@ -140,7 +140,7 @@ void MI_FILAMENT_SENSOR::OnChange(size_t old_index) {
 
     if (index && !fss.gui_wait_for_init_with_msg()) {
         FSensors_instance().set_enabled_global(false);
-        SetIndex(old_index);
+        set_index(old_index);
     }
 
     // Signal to the parent to check for changed
@@ -471,7 +471,7 @@ MI_SOUND_MODE::MI_SOUND_MODE()
 }
 
 void MI_SOUND_MODE::OnChange(size_t /*old_index*/) {
-    Sound_SetMode(static_cast<eSOUND_MODE>(GetIndex()));
+    Sound_SetMode(static_cast<eSOUND_MODE>(get_index()));
 }
 
 /*****************************************************************************/
@@ -537,7 +537,7 @@ MI_TIMEZONE_MIN::MI_TIMEZONE_MIN()
 }
 
 void MI_TIMEZONE_MIN::OnChange([[maybe_unused]] size_t old_index) {
-    config_store().timezone_minutes.set(static_cast<time_tools::TimezoneOffsetMinutes>(GetIndex()));
+    config_store().timezone_minutes.set(static_cast<time_tools::TimezoneOffsetMinutes>(get_index()));
 }
 
 /*****************************************************************************/
@@ -546,7 +546,7 @@ MI_TIMEZONE_SUMMER::MI_TIMEZONE_SUMMER()
     : WI_ICON_SWITCH_OFF_ON_t(static_cast<uint8_t>(config_store().timezone_summer.get()), _(label), nullptr, is_enabled_t::yes, is_hidden_t::no) {}
 
 void MI_TIMEZONE_SUMMER::OnChange([[maybe_unused]] size_t old_index) {
-    config_store().timezone_summer.set(static_cast<time_tools::TimezoneOffsetSummerTime>(GetIndex()));
+    config_store().timezone_summer.set(static_cast<time_tools::TimezoneOffsetSummerTime>(get_index()));
 }
 
 /*****************************************************************************/
@@ -563,7 +563,7 @@ MI_TIME_FORMAT::MI_TIME_FORMAT()
 }
 
 void MI_TIME_FORMAT::OnChange([[maybe_unused]] size_t old_index) {
-    config_store().time_format.set(static_cast<time_tools::TimeFormat>(GetIndex()));
+    config_store().time_format.set(static_cast<time_tools::TimeFormat>(get_index()));
 }
 
 /*****************************************************************************/
@@ -1093,7 +1093,7 @@ MI_DISPLAY_BAUDRATE::MI_DISPLAY_BAUDRATE()
 }
 
 void MI_DISPLAY_BAUDRATE::OnChange(size_t) {
-    config_store().reduce_display_baudrate.set(GetIndex());
+    config_store().reduce_display_baudrate.set(get_index());
 }
 #endif
 

--- a/src/gui/screen_menu_cancel_object.cpp
+++ b/src/gui/screen_menu_cancel_object.cpp
@@ -38,8 +38,8 @@ MI_CO_OBJECT_N::MI_CO_OBJECT_N(int ObjectId_)
 
 void MI_CO_OBJECT_N::UpdateState() {
     size_t new_index = (marlin_vars().get_cancel_object_mask() & (static_cast<uint64_t>(1) << ObjectId)) ? 1 : 0;
-    if (GetIndex() != new_index) {
-        SetIndex(new_index);
+    if (get_index() != new_index) {
+        set_index(new_index);
     }
 }
 
@@ -88,7 +88,7 @@ void MI_CO_OBJECT_N::OnChange(size_t old_index) {
         marlin_client::uncancel_object(ObjectId);
     }
 
-    SetIndex(old_index); // Keep previous index and wait for UpdateState()
+    set_index(old_index); // Keep previous index and wait for UpdateState()
 }
 
 MI_CO_CANCEL_CURRENT::MI_CO_CANCEL_CURRENT()

--- a/src/gui/screen_menu_connect.cpp
+++ b/src/gui/screen_menu_connect.cpp
@@ -31,8 +31,8 @@ void MI_CONNECT_ENABLED::Loop() {
     // access to our items (AFAIK).
     //
     // It should be cheap anyway - both the eeprom access is cached in RAM and
-    // the SetIndex checks it is different before doing anything.
-    SetIndex(config_store().connect_enabled.get());
+    // the set_index checks it is different before doing anything.
+    set_index(config_store().connect_enabled.get());
 }
 
 MI_CONNECT_STATUS::MI_CONNECT_STATUS()

--- a/src/gui/screen_menu_experimental_settings_debug.cpp
+++ b/src/gui/screen_menu_experimental_settings_debug.cpp
@@ -72,18 +72,18 @@ void ScreenMenuExperimentalSettings::windowEvent(window_t *sender, GUI_event_t e
         Item<MI_STEPS_PER_UNIT_Z>().SetVal(std::abs(config_store().axis_steps_per_unit_z.default_val));
         Item<MI_STEPS_PER_UNIT_E>().SetVal(std::abs(config_store().axis_steps_per_unit_e0.default_val));
         // Set default axis direction
-        Item<MI_DIRECTION_X>().SetIndex(0);
-        Item<MI_DIRECTION_Y>().SetIndex(0);
-        Item<MI_DIRECTION_Z>().SetIndex(0);
-        Item<MI_DIRECTION_E>().SetIndex(0);
+        Item<MI_DIRECTION_X>().set_index(0);
+        Item<MI_DIRECTION_Y>().set_index(0);
+        Item<MI_DIRECTION_Z>().set_index(0);
+        Item<MI_DIRECTION_E>().set_index(0);
         Invalidate();
         break;
     case ClickCommand::Reset_directions:
         // set index to Prusa
-        Item<MI_DIRECTION_X>().SetIndex(0);
-        Item<MI_DIRECTION_Y>().SetIndex(0);
-        Item<MI_DIRECTION_Z>().SetIndex(0);
-        Item<MI_DIRECTION_E>().SetIndex(0);
+        Item<MI_DIRECTION_X>().set_index(0);
+        Item<MI_DIRECTION_Y>().set_index(0);
+        Item<MI_DIRECTION_Z>().set_index(0);
+        Item<MI_DIRECTION_E>().set_index(0);
         Invalidate();
         break;
     case ClickCommand::Reset_currents:
@@ -106,10 +106,10 @@ bool ExperimentalSettingsValues::operator!=(const ExperimentalSettingsValues &ot
 
 ExperimentalSettingsValues::ExperimentalSettingsValues(ScreenMenuExperimentalSettings__ &parent)
     : z_len(parent.Item<MI_Z_AXIS_LEN>().GetVal())
-    , steps_per_unit_x(parent.Item<MI_STEPS_PER_UNIT_X>().GetVal() * ((parent.Item<MI_DIRECTION_X>().GetIndex() == 1) ? -1 : 1))
-    , steps_per_unit_y(parent.Item<MI_STEPS_PER_UNIT_Y>().GetVal() * ((parent.Item<MI_DIRECTION_Y>().GetIndex() == 1) ? -1 : 1))
-    , steps_per_unit_z(parent.Item<MI_STEPS_PER_UNIT_Z>().GetVal() * ((parent.Item<MI_DIRECTION_Z>().GetIndex() == 1) ? -1 : 1))
-    , steps_per_unit_e(parent.Item<MI_STEPS_PER_UNIT_E>().GetVal() * ((parent.Item<MI_DIRECTION_E>().GetIndex() == 1) ? -1 : 1))
+    , steps_per_unit_x(parent.Item<MI_STEPS_PER_UNIT_X>().GetVal() * ((parent.Item<MI_DIRECTION_X>().get_index() == 1) ? -1 : 1))
+    , steps_per_unit_y(parent.Item<MI_STEPS_PER_UNIT_Y>().GetVal() * ((parent.Item<MI_DIRECTION_Y>().get_index() == 1) ? -1 : 1))
+    , steps_per_unit_z(parent.Item<MI_STEPS_PER_UNIT_Z>().GetVal() * ((parent.Item<MI_DIRECTION_Z>().get_index() == 1) ? -1 : 1))
+    , steps_per_unit_e(parent.Item<MI_STEPS_PER_UNIT_E>().GetVal() * ((parent.Item<MI_DIRECTION_E>().get_index() == 1) ? -1 : 1))
     , rms_current_ma_x(parent.Item<MI_CURRENT_X>().GetVal())
     , rms_current_ma_y(parent.Item<MI_CURRENT_Y>().GetVal())
     , rms_current_ma_z(parent.Item<MI_CURRENT_Z>().GetVal())

--- a/src/gui/screen_menu_experimental_settings_release.cpp
+++ b/src/gui/screen_menu_experimental_settings_release.cpp
@@ -56,7 +56,7 @@ void ScreenMenuExperimentalSettings::windowEvent(window_t *sender, GUI_event_t e
         Invalidate();
         break;
     case ClickCommand::Reset_directions:
-        Item<MI_DIRECTION_E>().SetIndex(0);
+        Item<MI_DIRECTION_E>().set_index(0);
         Invalidate();
         break;
     default:
@@ -73,6 +73,6 @@ bool ExperimentalSettingsValues::operator!=(const ExperimentalSettingsValues &ot
 
 ExperimentalSettingsValues::ExperimentalSettingsValues(ScreenMenuExperimentalSettings__ &parent)
     : z_len(parent.Item<MI_Z_AXIS_LEN>().GetVal())
-    , steps_per_unit_e(parent.Item<MI_STEPS_PER_UNIT_E>().GetVal() * ((parent.Item<MI_DIRECTION_E>().GetIndex() == 1) ? -1 : 1))
+    , steps_per_unit_e(parent.Item<MI_STEPS_PER_UNIT_E>().GetVal() * ((parent.Item<MI_DIRECTION_E>().get_index() == 1) ? -1 : 1))
 
 {}

--- a/src/gui/screen_menu_filament_sensors.cpp
+++ b/src/gui/screen_menu_filament_sensors.cpp
@@ -36,9 +36,9 @@ void IMI_AnySensor::update() {
     const uint8_t bit_mask = (1 << sensor_index);
 
     if (is_side) {
-        SetIndex(bool(config_store().fsensor_side_enabled_bits.get() & bit_mask));
+        set_index(bool(config_store().fsensor_side_enabled_bits.get() & bit_mask));
     } else {
-        SetIndex(bool(config_store().fsensor_extruder_enabled_bits.get() & bit_mask));
+        set_index(bool(config_store().fsensor_extruder_enabled_bits.get() & bit_mask));
     }
 }
 
@@ -46,8 +46,8 @@ void IMI_AnySensor::OnChange(size_t old_index) {
     // Enabling/disabling FS can generate gcodes (I'm looking at you, MMU!).
     // Fail the action if there's no space in the queue.
     if (!gui_check_space_in_gcode_queue_with_msg()) {
-        // SetIndex doesn't call OnChange
-        SetIndex(old_index);
+        // set_index doesn't call OnChange
+        set_index(old_index);
         return;
     }
 
@@ -64,7 +64,7 @@ void IMI_AnySensor::OnChange(size_t old_index) {
     fss.request_enable_state_update();
 
     if (index && !fss.gui_wait_for_init_with_msg()) {
-        SetIndex(0);
+        set_index(0);
     }
 }
 

--- a/src/gui/screen_menu_footer_settings.cpp
+++ b/src/gui/screen_menu_footer_settings.cpp
@@ -43,7 +43,7 @@ MI_LEFT_ALIGN_TEMP::MI_LEFT_ALIGN_TEMP()
     : MenuItemSwitch(_("Temp. style"), temp_align_values, size_t(FooterItemHeater::GetDrawType())) {}
 
 void MI_LEFT_ALIGN_TEMP::OnChange(size_t /*old_index*/) {
-    FooterItemHeater::SetDrawType(footer::ItemDrawType(index));
+    FooterItemHeater::SetDrawType(footer::ItemDrawType(GetIndex()));
 }
 
 MI_SHOW_ZERO_TEMP_TARGET::MI_SHOW_ZERO_TEMP_TARGET()

--- a/src/gui/screen_menu_footer_settings.cpp
+++ b/src/gui/screen_menu_footer_settings.cpp
@@ -43,7 +43,7 @@ MI_LEFT_ALIGN_TEMP::MI_LEFT_ALIGN_TEMP()
     : MenuItemSwitch(_("Temp. style"), temp_align_values, size_t(FooterItemHeater::GetDrawType())) {}
 
 void MI_LEFT_ALIGN_TEMP::OnChange(size_t /*old_index*/) {
-    FooterItemHeater::SetDrawType(footer::ItemDrawType(GetIndex()));
+    FooterItemHeater::SetDrawType(footer::ItemDrawType(get_index()));
 }
 
 MI_SHOW_ZERO_TEMP_TARGET::MI_SHOW_ZERO_TEMP_TARGET()

--- a/src/gui/screen_menu_fw_update.cpp
+++ b/src/gui/screen_menu_fw_update.cpp
@@ -60,13 +60,13 @@ MI_UPDATE::MI_UPDATE()
 }
 
 void MI_UPDATE::OnChange(size_t /*old_index*/) {
-    if (GetIndex() == 1) {
+    if (get_index() == 1) {
         data_exchange::fw_update_on_restart_enable();
         sys_fw_update_disable();
-    } else if (GetIndex() == 2) {
+    } else if (get_index() == 2) {
         data_exchange::fw_update_on_restart_disable();
         sys_fw_update_enable();
-    } else if (GetIndex() == 0) {
+    } else if (get_index() == 0) {
         data_exchange::fw_update_on_restart_disable();
         sys_fw_update_disable();
     }

--- a/src/gui/screen_menu_fw_update.cpp
+++ b/src/gui/screen_menu_fw_update.cpp
@@ -60,13 +60,13 @@ MI_UPDATE::MI_UPDATE()
 }
 
 void MI_UPDATE::OnChange(size_t /*old_index*/) {
-    if (index == 1) {
+    if (GetIndex() == 1) {
         data_exchange::fw_update_on_restart_enable();
         sys_fw_update_disable();
-    } else if (index == 2) {
+    } else if (GetIndex() == 2) {
         data_exchange::fw_update_on_restart_disable();
         sys_fw_update_enable();
-    } else if (index == 0) {
+    } else if (GetIndex() == 0) {
         data_exchange::fw_update_on_restart_disable();
         sys_fw_update_disable();
     }

--- a/src/guiapi/include/WindowMenuItems.hpp
+++ b/src/guiapi/include/WindowMenuItems.hpp
@@ -26,12 +26,12 @@ public:
     }
 
     // TODO: Remove this legacy function
-    inline size_t GetIndex() const {
+    inline size_t get_index() const {
         return value_;
     }
 
     // TODO: Remove this legacy function
-    inline void SetIndex(size_t index) {
+    inline void set_index(size_t index) {
         set_value(index > 0, false);
     }
 

--- a/src/guiapi/include/WindowMenuSwitch.hpp
+++ b/src/guiapi/include/WindowMenuSwitch.hpp
@@ -27,13 +27,8 @@ public:
 
     string_view_utf8 current_item_text() const;
 
-    inline size_t GetIndex() const {
-        return index;
-    }
-
-    /// DEPRECATED
-    inline void SetIndex(size_t set) {
-        set_index(set);
+    inline size_t get_index() const {
+        return index_;
     }
 
 protected:
@@ -50,7 +45,7 @@ protected:
     virtual void printExtension(Rect16 extension_rect, Color color_text, Color color_back, ropfn raster_op) const override;
 
 private:
+    size_t index_ = 0;
     std::span<const char *const> items_;
     bool translate_items_ = true;
-    size_t index = 0;
 };

--- a/src/guiapi/include/WindowMenuSwitch.hpp
+++ b/src/guiapi/include/WindowMenuSwitch.hpp
@@ -49,10 +49,8 @@ protected:
     virtual void click(IWindowMenu &window_menu) final;
     virtual void printExtension(Rect16 extension_rect, Color color_text, Color color_back, ropfn raster_op) const override;
 
-protected:
-    size_t index = 0;
-
 private:
     std::span<const char *const> items_;
     bool translate_items_ = true;
+    size_t index = 0;
 };

--- a/src/guiapi/include/i_window_menu_container.hpp
+++ b/src/guiapi/include/i_window_menu_container.hpp
@@ -35,7 +35,7 @@ public:
     std::optional<int> GetVisibleIndex(const IWindowMenuItem &item) const;
     int GetVisibleCount() const;
 
-    bool SetIndex(int visible_index);
+    bool set_index(int visible_index);
     std::optional<int> GetFocusedIndex() const;
     bool SwapVisibility(IWindowMenuItem &item0, IWindowMenuItem &item1);
 };

--- a/src/guiapi/src/WindowMenuSwitch.cpp
+++ b/src/guiapi/src/WindowMenuSwitch.cpp
@@ -2,7 +2,7 @@
 
 MenuItemSwitch::MenuItemSwitch(const string_view_utf8 &label, const std::span<const char *const> &items, size_t initial_index)
     : IWindowMenuItem(label)
-    , index(initial_index)
+    , index_(initial_index)
     , items_(items) //
 {
     touch_extension_only_ = true;
@@ -11,25 +11,25 @@ MenuItemSwitch::MenuItemSwitch(const string_view_utf8 &label, const std::span<co
 }
 
 invalidate_t MenuItemSwitch::change(int /*dif*/) {
-    if ((++index) >= item_count()) {
-        index = 0;
+    if ((++index_) >= item_count()) {
+        index_ = 0;
     }
     return invalidate_t::yes;
 }
 
 void MenuItemSwitch::click(IWindowMenu & /*window_menu*/) {
-    const size_t old_index = index;
+    const size_t old_index = index_;
     Change(0);
     OnChange(old_index);
     changeExtentionWidth();
 }
 
 void MenuItemSwitch::set_index(size_t idx) {
-    if (idx == index || idx >= item_count()) {
+    if (idx == index_ || idx >= item_count()) {
         return;
     }
 
-    index = idx;
+    index_ = idx;
     changeExtentionWidth();
     InValidateExtension();
 }
@@ -89,6 +89,6 @@ void MenuItemSwitch::changeExtentionWidth() {
 }
 
 string_view_utf8 MenuItemSwitch::current_item_text() const {
-    const char *str = items_[index];
+    const char *str = items_[index_];
     return translate_items_ ? _(str) : string_view_utf8::MakeRAM(str);
 }

--- a/src/guiapi/src/i_window_menu_container.cpp
+++ b/src/guiapi/src/i_window_menu_container.cpp
@@ -68,7 +68,7 @@ int IWinMenuContainer::GetVisibleCount() const {
     return ret;
 }
 
-bool IWinMenuContainer::SetIndex(int visible_index) {
+bool IWinMenuContainer::set_index(int visible_index) {
     if (IWindowMenuItem *item = GetItemByVisibleIndex(visible_index)) {
         return item->move_focus();
     }


### PR DESCRIPTION
Reuse of the variable "index" within a WI_SWITCH_t derived class can lead to issues as the variable "index" might be used outside the WI_SWITCH_t class and could interfer with the derived class index value, thus leading to functionality issues. By redefining index as private variable in WI_SWITCH_t and making usage of the defined GetIndex/SetIndex functions, similar issues can be prevented in the future.