### PR TITLE
Cleanup dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     - id: clang-format
       name: clang-format
       description: This hook automatically checks and reformats changed files using clang-format formatter.
-      entry: './.dependencies/clang-format-16-83817c2f/clang-format'
+      entry: './.dependencies/clang-format-18.1.8/clang-format'
       language: script
       files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
       args: ['-i', '-style=file']

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "cmake.configureOnOpen": true,
     "cmake.copyCompileCommands": "${workspaceFolder}/compile_commands.json",
-    "cmake.cmakePath": "${workspaceFolder}/.dependencies/cmake-3.28.3/bin/cmake",
+    "cmake.cmakePath": "${workspaceFolder}/.dependencies/cmake-3.30.3/bin/cmake",
     "cmake.generator": "Ninja",
     "files.insertFinalNewline": true,
     "files.associations": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -72,7 +72,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -131,7 +131,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -190,7 +190,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -249,7 +249,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -312,7 +312,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -375,7 +375,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -438,7 +438,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -501,7 +501,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -564,7 +564,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -627,7 +627,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -690,7 +690,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -753,7 +753,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -816,7 +816,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -879,7 +879,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -942,7 +942,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1005,7 +1005,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1068,7 +1068,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1131,7 +1131,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1194,7 +1194,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1257,7 +1257,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1320,7 +1320,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1383,7 +1383,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1446,7 +1446,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1509,7 +1509,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1572,7 +1572,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1635,7 +1635,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1698,7 +1698,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -1761,7 +1761,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "CMAKE_EXPORT_COMPILE_COMMANDS": {
                     "type": "STRING",
@@ -1828,7 +1828,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "CMAKE_EXPORT_COMPILE_COMMANDS": {
                     "type": "STRING",
@@ -1895,7 +1895,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "CMAKE_EXPORT_COMPILE_COMMANDS": {
                     "type": "STRING",
@@ -1962,7 +1962,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "CMAKE_EXPORT_COMPILE_COMMANDS": {
                     "type": "STRING",
@@ -2029,7 +2029,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2084,7 +2084,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2139,7 +2139,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2194,7 +2194,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2249,7 +2249,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2304,7 +2304,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2359,7 +2359,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2414,7 +2414,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2469,7 +2469,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2528,7 +2528,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2587,7 +2587,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2646,7 +2646,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2705,7 +2705,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2772,7 +2772,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2839,7 +2839,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2906,7 +2906,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -2973,7 +2973,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3044,7 +3044,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3115,7 +3115,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3186,7 +3186,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3257,7 +3257,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3324,7 +3324,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3391,7 +3391,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3458,7 +3458,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3525,7 +3525,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3584,7 +3584,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3643,7 +3643,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3702,7 +3702,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3761,7 +3761,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3816,7 +3816,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3871,7 +3871,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3926,7 +3926,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -3981,7 +3981,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -4036,7 +4036,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -4091,7 +4091,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -4146,7 +4146,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -4201,7 +4201,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -4256,7 +4256,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -4311,7 +4311,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -4366,7 +4366,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PRINTER": {
                     "type": "STRING",
@@ -4421,7 +4421,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PNG2FONT_ENABLE": {
                     "type": "BOOL",
@@ -4448,7 +4448,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PNG2FONT_ENABLE": {
                     "type": "BOOL",
@@ -4475,7 +4475,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PNG2FONT_ENABLE": {
                     "type": "BOOL",
@@ -4502,7 +4502,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PNG2FONT_ENABLE": {
                     "type": "BOOL",
@@ -4529,7 +4529,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PNG2FONT_ENABLE": {
                     "type": "BOOL",
@@ -4556,7 +4556,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PNG2FONT_ENABLE": {
                     "type": "BOOL",
@@ -4583,7 +4583,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PNG2FONT_ENABLE": {
                     "type": "BOOL",
@@ -4610,7 +4610,7 @@
             "cacheVariables": {
                 "CMAKE_MAKE_PROGRAM": {
                     "type": "FILEPATH",
-                    "value": "${sourceDir}/.dependencies/ninja-1.10.2/ninja"
+                    "value": "${sourceDir}/.dependencies/ninja-1.12.1/ninja"
                 },
                 "PNG2FONT_ENABLE": {
                     "type": "BOOL",

--- a/lib/Prusa-Firmware-MMU/.pre-commit-config.yaml
+++ b/lib/Prusa-Firmware-MMU/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     - id: clang-format
       name: clang-format
       description: This hook automatically checks and reformats changed files using clang-format formatter.
-      entry: './.dependencies/clang-format-9.0.0-noext/clang-format'
+      entry: './.dependencies/clang-format-18.1.8/clang-format'
       language: script
       files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
       args: ['-i', '-style=file']

--- a/lib/Prusa-Firmware-MMU/.vscode/cmake-kits.json
+++ b/lib/Prusa-Firmware-MMU/.vscode/cmake-kits.json
@@ -3,7 +3,7 @@
         "name": "avr-gcc",
         "toolchainFile": "${workspaceFolder}/cmake/AvrGcc.cmake",
         "cmakeSettings": {
-            "CMAKE_MAKE_PROGRAM": "${workspaceFolder}/.dependencies/ninja-1.10.2/ninja",
+            "CMAKE_MAKE_PROGRAM": "${workspaceFolder}/.dependencies/ninja-1.12.1/ninja",
             "CMAKE_BUILD_TYPE": "Release"
         }
     }

--- a/lib/Prusa-Firmware-MMU/.vscode/settings.json
+++ b/lib/Prusa-Firmware-MMU/.vscode/settings.json
@@ -13,7 +13,7 @@
         "-isystem${workspaceFolder}/.dependencies/avr-gcc-7.3.0/avr/include/util",
     ],
     "cmake.buildDirectory": "${workspaceFolder}/build-vscode/${buildKit}",
-    "cmake.cmakePath": "${workspaceFolder}/.dependencies/cmake-3.22.5/bin/cmake",
+    "cmake.cmakePath": "${workspaceFolder}/.dependencies/cmake-3.30.3/bin/cmake",
     "cmake.generator": "Ninja",
     "files.insertFinalNewline": true,
 }

--- a/lib/Prusa-Firmware-MMU/README.md
+++ b/lib/Prusa-Firmware-MMU/README.md
@@ -39,7 +39,7 @@ Run `git clone https://github.com/prusa3d/Prusa-Firmware-MMU.git`.
 Run `./utils/bootstrap.py`
 
 `bootstrap.py` will now download all the "missing" dependencies into the `.dependencies` folder:
-- clang-format-9.0.0-noext
+- clang-format-18.1.8
 - cmake-3.30.3
 - ninja-1.10.2
 - avr-gcc-7.3.0

--- a/lib/Prusa-Firmware-MMU/README.md
+++ b/lib/Prusa-Firmware-MMU/README.md
@@ -40,7 +40,7 @@ Run `./utils/bootstrap.py`
 
 `bootstrap.py` will now download all the "missing" dependencies into the `.dependencies` folder:
 - clang-format-9.0.0-noext
-- cmake-3.22.5
+- cmake-3.30.3
 - ninja-1.10.2
 - avr-gcc-7.3.0
 

--- a/lib/Prusa-Firmware-MMU/README.md
+++ b/lib/Prusa-Firmware-MMU/README.md
@@ -41,7 +41,7 @@ Run `./utils/bootstrap.py`
 `bootstrap.py` will now download all the "missing" dependencies into the `.dependencies` folder:
 - clang-format-18.1.8
 - cmake-3.30.3
-- ninja-1.10.2
+- ninja-1.12.1
 - avr-gcc-7.3.0
 
 ### How to build the preliminary project so far:

--- a/lib/Prusa-Firmware-MMU/utils/bootstrap.py
+++ b/lib/Prusa-Firmware-MMU/utils/bootstrap.py
@@ -28,11 +28,13 @@ dependencies_dir = project_root_dir / '.dependencies'
 # yapf: disable
 dependencies = {
     'ninja': {
-        'version': '1.10.2',
+        'version': '1.12.1',
         'url': {
-            'Linux': 'https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip',
-            'Windows': 'https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip',
-            'Darwin': 'https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-mac.zip',
+            'Linux': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip',
+            'Linux-aarch64': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux-aarch64.zip',
+            'Windows': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip',
+            'Windows-arm64': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-winarm64.zip',
+            'Darwin': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-mac.zip',
         },
     },
     'cmake': {

--- a/lib/Prusa-Firmware-MMU/utils/bootstrap.py
+++ b/lib/Prusa-Firmware-MMU/utils/bootstrap.py
@@ -54,11 +54,12 @@ dependencies = {
         },
     },
     'clang-format': {
-        'version': '9.0.0-noext',
+        'version': '18.1.8',
         'url': {
-            'Linux': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/clang-format-9.0.0-linux.zip',
-            'Windows': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/clang-format-9.0.0-noext-win.zip',
-            'Darwin': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/clang-format-9.0.0-darwin.zip',
+            'Linux': 'https://github.com/ysmilda/clang-llvm/releases/download/llvmorg-18.1.8/clang-format-18.1.8-x86_64-linux-gnu-ubuntu-18.04',
+            'Linux-aarch64': 'https://github.com/ysmilda/clang-llvm/releases/download/llvmorg-18.1.8/clang-format-18.1.8-aarch64-linux-gnu',
+            'Windows': 'https://github.com/ysmilda/clang-llvm/releases/download/llvmorg-18.1.8/clang-format-18.1.8-x86_64-pc-windows-msvc.exe',
+            'Darwin': 'https://github.com/ysmilda/clang-llvm/releases/download/llvmorg-18.1.8/clang-format-18.1.8-arm64-apple-macos11',
         }
     },
     'prusa3dboards': {

--- a/lib/Prusa-Firmware-MMU/utils/bootstrap.py
+++ b/lib/Prusa-Firmware-MMU/utils/bootstrap.py
@@ -36,11 +36,13 @@ dependencies = {
         },
     },
     'cmake': {
-        'version': '3.22.5',
+        'version': '3.30.3',
         'url': {
-            'Linux': 'https://github.com/Kitware/CMake/releases/download/v3.22.5/cmake-3.22.5-linux-x86_64.tar.gz',
-            'Windows': 'https://github.com/Kitware/CMake/releases/download/v3.22.5/cmake-3.22.5-windows-x86_64.zip',
-            'Darwin': 'https://github.com/Kitware/CMake/releases/download/v3.22.5/cmake-3.22.5-macos-universal.tar.gz',
+            'Linux': 'https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-linux-x86_64.tar.gz',
+            'Linux-aarch64': 'https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-linux-aarch64.tar.gz',
+            'Windows': 'https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-windows-x86_64.zip',
+            'Windows-arm64': 'https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-windows-arm64.zip',
+            'Darwin': 'https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-macos-universal.tar.gz',
         },
     },
     'avr-gcc': {

--- a/lib/Prusa-Firmware-MMU/utils/holly/Jenkinsfile
+++ b/lib/Prusa-Firmware-MMU/utils/holly/Jenkinsfile
@@ -93,10 +93,10 @@ pipeline {
             steps {
                 sh """
                 python3 utils/bootstrap.py
-                export PATH=\$PWD/.dependencies/cmake-3.22.5/bin:\$PWD/.dependencies/ninja-1.10.2:\$PATH
+                export PATH=\$PWD/.dependencies/cmake-3.30.3/bin:\$PWD/.dependencies/ninja-1.10.2:\$PATH
                 export CTEST_OUTPUT_ON_FAILURE=1
                 mkdir -p build-test
-                LD_LIBRARY_PATH=/usr/local/lib32 \$PWD/.dependencies/cmake-3.22.5/bin/ctest --build-and-test . build-test \
+                LD_LIBRARY_PATH=/usr/local/lib32 \$PWD/.dependencies/cmake-3.30.3/bin/ctest --build-and-test . build-test \
                     -DCMAKE_MAKE_PROGRAM=\$PWD/.dependencies/ninja-1.10.2/ninja \
                     --build-generator Ninja \
                     --build-target tests \

--- a/lib/Prusa-Firmware-MMU/utils/holly/Jenkinsfile
+++ b/lib/Prusa-Firmware-MMU/utils/holly/Jenkinsfile
@@ -93,11 +93,11 @@ pipeline {
             steps {
                 sh """
                 python3 utils/bootstrap.py
-                export PATH=\$PWD/.dependencies/cmake-3.30.3/bin:\$PWD/.dependencies/ninja-1.10.2:\$PATH
+                export PATH=\$PWD/.dependencies/cmake-3.30.3/bin:\$PWD/.dependencies/ninja-1.12.1:\$PATH
                 export CTEST_OUTPUT_ON_FAILURE=1
                 mkdir -p build-test
                 LD_LIBRARY_PATH=/usr/local/lib32 \$PWD/.dependencies/cmake-3.30.3/bin/ctest --build-and-test . build-test \
-                    -DCMAKE_MAKE_PROGRAM=\$PWD/.dependencies/ninja-1.10.2/ninja \
+                    -DCMAKE_MAKE_PROGRAM=\$PWD/.dependencies/ninja-1.12.1/ninja \
                     --build-generator Ninja \
                     --build-target tests \
                     --test-command ctest

--- a/src/gui/res/png2cc.sh
+++ b/src/gui/res/png2cc.sh
@@ -79,7 +79,7 @@ else
 	stripFileType | png2indexed
 	stripFileType | convertToCC
 
-	../../../.dependencies/clang-format-9.0.0-noext/clang-format $CC_DIR/* -i
+	../../../.dependencies/clang-format-18.1.8/clang-format $CC_DIR/* -i
 
 		rm -rf $PAL_DIR
 

--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -64,11 +64,12 @@ dependencies = {
         }
     },
     'clang-format': {
-        'version': '16-83817c2f',
+        'version': '18.1.8',
         'url': {
-            'Linux': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/clang-format-16-83817c2f-linux.zip',
-            'Windows': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/clang-format-16-83817c2f-windows.zip',
-            'Darwin': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/clang-format-16-83817c2f-macosx.zip',
+            'Linux': 'https://github.com/ysmilda/clang-llvm/releases/download/llvmorg-18.1.8/clang-format-18.1.8-x86_64-linux-gnu-ubuntu-18.04',
+            'Linux-aarch64': 'https://github.com/ysmilda/clang-llvm/releases/download/llvmorg-18.1.8/clang-format-18.1.8-aarch64-linux-gnu',
+            'Windows': 'https://github.com/ysmilda/clang-llvm/releases/download/llvmorg-18.1.8/clang-format-18.1.8-x86_64-pc-windows-msvc.exe',
+            'Darwin': 'https://github.com/ysmilda/clang-llvm/releases/download/llvmorg-18.1.8/clang-format-18.1.8-arm64-apple-macos11',
         }
     },
     'bootloader-mini': {

--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -36,12 +36,13 @@ running_in_venv = Path(sys.prefix).resolve() == venv_dir.resolve()
 # yapf: disable
 dependencies = {
     'ninja': {
-        'version': '1.10.2',
+        'version': '1.12.1',
         'url': {
-            'Linux': 'https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip',
-            'Linux-aarch64': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/ninja-v1.10.2-linux-aarch64.zip',
-            'Windows': 'https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip',
-            'Darwin': 'https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-mac.zip',
+            'Linux': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip',
+            'Linux-aarch64': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux-aarch64.zip',
+            'Windows': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip',
+            'Windows-arm64': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-winarm64.zip',
+            'Darwin': 'https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-mac.zip',
         },
     },
     'cmake': {

--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -45,12 +45,13 @@ dependencies = {
         },
     },
     'cmake': {
-        'version': '3.28.3',
+        'version': '3.30.3',
         'url': {
-            'Linux': 'https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-linux-x86_64.tar.gz',
-            'Linux-aarch64': 'https://prusa-buddy-firmware-dependencies.s3.eu-central-1.amazonaws.com/cmake-3.28.3-Linux-aarch64.tar.gz',
-            'Windows': 'https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-windows-x86_64.zip',
-            'Darwin': 'https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-macos-universal.tar.gz',
+            'Linux': 'https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-linux-x86_64.tar.gz',
+            'Linux-aarch64': 'https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-linux-aarch64.tar.gz',
+            'Windows': 'https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-windows-x86_64.zip',
+            'Windows-arm64': 'https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-windows-arm64.zip',
+            'Darwin': 'https://github.com/Kitware/CMake/releases/download/v3.30.3/cmake-3.30.3-macos-universal.tar.gz',
         },
     },
     'gcc-arm-none-eabi': {

--- a/utils/holly/build-pr.jenkins
+++ b/utils/holly/build-pr.jenkins
@@ -242,13 +242,13 @@ pipeline {
                     }
                     steps {
                         sh """
-                        export PATH=/work/.dependencies/cmake-3.30.3/bin:/work/.dependencies/ninja-1.10.2:\$PATH
+                        export PATH=/work/.dependencies/cmake-3.30.3/bin:/work/.dependencies/ninja-1.12.1:\$PATH
                         ln -fs /work/.dependencies
                         ln -fs /work/.venv
                         . .venv/bin/activate
                         mkdir -p build-test
                         LD_LIBRARY_PATH=/usr/local/lib32 /work/.dependencies/cmake-3.30.3/bin/ctest --build-and-test . build-test \
-                            -DCMAKE_MAKE_PROGRAM=/work/.dependencies/ninja-1.10.2/ninja \
+                            -DCMAKE_MAKE_PROGRAM=/work/.dependencies/ninja-1.12.1/ninja \
                             --build-generator Ninja \
                             --build-target tests \
                             --build-options -DBOARD=BUDDY \

--- a/utils/holly/build-pr.jenkins
+++ b/utils/holly/build-pr.jenkins
@@ -242,12 +242,12 @@ pipeline {
                     }
                     steps {
                         sh """
-                        export PATH=/work/.dependencies/cmake-3.28.3/bin:/work/.dependencies/ninja-1.10.2:\$PATH
+                        export PATH=/work/.dependencies/cmake-3.30.3/bin:/work/.dependencies/ninja-1.10.2:\$PATH
                         ln -fs /work/.dependencies
                         ln -fs /work/.venv
                         . .venv/bin/activate
                         mkdir -p build-test
-                        LD_LIBRARY_PATH=/usr/local/lib32 /work/.dependencies/cmake-3.28.3/bin/ctest --build-and-test . build-test \
+                        LD_LIBRARY_PATH=/usr/local/lib32 /work/.dependencies/cmake-3.30.3/bin/ctest --build-and-test . build-test \
                             -DCMAKE_MAKE_PROGRAM=/work/.dependencies/ninja-1.10.2/ninja \
                             --build-generator Ninja \
                             --build-target tests \

--- a/utils/translations_and_fonts/README_TRANSLATIONS.md
+++ b/utils/translations_and_fonts/README_TRANSLATIONS.md
@@ -88,7 +88,7 @@ cd build_tests
 # If it says, that -std=c++20 does not exist, your compilator is too old. Install g++-10 and run this command before cmake:
 # export CXX=/bin/g++-10
 
-../.dependencies/cmake-3.28.3/bin/cmake -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=YES -D CMAKE_C_FLAGS="-O0 -ggdb3" -D CMAKE_CXX_FLAGS="-O0 -ggdb3 -std=c++20" -D CMAKE_BUILD_TYPE=Debug ..
+../.dependencies/cmake-3.30.3/bin/cmake -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=YES -D CMAKE_C_FLAGS="-O0 -ggdb3" -D CMAKE_CXX_FLAGS="-O0 -ggdb3 -std=c++20" -D CMAKE_BUILD_TYPE=Debug ..
 make -j$(nproc) tests VERBOSE=1 # This will build unit tests
-../.dependencies/cmake-3.28.3/bin/ctest --output-on-failure . # This will run unit tests
+../.dependencies/cmake-3.30.3/bin/ctest --output-on-failure . # This will run unit tests
 ```

--- a/utils/translations_and_fonts/generate_single_font.sh
+++ b/utils/translations_and_fonts/generate_single_font.sh
@@ -53,7 +53,7 @@ rm -rf full-chars.txt standard-chars.txt digits-chars.txt
 # Build png2font binary
 mkdir -p build_tests
 cd build_tests
-../.dependencies/cmake-3.28.3/bin/cmake -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=YES -D CMAKE_C_FLAGS="-O0 -ggdb3" -D CMAKE_CXX_FLAGS="-O0 -ggdb3 -std=c++20" -D CMAKE_BUILD_TYPE=Debug .. -G Ninja
+../.dependencies/cmake-3.30.3/bin/cmake -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=YES -D CMAKE_C_FLAGS="-O0 -ggdb3" -D CMAKE_CXX_FLAGS="-O0 -ggdb3 -std=c++20" -D CMAKE_BUILD_TYPE=Debug .. -G Ninja
 ninja utils/translations_and_fonts/png2font/png2font
 cd ../
 

--- a/utils/translations_and_fonts/script.sh
+++ b/utils/translations_and_fonts/script.sh
@@ -14,7 +14,7 @@ rm -rf non-ascii-chars.txt non-ascii-chars.raw
 
 mkdir -p build_tests
 cd build_tests
-../.dependencies/cmake-3.28.3/bin/cmake -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=YES -D CMAKE_C_FLAGS="-O0 -ggdb3" -D CMAKE_CXX_FLAGS="-O0 -ggdb3 -std=c++20" -D CMAKE_BUILD_TYPE=Debug .. -G Ninja -D BOARD=XBUDDY
+../.dependencies/cmake-3.30.3/bin/cmake -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=YES -D CMAKE_C_FLAGS="-O0 -ggdb3" -D CMAKE_CXX_FLAGS="-O0 -ggdb3 -std=c++20" -D CMAKE_BUILD_TYPE=Debug .. -G Ninja -D BOARD=XBUDDY
 ninja utils/translations_and_fonts/png2font/png2font
 cd ../
 


### PR DESCRIPTION
Closes #4195

This pull request updates the various dependencies to the latest versions. These updates bring support for using this codebase on ARM devices.

The following dependencies are updated:
 - clang-format 16 > 18.1.8 (19.1 has been released, but binaries not yet available)
 - ninja 1.10.2 > 1.12.1
 - cmake 3.28.3 > 3.30.3

An update for `gcc-arm-none-eabi` is available, but still working through some [issues](https://gitlab.kitware.com/cmake/cmake/-/issues/23105) when used from ARM devices.

This is still in development, but anyone wanting to help out and test the various integrations is more than welcome!