### PR TITLE
[BFW-7076] gcode: M865 fix EXTRUDER param max size for L option

### DIFF
--- a/src/marlin_stubs/M865.cpp
+++ b/src/marlin_stubs/M865.cpp
@@ -97,7 +97,7 @@ void PrusaGcodeSuite::M865() {
         filament_type.set_parameters(params);
     }
 
-    if (auto load = p.option<uint8_t>('L', static_cast<uint8_t>(0), static_cast<uint8_t>(EXTRUDERS))) {
+    if (auto load = p.option<uint8_t>('L', static_cast<uint8_t>(0), static_cast<uint8_t>(EXTRUDERS - 1))) {
         config_store().set_filament_type(*load, filament_type);
     }
 }


### PR DESCRIPTION
This corrects an issue in gcode M865, correcting the wrong max size for the EXTRUDER specified parameter in the 'L' option.