### PR TITLE
Fix handling of .tar.xzg in bootstrap

### DIFF
--- a/utils/bootstrap.py
+++ b/utils/bootstrap.py
@@ -173,7 +173,9 @@ def download_and_unzip(url: str, directory: Path):
     print('Extracting ' + file, end=" ")
 
     # Check if tar or zip
-    if any(url.endswith(ext) for ext in ['.tar.bz2', '.tar.gz', '.tar.xz']):
+    if any(
+            url.endswith(ext)
+            for ext in ['.tar.bz2', '.tar.gz', '.tar.xz', 'tar.xzg']):
         with tarfile.open(filename) as obj:
             obj.extractall(path=extract_dir)
     else:


### PR DESCRIPTION
The macOS build includes a `.tar.xzg` file, which 1bfe80a67 does not properly handle. This simply adds this extension to the list which should be extracted with tar instead of zip.