### PR TITLE
[BFW-6693] gcode: Add support for delete file via M30 gcode command

### DIFF
--- a/src/marlin_stubs/sdcard/M20-M30_M32-M34.cpp
+++ b/src/marlin_stubs/sdcard/M20-M30_M32-M34.cpp
@@ -1,9 +1,11 @@
 #include <dirent.h>
 
 #include "../../lib/Marlin/Marlin/src/gcode/gcode.h"
+#include "../src/common/print_utils.hpp"
 #include "marlin_server.hpp"
 #include "media.hpp"
 #include "marlin_vars.hpp"
+#include <str_utils.hpp>
 
 /** \addtogroup G-Codes
  * @{
@@ -119,7 +121,15 @@ void GcodeSuite::M29() {
 
 // M30 - Delete a file on the SD card
 void GcodeSuite::M30() {
-    // TODO
+    ArrayStringBuilder<FF_MAX_LFN> filepath;
+    filepath.append_printf("/usb/%s", parser.string_arg);
+    DeleteResult result = DeleteResult::GeneralError;
+    if (filepath.is_ok()) {
+        result = remove_file(filepath.str());
+    }
+    SERIAL_ECHOPGM(result == DeleteResult::Success ? "File deleted:" : "Deletion failed:");
+    SERIAL_ECHO(parser.string_arg);
+    SERIAL_ECHOLN(".");
 }
 
 // M32 - Select file and start SD print


### PR DESCRIPTION
This partially refers to [Octoprint issue #5077] (https://github.com/OctoPrint/OctoPrint/issues/5077).

The gcode M30 for deleting files, required by octoprint and third party tools hasn't been implemented.