### PR TITLE
[BFW-7076] gcode: rework M865

### DIFF
--- a/src/marlin_stubs/M865.cpp
+++ b/src/marlin_stubs/M865.cpp
@@ -13,8 +13,7 @@
  * - `I<ix>` - Configure parameters of a filament currently loaded to the specified tool (indexed from 0)
  * - `U<ix>` - Configure parameters of a User filament (indexed from 0)
  * - `X` - Configure parameters of a Custom filament type that will be loaded using `M600 F"##"` (or similar filament change gcode)
- * - `F"<preset>"` - Configure parameters of User filament with this name  (or select Preset filament for `L`)
- *
+ * - `S"<preset>"` - Configure parameters of filament with this name  (or select Preset filament for `L`)
  * - `L<ix>` - Set currently loaded filament for the given tool to the selected filament
  *
  * - `R` - Reset parameters not specified in this gcode to defaults
@@ -23,12 +22,13 @@
  * - `P` - Nozzle preheat temperature
  * - `B` - Bed temperature
  * - `A` - Is abrasive
- * - `F` - Requries filtration
+ * - `F` - Requires filtration
  * - `N"<string>"` - New filament name
  *
  * Ad-hoc/custom filaments can the be referenced in other gcodes using adhoc_filament_gcode_prefix.
  * For example `M600 S"#0"` will load ad-hoc filament previously set with `M865 I0`.
- * The current filament settings of the specified tool (indexed from 0) are printed to the serial console
+ * The filament_type settings are printed to the serial console. For option I, the current filament_type
+ * setting of the specified tool (indexed from 0) is displayed instead.
  */
 void PrusaGcodeSuite::M865() {
     GCodeParser2 p;
@@ -47,7 +47,7 @@ void PrusaGcodeSuite::M865() {
     } else if (const auto slot = p.option<uint8_t>('U', static_cast<uint8_t>(0), static_cast<uint8_t>(user_filament_type_count - 1))) {
         filament_type = UserFilamentType { .index = *slot };
 
-    } else if (const auto ft = p.option<FilamentType>('F')) {
+    } else if (const auto ft = p.option<FilamentType>('S')) {
         filament_type = *ft;
 
     } else {

--- a/src/marlin_stubs/M865.cpp
+++ b/src/marlin_stubs/M865.cpp
@@ -28,6 +28,7 @@
  *
  * Ad-hoc/custom filaments can the be referenced in other gcodes using adhoc_filament_gcode_prefix.
  * For example `M600 S"#0"` will load ad-hoc filament previously set with `M865 I0`.
+ * The current filament settings of the specified tool (indexed from 0) are printed to the serial console
  */
 void PrusaGcodeSuite::M865() {
     GCodeParser2 p;
@@ -96,6 +97,18 @@ void PrusaGcodeSuite::M865() {
 
     if (auto load = p.option<uint8_t>('L', static_cast<uint8_t>(0), static_cast<uint8_t>(EXTRUDERS))) {
         config_store().set_filament_type(*load, filament_type);
+    }
+
+    if (filament_type != FilamentType::none) {
+        ArrayStringBuilder<filament_name_buffer_size + 82> filament_info;
+        filament_info.append_printf("name:%s\n", params.name);
+        filament_info.append_printf("nozzle_temperature:%d\n", params.nozzle_temperature);
+        filament_info.append_printf("heatbed_temperature:%d\n", params.heatbed_temperature);
+        filament_info.append_printf("is_abrasive:%d\n", params.is_abrasive);
+#if HAS_CHAMBER_API()
+        filament_info.append_printf("requires_filtration:%d\n", params.requires_filtration);
+#endif
+        SERIAL_ECHOLN(filament_info.str());
     }
 }
 

--- a/src/marlin_stubs/M865.cpp
+++ b/src/marlin_stubs/M865.cpp
@@ -10,7 +10,7 @@
  *### M865: Configure filament parameters
  *
  *#### Parameters
- * - `I<ix>` - Configure parameters of a Custom filament currently loaded to the specified tool (indexed from 0)
+ * - `I<ix>` - Configure parameters of a filament currently loaded to the specified tool (indexed from 0)
  * - `U<ix>` - Configure parameters of a User filament (indexed from 0)
  * - `X` - Configure parameters of a Custom filament type that will be loaded using `M600 F"##"` (or similar filament change gcode)
  * - `F"<preset>"` - Configure parameters of User filament with this name  (or select Preset filament for `L`)
@@ -37,11 +37,8 @@ void PrusaGcodeSuite::M865() {
 
     FilamentType filament_type;
 
-    if (const auto slot = p.option<uint8_t>('I', static_cast<uint8_t>(0), static_cast<uint8_t>(adhoc_filament_type_count - 1))) {
-        filament_type = AdHocFilamentType { .tool = *slot };
-        if (config_store().get_filament_type(*slot) != filament_type) {
-            SERIAL_ERROR_MSG("The selected tool does not have the ad-hoc filament loaded. Changes will have no effect.");
-        }
+    if (const auto slot = p.option<uint8_t>('I', static_cast<uint8_t>(0), static_cast<uint8_t>(EXTRUDERS - 1))) {
+        filament_type = config_store().get_filament_type(*slot);
 
     } else if (p.option<bool>('X').value_or(false)) {
         filament_type = PendingAdHocFilamentType {};


### PR DESCRIPTION
This solves issue #4542 by adding an option to print the filament type for a specific tool slot:

`M865 I0` will print for tool slot 0 (Extruder 1):

![image](https://github.com/user-attachments/assets/997f5170-7361-4c21-b621-8b1d20e7b8c6)

Furthermore:
- Rename F<type> to S<type> due to conflict with F (Required filtration), update documentation
- Fix max value of Extruder slot for L<ix>, update documentation
- Change behavior of I<ix> for changing/getting the current filament, update documentation