### PR TITLE
[BFW-6223] Closes #3870 - improve nozzle diameter footer item

### DIFF
--- a/src/gui/footer/footer_items_nozzle_bed.cpp
+++ b/src/gui/footer/footer_items_nozzle_bed.cpp
@@ -252,7 +252,17 @@ string_view_utf8 FooterItemNozzleDiameter::static_makeView(float value) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
-    snprintf(buff.data(), buff.size(), "%.1gmm", (double)value);
+    buff.fill('\0');
+    auto printed_chars = snprintf(buff.data(), buff.size(), "%.2f", (double)value);
+    for (int8_t i = printed_chars - 1; i >= 0; --i) {
+        if (buff[i] != '0' && buff[i] != '.') {
+            // append dimensions in mm
+            buff[++i] = 'm';
+            buff[++i] = 'm';
+            break;
+        }
+        buff[i] = '\0';
+    }
 #pragma GCC diagnostic pop
 
     return string_view_utf8::MakeRAM((const uint8_t *)(buff.data() + (buff[0] == '0' ? 1 : 0) /* if value ~ 0.xx, skip the 0 */));

--- a/src/gui/footer/footer_items_nozzle_bed.cpp
+++ b/src/gui/footer/footer_items_nozzle_bed.cpp
@@ -12,6 +12,8 @@
 #include "footer_eeprom.hpp"
 #include <option/has_toolchanger.h>
 #include <config_store/store_instance.hpp>
+#include <str_utils.hpp>
+#include <common/nozzle_diameter.hpp>
 
 #if ENABLED(MODULAR_HEATBED)
     #include <puppies/modular_bed.hpp>
@@ -252,20 +254,12 @@ string_view_utf8 FooterItemNozzleDiameter::static_makeView(float value) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
-    buff.fill('\0');
-    auto printed_chars = snprintf(buff.data(), buff.size(), "%.2f", (double)value);
-    for (int8_t i = printed_chars - 1; i >= 0; --i) {
-        if (buff[i] != '0' && buff[i] != '.') {
-            // append dimensions in mm
-            buff[++i] = 'm';
-            buff[++i] = 'm';
-            break;
-        }
-        buff[i] = '\0';
-    }
+    StringBuilder b(buff);
+    b.append_float((double)value, { .max_decimal_places = nozzle_diameter_spin_config.max_decimal_places, .skip_zero_before_dot = true });
+    b.append_string("mm");
 #pragma GCC diagnostic pop
 
-    return string_view_utf8::MakeRAM((const uint8_t *)(buff.data() + (buff[0] == '0' ? 1 : 0) /* if value ~ 0.xx, skip the 0 */));
+    return string_view_utf8::MakeRAM((const uint8_t *)(buff.data()));
 }
 
 string_view_utf8 FooterItemNozzlePWM::static_makeView(int value) {

--- a/src/gui/footer/footer_items_nozzle_bed.cpp
+++ b/src/gui/footer/footer_items_nozzle_bed.cpp
@@ -252,14 +252,11 @@ string_view_utf8 FooterItemNozzle::static_makeView(int value) {
 string_view_utf8 FooterItemNozzleDiameter::static_makeView(float value) {
     static std::array<char, 7> buff;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
     StringBuilder b(buff);
     b.append_float((double)value, { .max_decimal_places = nozzle_diameter_spin_config.max_decimal_places, .skip_zero_before_dot = true });
     b.append_string("mm");
-#pragma GCC diagnostic pop
 
-    return string_view_utf8::MakeRAM((const uint8_t *)(buff.data()));
+    return string_view_utf8::MakeRAM(buff.data());
 }
 
 string_view_utf8 FooterItemNozzlePWM::static_makeView(int value) {


### PR DESCRIPTION
I have found 

https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/3870

quite distracting during nozzle changes, due to footer item number not corresponding to actual inputted number. Touch version of nozzle diameter input autocorrection feature as well as nozzle diameter warning check in combination with truncated number can in case of mismatch add to confusion.

I have dropped original 'g' formatting in favour of fixed decimal places and manual zero and decimal point removal, since I don't think this is easily achievable otherwise. Appending of dimensions looks a bit iffy, but the use-case seemed like overkill for StringBuilder. Usage of buffer fill could be avoided by testing for 'm' character in the cleaning loop, but results was IMO less understandable. 

0.25
<img width="483" alt="nozzle_0_25" src="https://github.com/user-attachments/assets/aeda03aa-c1bb-4873-a17e-67fec21e1ecc">

0.40
<img width="482" alt="nozzle_0_4" src="https://github.com/user-attachments/assets/76fe8753-2d96-4204-b215-90e74c8c0403">

1.00
<img width="482" alt="nozzle_1" src="https://github.com/user-attachments/assets/53ab1172-6da4-4145-8d16-f4fb8dcd968a">

1.05
<img width="481" alt="nozzle_1_05" src="https://github.com/user-attachments/assets/6b650e34-d13c-4503-b4a3-ca052423cc49">

1.10
<img width="481" alt="nozze_1_1" src="https://github.com/user-attachments/assets/890fd681-e8f9-4a59-a38d-2ca8229dd774">
