### PR TITLE
XL: Disable temp sensor chamber as it doesn't exist, causing wrong chamber temp report

### DIFF
--- a/include/marlin/Configuration_XL.h
+++ b/include/marlin/Configuration_XL.h
@@ -154,6 +154,10 @@
 //===========================================================================
 
 #define TEMP_SENSOR_BED 5
+
+// Chamber temperature is thermistor connector on sandwich. Connected to virtual MARLIN_PIN(AMBIENT) and AdcGet::ambientTemp().
+#define TEMP_SENSOR_CHAMBER 0
+
 #define TEMP_SENSOR_HEATBREAK 5
 #define TEMP_SENSOR_BOARD 2000
 


### PR DESCRIPTION
This solves issue #3848.

Issue: If the device doesn't have a heated chamber, then chamber temps shouldn't be reported via gcode M155.

Solution: on XL, TEMP_SENSOR_CHAMBER was defined as 2000, which was invalid. Setting the value to 0 disables the TEMP_SENSOR_CHAMBER, thus M155 no longer will report a chamber temperature that doesn't exist.
