### PR TITLE
I2C: Increase TWIBUS buffer size from 32 to 256

### DIFF
--- a/lib/Marlin/Marlin/src/feature/twibus.h
+++ b/lib/Marlin/Marlin/src/feature/twibus.h
@@ -35,7 +35,7 @@
 typedef void (*twiReceiveFunc_t)(int bytes);
 typedef void (*twiRequestFunc_t)();
 
-#define TWIBUS_BUFFER_SIZE 32
+#define TWIBUS_BUFFER_SIZE 256
 
 /**
  * TWIBUS class
@@ -44,7 +44,7 @@ typedef void (*twiRequestFunc_t)();
  * Marlin to send and request data from any slave device on the bus.
  *
  * The two main consumers of this class are M260 and M261. M260 provides a way
- * to send an I2C packet to a device (no repeated starts) by caching up to 32
+ * to send an I2C packet to a device (no repeated starts) by caching up to 256
  * bytes in a buffer and then sending the buffer.
  * M261 requests data from a device. The received data is relayed to serial out
  * for the host to interpret.


### PR DESCRIPTION
This covers issue #4343.

**For reference :** 
Originally the TWI Bus buffersize has been limited to 32 bytes. The reason mainly was the eeprom size limit. However, this doesn't seem to be a real hardware limitation but more a device dependent limitation, as it was stated on places all over the internet, for example see: [Arduino discussion on i2c twi buffer limitation](https://forum.arduino.cc/t/increase-32-byte-i2c-buffer-size-in-wire-library/54503)

**Alternative:**
In the past, if more than 32 bytes should be sent, a chain of multiple 32 byte buffers was sent in sequence instead.

**What this PR does:**
As this is no real limitation but in order to make sure that not too much ram is used for this feature, the buffer limit has been increased to only 256 bytes which should be sufficient for most edge cases.
For data larger then 256, multiple packet should be sent instead, further increasing the buffer size would unnecessarily fill the RAM.
