### PR TITLE
octoprint: Fix serial output from chamber power to expected chamber temp format

### DIFF
--- a/lib/Marlin/Marlin/src/module/temperature.cpp
+++ b/lib/Marlin/Marlin/src/module/temperature.cpp
@@ -1014,6 +1014,29 @@ void Temperature::isr() {
       print_heater_state(degBed(), degTargetBed(), H_BED);
     #endif
 
+    #if HAS_CHAMBER_API()
+      {
+        const auto chamber_capabilities = buddy::chamber().capabilities();
+        if (chamber_capabilities.temperature_reporting) {
+          const auto current_chamber_temperature = buddy::chamber().current_temperature();
+          const auto target_chamber_temperature = buddy::chamber().target_temperature();
+          SERIAL_ECHOPAIR(" C:", current_chamber_temperature.value_or(0.0f));
+          SERIAL_ECHOPAIR("/", target_chamber_temperature.value_or(0.0f));
+        }
+      }
+    #else
+      #if HAS_TEMP_CHAMBER
+        print_heater_state(degChamber()
+        #if HAS_HEATED_CHAMBER
+          , degTargetChamber()
+        #else
+          , 0
+        #endif
+        , H_CHAMBER
+      );
+      #endif
+    #endif // HAS_CHAMBER_API()
+
     #if HAS_TEMP_HEATBREAK
       print_heater_state(degHeatbreak(target_extruder)
           , degTargetHeatbreak(target_extruder)
@@ -1037,9 +1060,8 @@ void Temperature::isr() {
     #if HAS_HEATED_BED
       SERIAL_ECHOPAIR(" B@:", getHeaterPower(H_BED));
     #endif
-    #if HAS_CHAMBER_API()
-      auto current_chamber_temperature = buddy::chamber().current_temperature();
-      if (current_chamber_temperature.has_value()) SERIAL_ECHOPAIR(" C@:", current_chamber_temperature.value());
+    #if HAS_HEATED_CHAMBER
+      SERIAL_ECHOPAIR(" C@:", getHeaterPower(H_CHAMBER));
     #endif
 
     #if HAS_TEMP_HEATBREAK

--- a/src/marlin_stubs/feature/chamber/M141_M191.cpp
+++ b/src/marlin_stubs/feature/chamber/M141_M191.cpp
@@ -80,6 +80,7 @@ void PrusaGcodeSuite::M141_no_parser(const M141Args &args) {
 
     if (!chamber().capabilities().temperature_control()) {
         SERIAL_ERROR_MSG("Chamber does not allow temperature control");
+        return;
     }
 
     auto target = args.target_temp;


### PR DESCRIPTION
This changes the C@: output which shall be used for chamber power only to C:x.x/m.m where x is current chamber temp and m is target chamber temp in order to match the expected behaviour, see [reference](https://reprap.org/wiki/G-code#M105:_Get_Extruder_Temperature). Also separated from chamber power define to allow chamber temp being used if chamber api and chamber temp is supported, even if chamber power isn't defined.

As HAS_HEATER_CHAMBER and HAS_TEMP_CHAMBER are old Merlin defines and HAS_CHAMBER_API() is used in favor, we prioritize HAS_CHAMBER_API for now until the old Merlin code has been removed.
Solves issues #4800 and #4479