### PR TITLE
GUI: Add footer item for ready status

### DIFF
--- a/src/common/footer_def.hpp
+++ b/src/common/footer_def.hpp
@@ -72,6 +72,7 @@ enum class Item : uint8_t { // stored in eeprom, must fit to footer::eeprom::val
     nozzle_diameter = 22,
     nozzle_pwm = 23,
     enclosure_temp = 24,
+    ready = 25,
     _count,
 };
 
@@ -204,6 +205,8 @@ constexpr const char *to_string(Item item) {
 #else
         break;
 #endif
+    case Item::ready:
+        return N_("Ready status");
     case Item::none:
         return N_("None");
     case Item::_count:

--- a/src/common/footer_eeprom.cpp
+++ b/src/common/footer_eeprom.cpp
@@ -210,9 +210,10 @@ static_assert(ftrstd::to_underlying(Item::none) == 0
         && ftrstd::to_underlying(Item::nozzle_diameter) == 22
         && ftrstd::to_underlying(Item::nozzle_pwm) == 23
         && ftrstd::to_underlying(Item::enclosure_temp) == 24
+        && ftrstd::to_underlying(Item::ready) == 25
         && true, // So that we don't have to move the ',' around
     "Numbers assigned to items should never change and always be available (not ifdefed)!!");
 
-static_assert(ftrstd::to_underlying(Item::_count) == 25, "When adding a new item, increment this counter and add it to the static_assert above");
+static_assert(ftrstd::to_underlying(Item::_count) == 26, "When adding a new item, increment this counter and add it to the static_assert above");
 
 } // namespace footer::eeprom

--- a/src/gui/footer/CMakeLists.txt
+++ b/src/gui/footer/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(
           footer_item_input_shaper.cpp
           footer_item_live_z.cpp
           footer_item_printspeed.cpp
+          footer_item_ready_status.cpp
           footer_items_heaters.cpp
           footer_items_nozzle_bed.cpp
           footer_line.cpp

--- a/src/gui/footer/footer_item_ready_status.cpp
+++ b/src/gui/footer/footer_item_ready_status.cpp
@@ -1,0 +1,15 @@
+#include "footer_item_ready_status.hpp"
+#include "connect/marlin_printer.hpp"
+#include "img_resources.hpp"
+
+FooterItemReadyStatus::FooterItemReadyStatus(window_t *parent)
+    : FooterIconText_IntVal(parent, &img::ok_16x16, static_makeView, static_readValue) {
+}
+
+int FooterItemReadyStatus::static_readValue() {
+    return connect_client::MarlinPrinter::is_printer_ready();
+}
+
+string_view_utf8 FooterItemReadyStatus::static_makeView(int value) {
+    return string_view_utf8::MakeRAM(value == 1 ? (const uint8_t *)N_("YES") : (const uint8_t *)N_("NO"));
+}

--- a/src/gui/footer/footer_item_ready_status.hpp
+++ b/src/gui/footer/footer_item_ready_status.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "ifooter_item.hpp"
+#include "i18n.h"
+
+class FooterItemReadyStatus : public FooterIconText_IntVal {
+    static string_view_utf8 static_makeView(int value);
+    static int static_readValue();
+
+public:
+    FooterItemReadyStatus(window_t *parent);
+};

--- a/src/gui/footer/footer_item_types.hpp
+++ b/src/gui/footer/footer_item_types.hpp
@@ -14,6 +14,7 @@
 #include "footer_item_fsvalue.hpp"
 #include "footer_item_input_shaper.hpp"
 #include "footer_item_enclosure.hpp"
+#include "footer_item_ready_status.hpp"
 #include <option/has_mmu2.h>
 #include <option/has_sheet_profiles.h>
 #include <meta_utils.hpp>
@@ -72,6 +73,7 @@ using FooterItemMappings = TypeList< //
 #if XL_ENCLOSURE_SUPPORT()
     FooterItemMappingRec<FooterItemEnclosure, Item::enclosure_temp>,
 #endif
+    FooterItemMappingRec<FooterItemReadyStatus, Item::ready>,
     FooterItemMappingRec<FooterItemNozzle, Item::nozzle>
     //
     >;


### PR DESCRIPTION
This adds a footer in order to display the printer ready status as requested in the issue #3812.