### PR TITLE
[BFW-6223] gui: Use marlin's cold extrusion temperature and allowance in extruder move screen

### DIFF
--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -2752,6 +2752,9 @@ static void _server_update_vars() {
 
     marlin_vars()->active_extruder = active_extruder;
 
+    marlin_vars()->extrude_min_temp = thermalManager.extrude_min_temp;
+    marlin_vars()->allow_cold_extrude = thermalManager.allow_cold_extrude;
+
     // print state is updated last, to make sure other related variables (like job_id, filenames) are already set when we start print
     marlin_vars()->print_state = static_cast<State>(server.print_state);
 }

--- a/src/common/marlin_vars.hpp
+++ b/src/common/marlin_vars.hpp
@@ -349,6 +349,7 @@ public:
     MarlinVariable<uint16_t> print_speed; // printing speed factor [%]
     MarlinVariable<uint16_t> job_id; // print job id incremented at every print start(for connect)
     MarlinVariable<uint16_t> enabled_bedlet_mask; // enabled bedlet mask 1 - enabled, 0 disabled
+    MarlinVariable<uint16_t> extrude_min_temp; // See marlin's cold extrusion temperature set via M302
 
     // 1B base types
     MarlinVariable<uint8_t> gqueue; // number of commands in gcode queue
@@ -360,6 +361,7 @@ public:
     MarlinVariable<uint8_t> mmu2_state; // Corresponds to MMU2::xState
     MarlinVariable<uint8_t> mmu2_finda; // FINDA pressed = 1, FINDA not pressed = 0 - shall be used as the main fsensor in case of mmu2State
     MarlinVariable<uint8_t> active_extruder; // See marlin's active_extruder. It will contain currently selected extruder (tool in case of XL, loaded filament nr in case of MMU2)
+    MarlinVariable<bool> allow_cold_extrude; // See if marlin's allows cold extrusion
 
     // TODO: prints fans should be in extruder struct, but we are not able to control multiple print fans yet
     MarlinVariable<uint8_t> print_fan_speed; // print fan speed [0..255]

--- a/src/gui/screen_menu_move.cpp
+++ b/src/gui/screen_menu_move.cpp
@@ -187,8 +187,9 @@ void ScreenMenuMove::checkNozzleTemp() {
 #endif // 0 .. make unit test
 
 bool ScreenMenuMove::IsTempOk() {
-    return DUMMY_AXIS_E::IsTargetTempOk() // target correctly set
-        && (marlin_vars()->active_hotend().temp_nozzle >= temp_ok); // Temperature is above coldextrusion
+    return DUMMY_AXIS_E::IsTargetTempOk() // target correctly set the selected material of extruder
+        && (marlin_vars()->allow_cold_extrude // don't check cold extrusion temp if marlin doesn't
+            || (marlin_vars()->active_hotend().temp_nozzle >= marlin_vars()->extrude_min_temp)); // Temperature is above cold extrusion temp of marlin
 }
 
 ScreenMenuMove::ScreenMenuMove()

--- a/src/gui/screen_menu_move.hpp
+++ b/src/gui/screen_menu_move.hpp
@@ -81,7 +81,6 @@ class ScreenMenuMove : public ScreenMenuMove__ {
 
 public:
     constexpr static const char *label = N_("MOVE AXIS");
-    static constexpr int temp_ok = 170; ///< Allow moving extruder if temperature is above this value [degC]
     static bool IsTempOk();
 
     ScreenMenuMove();


### PR DESCRIPTION
As I found in issue #3674 the screen menu source code has a magic cold extrusion temperature defined as constexpr.
The Marlin core actually has a cold ectrusion tempereature and an allowance state, that can be modified with M302.

I modified the marlin_server to give access to this information and modified the GUI code to either ignore the cold extrusion temperature or to check the temperature against the limit of Marlin core.

I have not changed the material's "minimum" temerature check. If this temperature is above marlins cold-extrusion temperature, the material temp will be checked. Just as it was before.

Finally I did a small change in the CMakeLists.txt:
As I compile on a Windows machine, I need the Python executable infront of a Python file to run it.
I found the variable "${Python3_EXECUTABLE}" somewhere else in the file, so I used it here too.