### PR TITLE
gui: Allow automatic offset tool calibration per toolhead

### DIFF
--- a/src/common/selftest/selftest_tool_offsets_interface.hpp
+++ b/src/common/selftest/selftest_tool_offsets_interface.hpp
@@ -9,5 +9,5 @@
 namespace selftest {
 
 TestReturn phaseToolOffsets(const ToolMask tool_mask, IPartHandler *&pToolOffsets, const ToolOffsetsConfig_t &config);
-
-};
+TestReturn phaseToolOffset(const ToolMask tool_mask, IPartHandler *&pToolOffsets, const ToolOffsetsConfig_t &config, std::bitset<config_store_ns::max_tool_count> selected_tools);
+}; // namespace selftest

--- a/src/gui/screen/toolhead/screen_toolhead_settings.hpp
+++ b/src/gui/screen/toolhead/screen_toolhead_settings.hpp
@@ -81,6 +81,18 @@ public:
 private:
     bool is_picked = false;
 };
+
+    #if HAS_SELFTEST()
+class MI_CALIBRATE_TOOL_OFFSET : public MI_TOOLHEAD_SPECIFIC<MI_CALIBRATE_TOOL_OFFSET, IWindowMenuItem> {
+public:
+    MI_CALIBRATE_TOOL_OFFSET(Toolhead toolhead = default_toolhead);
+    void update();
+    void click(IWindowMenu &) override;
+
+private:
+    bool is_picked = false;
+};
+    #endif // HAS_SELFTEST
 #endif
 
 class MI_FILAMENT_SENSORS : public MI_TOOLHEAD_SPECIFIC<MI_FILAMENT_SENSORS, IWindowMenuItem> {
@@ -125,6 +137,9 @@ using ScreenToolheadDetail_ = ScreenMenu<EFooter::Off,
     MI_PICK_PARK,
     MI_NOZZLE_OFFSET,
     MI_DOCK,
+#endif
+#if HAS_SELFTEST()
+    MI_CALIBRATE_TOOL_OFFSET,
 #endif
 #if FILAMENT_SENSOR_IS_ADC()
     MI_CALIBRATE_FILAMENT_SENSORS,


### PR DESCRIPTION
This solves issue #3478. Adds single tool offset calibration to Settings->Tool menu, which allows to do automatic offset tool calibration per toolhead instead of having to rerun self-test for all toolheads.

Settings -> Tool -> [Tool 1..6 / All Tools] -> Calibrate Tool Offset/Calibrate Tool Offsets
