### PR TITLE
[BFW-6669] Serial: Emulate M21 SD card response for octoprint / third party

### DIFF
--- a/lib/Marlin/Marlin/src/core/language.h
+++ b/lib/Marlin/Marlin/src/core/language.h
@@ -225,6 +225,7 @@
 #define MSG_SD_VOL_INIT_FAIL                "volume.init failed"
 #define MSG_SD_OPENROOT_FAIL                "openRoot failed"
 #define MSG_SD_CARD_OK                      "SD card ok"
+#define MSG_SD_CARD_FAIL                    "No SD card"
 #define MSG_SD_WORKDIR_FAIL                 "workDir open failed"
 #define MSG_SD_OPEN_FILE_FAIL               "open failed, File: "
 #define MSG_SD_FILE_OPENED                  "File opened: "

--- a/src/marlin_stubs/sdcard/M20-M30_M32-M34.cpp
+++ b/src/marlin_stubs/sdcard/M20-M30_M32-M34.cpp
@@ -30,7 +30,12 @@ void GcodeSuite::M20() {
  * M21 - Initialize SD card
  */
 void GcodeSuite::M21() {
-    // not necessary - empty implementation
+    // required for Octoprint / third party tools to simulate an inserted SD card when using USB
+    if (marlin_vars()->media_inserted) {
+        SERIAL_ECHOLNPGM(MSG_SD_CARD_OK);
+    } else {
+        SERIAL_ECHOLNPGM(MSG_SD_CARD_FAIL);
+    }
 }
 
 /**


### PR DESCRIPTION
This PR is related to issue #4293. Third party software like octoprint expects the M21 command to return "SD card ok" on existing usb and "No SD card" if no usb is found, according to [Marlin M21 documentation](https://marlinfw.org/docs/gcode/M021.html).

Related to [Octoprint issue #5077](https://github.com/OctoPrint/OctoPrint/issues/5077).
