### PR TITLE
[BFW-7619]prusa link: Allow long filenames on item download from Prusa Link

### DIFF
--- a/lib/WUI/nhttp/file_info.cpp
+++ b/lib/WUI/nhttp/file_info.cpp
@@ -131,7 +131,7 @@ JsonResult FileInfo::DirRenderer::renderStateV1(size_t resume_point, JsonOutput 
                 state.first = false;
             }
             JSON_OBJ_START;
-                JSON_FIELD_STR("name", state.ent->d_name) JSON_COMMA;
+                JSON_FIELD_STR("name", dirent_lfn(state.ent)) JSON_COMMA;
                 JSON_FIELD_BOOL("ro", state.read_only) JSON_COMMA;
                 JSON_FIELD_STR("type", file_type(state.ent)) JSON_COMMA;
 #ifdef UNITTESTS


### PR DESCRIPTION
This solves issue #4476, which on download of previously long filename files will truncate the filename to short filenames via Prusa Link.