### PR TITLE
[BFW-6459] Fix invalid display of E0 Extruder settings

### DIFF
--- a/src/gui/screen_menu_experimental_settings_release.cpp
+++ b/src/gui/screen_menu_experimental_settings_release.cpp
@@ -52,7 +52,7 @@ void ScreenMenuExperimentalSettings::windowEvent(window_t *sender, GUI_event_t e
         Invalidate();
         break;
     case ClickCommand::Reset_steps:
-        Item<MI_STEPS_PER_UNIT_E>().SetVal(config_store().axis_steps_per_unit_e0.default_val);
+        Item<MI_STEPS_PER_UNIT_E>().SetVal(std::abs(config_store().axis_steps_per_unit_e0.default_val));
         Invalidate();
         break;
     case ClickCommand::Reset_directions:


### PR DESCRIPTION
As default extruder settings can have negative values due to inversion, values below 0 are displayed incorrectly in the Experimental Settings display for RELEASE version (not the case for DEBUG version).

This solves issue #4330