### PR TITLE
Serial: Add TEMPORARY_AUTO_REPORT_OFF to pause autoreports

### DIFF
--- a/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -2020,7 +2020,7 @@
       uint32_t bitmap[GRID_MAX_POINTS_X] = { 0 };
       struct linear_fit_data lsf_results;
 
-      SERIAL_ECHOPGM("Extrapolating mesh...");
+      SERIAL_ECHOLNPGM("Extrapolating mesh...");
 
       const float weight_scaled = weight_factor * _MAX(MESH_X_DIST, MESH_Y_DIST);
 


### PR DESCRIPTION
This solves issues with #3866.

When auto report is enabled, such as gcode M155 for temperature, other gcode functions using SERIAL_ECHO or SERIAL_ECHOPGM might print out and then include the auto report data instead of the intended serial data that follows at a later time, causing a mix of serial messages in one line.

Using TEMPORARY_AUTO_REPORT_OFF will pause the autoreports so that the serial output isn't returning mixed messages.