### PR TITLE
serial: Report chamber temp support (gcode M115/M105/M155)

### DIFF
--- a/lib/Marlin/Marlin/src/module/temperature.cpp
+++ b/lib/Marlin/Marlin/src/module/temperature.cpp
@@ -43,6 +43,10 @@
 #include "printers.h"
 #include "MarlinPin.h"
 #include "../../../../src/common/adc.hpp"
+#include <option/has_chamber_api.h>
+#if HAS_CHAMBER_API()
+#include "feature/chamber/chamber.hpp"
+#endif
 
 #define MAX6675_SEPARATE_SPI (EITHER(HEATER_0_USES_MAX6675, HEATER_1_USES_MAX6675) && PINS_EXIST(MAX6675_SCK, MAX6675_DO))
 
@@ -3842,7 +3846,11 @@ void Temperature::isr() {
     #endif
     #if HAS_HEATED_CHAMBER
       SERIAL_ECHOPAIR(" C@:", getHeaterPower(H_CHAMBER));
+    #elif HAS_CHAMBER_API()
+      auto current_chamber_temperature = buddy::chamber().current_temperature();
+      if (current_chamber_temperature.has_value()) SERIAL_ECHOPAIR(" C@:", current_chamber_temperature.value());
     #endif
+
     #if HAS_TEMP_HEATBREAK
       SERIAL_ECHOPAIR(" HBR@:", getHeaterPower((heater_ind_t)(H_HEATBREAK_E0 + target_extruder)));
     #endif

--- a/src/common/feature/chamber/chamber.hpp
+++ b/src/common/feature/chamber/chamber.hpp
@@ -4,7 +4,7 @@
 
 #include <option/xl_enclosure_support.h>
 #include <option/has_xbuddy_extension.h>
-#include <common/temperature.hpp>
+#include <temperature.hpp>
 #include <freertos/mutex.hpp>
 
 // TODO: Migrate XL Enclosure to use this API (& unify)

--- a/src/marlin_stubs/host/M115.cpp
+++ b/src/marlin_stubs/host/M115.cpp
@@ -29,6 +29,9 @@
 #if HAS_TOOLCHANGER()
     #include "../../module/prusa/toolchanger.h"
 #endif
+#if HAS_CHAMBER_API()
+    #include "feature/chamber/chamber.hpp"
+#endif
 
 #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
 static void cap_line(PGM_P const name, bool ena = false) {
@@ -221,6 +224,9 @@ void GcodeSuite::M115() {
     #if HAS_HEATED_CHAMBER
                  ,
         true
+    #elif HAS_CHAMBER_API()
+                 ,
+        buddy::chamber().capabilities().temperature_reporting
     #endif
     );
 


### PR DESCRIPTION
This adds report chamber temp support for gcode M115 and chamber report temp on M105/M155 for third parties (gcode serial)

This resolves issue #4479.