### PR TITLE
Fix for SELFTEST-BUG 3480/BFW-5677.  Allowable overlap range on Switched Fan Detection.

### DIFF
--- a/src/common/selftest/selftest_MK4.cpp
+++ b/src/common/selftest/selftest_MK4.cpp
@@ -70,14 +70,16 @@ static constexpr SelftestFansConfig fans_configs[] = {
             ///  With MK4 shroud the values can be 6400 or so.
             .rpm_min = 5300,
             .rpm_max = 6799,
+            .ignore_min_overlap = 0,
         },
         .heatbreak_fan = {
             .rpm_min = 6800,
             .rpm_max = 8700,
+            .ignore_min_overlap = 0,
         },
     },
 };
-static_assert(fans_configs[0].print_fan.rpm_max < fans_configs[0].heatbreak_fan.rpm_min, "These cannot overlap for switched fan detection.");
+static_assert(fans_configs[0].print_fan.rpm_max < (fans_configs[0].heatbreak_fan.rpm_min + fans_configs[0].heatbreak_fan.ignore_min_overlap), "Parameters cannot overlap more than ignore_min_overlap for proper switched fan detection.");
 
 // reads data from eeprom, cannot be constexpr
 const AxisConfig_t selftest::Config_XAxis = {

--- a/src/common/selftest/selftest_XL.cpp
+++ b/src/common/selftest/selftest_XL.cpp
@@ -58,17 +58,26 @@ static consteval SelftestFansConfig make_fan_config(uint8_t index) {
         .print_fan = {
             ///@note Datasheet says 5900 +-10%, but that is without any fan shroud.
             ///  Blocked fan increases its RPMs over 7000.
-            ///  With XL shroud the values can be 6200 - 6600 depending on fan shroud version.
+            ///  With XL shroud the values can be 6200 - 7200 depending on fan shroud version.
+            /// and altitude, as reported by users in forums.
+            /// ignore_min_overlap has been added for switched fan detection and indicates the amount
+            /// of potential minimum overlap on the other fan.  IE a min overlap of 500 on the
+            /// heatbreak fan indicates that switched fan detection is not effective until the
+            /// print fan exceeds the heatbreak minimum by 500 rpm - so in the instances where
+            /// both fans are spinning within 500RPM of heatbreak fan minimum, switched fan
+            /// detection is not possible (which, is reality in some cases)
             .rpm_min = 5300,
-            .rpm_max = 6799,
+            .rpm_max = 7299,
+            .ignore_min_overlap = 0,
         },
         .heatbreak_fan = {
             .rpm_min = 6800,
             .rpm_max = 8700,
+            .ignore_min_overlap = 500,
         },
     };
 }
-static_assert(make_fan_config(0).print_fan.rpm_max < make_fan_config(0).heatbreak_fan.rpm_min, "These cannot overlap for switched fan detection.");
+static_assert(make_fan_config(0).print_fan.rpm_max < (make_fan_config(0).heatbreak_fan.rpm_min + make_fan_config(0).heatbreak_fan.ignore_min_overlap), "Parameters cannot overlap more than min_ignore_overlap for proper switched fan detection.");
 
 static constexpr SelftestFansConfig fans_configs[] = {
     make_fan_config(0),

--- a/src/common/selftest/selftest_fan.cpp
+++ b/src/common/selftest/selftest_fan.cpp
@@ -72,6 +72,10 @@ static bool is_rpm_within_bounds(const FanConfig &fan_config, uint16_t rpm) {
     return rpm > fan_config.rpm_min && rpm < fan_config.rpm_max;
 }
 
+static bool is_rpm_within_non_overlap_bounds(const FanConfig &fan_config, uint16_t rpm) {
+    return rpm > (fan_config.rpm_min + fan_config.ignore_min_overlap) && rpm < fan_config.rpm_max;
+}
+
 uint16_t FanHandler::calculate_avg_rpm() const {
     return sample_count ? (sample_sum / sample_count) : 0;
 }
@@ -190,7 +194,7 @@ LoopResult CSelftestPart_Fan::state_measure_rpm_100_percent() {
     }
 
     // Create config specifically for alt fans presence of which cannot be done compile-time.
-    SelftestFansConfig alt_config { .print_fan = { .rpm_min = 3000, .rpm_max = 4500 }, .heatbreak_fan = { .rpm_min = 7000, .rpm_max = 10000 } };
+	SelftestFansConfig alt_config { .print_fan = { .rpm_min = 3000, .rpm_max = 4500, .ignore_min_overlap = 0 }, .heatbreak_fan = { .rpm_min = 7000, .rpm_max = 10000, .ignore_min_overlap = 0 } };
 
     if (config_store().has_alt_fans.get()) {
         print_fan.evaluate(alt_config.print_fan, print_fan_rpm);
@@ -217,7 +221,7 @@ bool CSelftestPart_Fan::are_fans_switched(const FanHandler &print_fan, const Fan
     if (print_fan.is_failed() && heatbreak_fan.is_failed()) {
         // try if the rpms fit into the ranges when switched, if yes, fail the
         // "fans switched" test and pass the RPM tests
-        if (is_rpm_within_bounds(config.heatbreak_fan, print_fan_rpm) && is_rpm_within_bounds(config.print_fan, heatbreak_fan_rpm)) {
+        if (is_rpm_within_non_overlap_bounds(config.heatbreak_fan, print_fan_rpm) && is_rpm_within_non_overlap_bounds(config.print_fan, heatbreak_fan_rpm)) {
             log_error(Selftest, "Fans test %u print and hotend fan appear to be switched (the RPM of each fits into the range of the other)", config.tool_nr);
             // Since fans switched isn't the last check, it cannot tell whether the fans are ok or not. All that is certain at this point is that they are switched. They still can fail on 20 % test.
             result.print_fan_state = SelftestSubtestState_t::undef;

--- a/src/common/selftest/selftest_fan_config.hpp
+++ b/src/common/selftest/selftest_fan_config.hpp
@@ -14,9 +14,10 @@ namespace selftest {
 struct FanConfig {
     uint16_t rpm_min;
     uint16_t rpm_max;
+    uint16_t ignore_min_overlap;
 };
 
-constexpr selftest::FanConfig benevolent_fan_config = { .rpm_min = 10, .rpm_max = 10000 };
+constexpr selftest::FanConfig benevolent_fan_config = { .rpm_min = 10, .rpm_max = 10000, .ignore_min_overlap = 0 };
 
 struct SelftestFansConfig {
     using type_evaluation = SelftestFanHotendResult;


### PR DESCRIPTION
Allowing for an overlap range on Fan Check to allow for the fact that sometimes switched fan detection is not possible, and on XL's this happens quite frequently.  The hot ends also come preassembled, so this alleviates the annoyance of having to remove the shroud just to do initial calibration or a factory reset, while still allowing for switched fan detection when ranges permit.

This addresses https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/3480