### PR TITLE
[BFW-7072] gcode: Fix issues on gcode parsing with inline comments

### DIFF
--- a/src/common/gcode/gcode_info.cpp
+++ b/src/common/gcode/gcode_info.cpp
@@ -420,6 +420,13 @@ void GCodeInfo::parse_gcode(GcodeBuffer::String cmd, uint32_t &gcode_counter) {
     if (cmd.is_empty() || cmd.front() == ';') {
         return;
     }
+
+    // Make sure we don't parse inline comments
+    const auto comment = std::find(cmd.begin, cmd.end, ';');
+    if (comment != cmd.end) { // only if comments are found
+        cmd = GcodeBuffer::String(cmd.begin, comment);
+    }
+
     gcode_counter++;
 
     // skip line number if present


### PR DESCRIPTION
Using this gcode:
`M862.3 P "MK4S" ; Printer model check`
instead of
`M862.3 P "MK4S" ; printer model check`
will lead to an error due to incorrect printer type.

The reason is that the "GCodeInfo::parse_gcode" function only skips comments at the beginning, but not inline comments,
thus leading in an incorrect parsing of comments as parameters, which in this case results that the printer model is parsed incorrectly.