### PR TITLE
serial: Fix serial temp chamber reported if not enabled

### DIFF
--- a/lib/Marlin/Marlin/src/module/temperature.cpp
+++ b/lib/Marlin/Marlin/src/module/temperature.cpp
@@ -3805,8 +3805,10 @@ void Temperature::isr() {
     #if HAS_HEATED_BED
       SERIAL_ECHOPAIR(" B@:", getHeaterPower(H_BED));
     #endif
-    #if HAS_HEATED_CHAMBER
-      SERIAL_ECHOPAIR(" C@:", getHeaterPower(H_CHAMBER));
+    #if HAS_TEMP_CHAMBER
+      #if HAS_HEATED_CHAMBER
+        SERIAL_ECHOPAIR(" C@:", getHeaterPower(H_CHAMBER));
+      #endif
     #endif
     #if HAS_TEMP_HEATBREAK
       SERIAL_ECHOPAIR(" HBR@:", getHeaterPower((heater_ind_t)(H_HEATBREAK_E0 + target_extruder)));


### PR DESCRIPTION
This solves issue #3848.

If the device doesn't have a chamber temp, then chamber temps shouldn't be reported via gcode M155.