### PR TITLE
Translation: Update german translation for "MMU Preload Advanced"

### DIFF
--- a/src/lang/po/de/Prusa-Firmware-Buddy_de.po
+++ b/src/lang/po/de/Prusa-Firmware-Buddy_de.po
@@ -5074,7 +5074,7 @@ msgstr "Vorladen zur MMU"
 
 #: src/gui/MItem_mmu.hpp:10
 msgid "Preload to MMU Advanced"
-msgstr "Vorladen zur MMU Fortgeschritten"
+msgstr "Vorladen zur MMU Erweitert"
 
 #: src/gui/wizard/selftest_frame_temp.cpp:58
 msgid "Preparing"


### PR DESCRIPTION
This refers to issue #4357. 

The translation is changed from "Vorladen zur MMU Fortgeschritten" to a more meaningful "Vorladen zur MMU Erweitert".