### PR TITLE
[BFW-7007] nozzle_diameter: Change max nozzle diameter to 1.8mm

### DIFF
--- a/include/common/nozzle_diameter.hpp
+++ b/include/common/nozzle_diameter.hpp
@@ -4,7 +4,7 @@
 
 static constexpr NumericInputConfig nozzle_diameter_spin_config {
     .min_value = 0.2,
-    .max_value = 1.2,
+    .max_value = 1.8,
     .step = 0.05,
     .max_decimal_places = 2,
     .unit = Unit::millimeter,


### PR DESCRIPTION
This solves issue #4553, and changes the max nozzle diameter from 1.2mm to 1.8mm.