### PR TITLE
[BFW-7536] Report the correct number of probe points during bed leveling within a specified area.

### DIFF
--- a/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -24,6 +24,7 @@
 //#define UBL_DEVEL_DEBUGGING
 
 #include "../../../module/motion.h"
+#include "../../../feature/print_area.h"
 
 #define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
 #include "../../../core/debug_out.h"
@@ -69,11 +70,11 @@ class unified_bed_leveling {
       static void manually_probe_remaining_mesh(const xy_pos_t&, const float&, const float&, const bool) __O0;
       static void fine_tune_mesh(const xy_pos_t &pos, const bool do_ubl_mesh_map) __O0;
     #endif
-    static int count_points_to_probe();
+    static int count_points_to_probe(const PrintArea::rect_t &probe_area);
     static bool g29_parameter_parsing() __O0;
     static void shift_mesh_height();
     static void probe_entire_mesh(const xy_pos_t &near, const bool do_ubl_mesh_map, const bool stow_probe, const bool do_furthest) __O0;
-    static void probe_major_points(const xy_pos_t area_a, const xy_pos_t area_b, const bool do_ubl_mesh_map, const bool stow_probe);
+    static void probe_major_points(const PrintArea::rect_t &probe_area, const bool do_ubl_mesh_map, const bool stow_probe);
     static void tilt_mesh_based_on_3pts(const float &z1, const float &z2, const float &z3);
     static void tilt_mesh_based_on_probed_grid(const bool do_ubl_mesh_map);
     static bool smart_fill_one(const uint8_t x, const uint8_t y, const int8_t xdir, const int8_t ydir);

--- a/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -314,7 +314,7 @@
   #if PRINTER_IS_PRUSA_MK3_5() || PRINTER_IS_PRUSA_MINI()
 
   // Apply weighted correction on each point based on it's location.
-  // The whole correction is then conversed from µm to mm.
+  // The whole correction is then converted from µm to mm.
 
   float x_axis_correction(int x, int y) {
     int32_t left_correction_um{config_store().left_bed_correction.get()};

--- a/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -314,14 +314,14 @@
   #if PRINTER_IS_PRUSA_MK3_5() || PRINTER_IS_PRUSA_MINI()
 
   // Apply weighted correction on each point based on it's location.
-  // The whole correction is then conversed from µm to mm. 
+  // The whole correction is then conversed from µm to mm.
 
   float x_axis_correction(int x, int y) {
     int32_t left_correction_um{config_store().left_bed_correction.get()};
     int32_t right_correction_um{config_store().right_bed_correction.get()};
 
     int32_t x_len{GRID_MAX_POINTS_X-1};
-    
+
     return ( (left_correction_um*(x_len-x)) + (right_correction_um*(x)) ) / static_cast<float>(x_len);
   }
 
@@ -837,10 +837,10 @@
   }
   int unified_bed_leveling::count_points_to_probe(){
 
-/// probe area is print area enlarged by one major point
+    /// probe area is print area enlarged by one major point
     auto probe_area = print_area.get_bounding_rect().inset(-MESH_X_DIST * GRID_MAJOR_STEP,
                                                            -MESH_Y_DIST * GRID_MAJOR_STEP);
-// count points that are reachable to be probed
+    // count points that are reachable to be probed
     int num_of_points_to_probe = 0;
     for (int y = GRID_MAX_POINTS_Y - GRID_BORDER - 1; y >= GRID_BORDER; y -= GRID_MAJOR_STEP) {
       int y_idx = (y - GRID_BORDER) / GRID_MAJOR_STEP;
@@ -968,10 +968,10 @@
 
       bool is_initial_probe = true;
       #if DISABLED(UBL_DONT_REPORT_POINT_COUNT)
-      const int  num_of_points_to_probe = count_points_to_probe();
+      const int num_of_points_to_probe = count_points_to_probe();
       #endif /*DISABLED(UBL_DONT_REPORT_POINT_COUNT)*/
       int num_of_probed_points = 0;
-       // enumerate over all major points
+      // enumerate over all major points
       for (int y = GRID_MAX_POINTS_Y - GRID_BORDER - 1; y >= GRID_BORDER; y -= GRID_MAJOR_STEP) {
         int y_idx = (y - GRID_BORDER) / GRID_MAJOR_STEP;
         bool is_odd_y_position = y_idx % 2 == 1;
@@ -1034,11 +1034,11 @@
           const auto prev_measured_z = g29_min_max_measured_z.value_or(std::make_pair(measured_z, measured_z));
           g29_min_max_measured_z = { std::min(prev_measured_z.first, measured_z), std::max(prev_measured_z.second, measured_z) };
           log_info(Marlin, "Measured z: %f", (double) measured_z);
-          
+
           #if PRINTER_IS_PRUSA_MK3_5() || PRINTER_IS_PRUSA_MINI()
             //apply bed level correction on each probed point
             apply_bed_level_correction(x,y);
-          #endif 
+          #endif
 
           #if ENABLED(EXTENSIBLE_UI)
             ExtUI::onMeshUpdate(x, y, measured_z);

--- a/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/lib/Marlin/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -513,14 +513,13 @@
               crash_s.set_gcode_replay_flags(Crash_s::RECOVER_AXIS_STATE);
             #endif
 
-            if (xy_seen && g29_size_seen) {
-              probe_major_points(g29_pos, g29_pos + g29_size, parser.seen('T'), parser.seen('E'));
-            } else {
-              /// probe area is print area enlarged by one major point
-              auto probe_area = print_area.get_bounding_rect().inset(-MESH_X_DIST * GRID_MAJOR_STEP,
-                                                                     -MESH_Y_DIST * GRID_MAJOR_STEP);
-              probe_major_points(probe_area.a, probe_area.b, parser.seen('T'), parser.seen('E'));
-            }
+            const auto probe_area = (xy_seen && g29_size_seen) ?
+              PrintArea::rect_t(g29_pos, g29_pos + g29_size) :
+              // probe area is print area enlarged by one major point
+              print_area.get_bounding_rect().inset(-MESH_X_DIST * GRID_MAJOR_STEP,
+                                                   -MESH_Y_DIST * GRID_MAJOR_STEP);
+
+            probe_major_points(probe_area, parser.seen('T'), parser.seen('E'));
 
             report_current_position();
             probe_deployed = true;
@@ -835,11 +834,8 @@
           #endif
         }
   }
-  int unified_bed_leveling::count_points_to_probe(){
 
-    /// probe area is print area enlarged by one major point
-    auto probe_area = print_area.get_bounding_rect().inset(-MESH_X_DIST * GRID_MAJOR_STEP,
-                                                           -MESH_Y_DIST * GRID_MAJOR_STEP);
+  int unified_bed_leveling::count_points_to_probe(const PrintArea::rect_t &probe_area){
     // count points that are reachable to be probed
     int num_of_points_to_probe = 0;
     for (int y = GRID_MAX_POINTS_Y - GRID_BORDER - 1; y >= GRID_BORDER; y -= GRID_MAJOR_STEP) {
@@ -947,7 +943,7 @@
       );
     }
 
-    void unified_bed_leveling::probe_major_points(const xy_pos_t area_a, const xy_pos_t area_b, const bool do_ubl_mesh_map, const bool stow_probe) {
+    void unified_bed_leveling::probe_major_points(const PrintArea::rect_t &probe_area, const bool do_ubl_mesh_map, const bool stow_probe) {
       save_ubl_active_state_and_disable();  // No bed level correction so only raw data is obtained
 
       #if ENABLED(NOZZLE_LOAD_CELL)
@@ -964,11 +960,9 @@
         }
       #endif
 
-      PrintArea::rect_t probe_area(area_a, area_b);
-
       bool is_initial_probe = true;
       #if DISABLED(UBL_DONT_REPORT_POINT_COUNT)
-      const int num_of_points_to_probe = count_points_to_probe();
+      const int num_of_points_to_probe = count_points_to_probe(probe_area);
       #endif /*DISABLED(UBL_DONT_REPORT_POINT_COUNT)*/
       int num_of_probed_points = 0;
       // enumerate over all major points

--- a/lib/Marlin/Marlin/src/feature/print_area.h
+++ b/lib/Marlin/Marlin/src/feature/print_area.h
@@ -43,19 +43,19 @@ class PrintArea {
       }
 
       /// Check the rectangle contains given point
-      bool contains(xy_pos_t point) {
+      bool contains(xy_pos_t point) const {
         bool x_within = a.x <= point.x && point.x <= b.x;
         bool y_within = a.y <= point.y && point.y <= b.y;
         return x_within && y_within;
       }
 
       /// Check the rectangle contains another rect (i.e. this one is a superset of the other one)
-      bool contains(rect_t other) {
+      bool contains(rect_t other) const {
         return contains(other.a) && contains(other.b);
       }
 
       /// Return an intersection of `this` and `other`
-      rect_t intersection(rect_t other) {
+      rect_t intersection(rect_t other) const {
         xy_pos_t ia, ib;
         ia.x = std::fmax(this->a.x, other.a.x);
         ia.y = std::fmax(this->a.y, other.a.y);
@@ -65,7 +65,7 @@ class PrintArea {
       }
 
       /// Return a rect with its edges moved inward by dx/dy
-      rect_t inset(float dx, float dy) {
+      rect_t inset(float dx, float dy) const {
         rect_t r = *this;
         r.a.x += dx;
         r.a.y += dy;
@@ -75,7 +75,7 @@ class PrintArea {
       }
 
       /// Return rect with guarantees that a.x <= b.x && a.y <= b.y
-      rect_t normalized() {
+      rect_t normalized() const {
         rect_t r = *this;
         if (r.b.x < r.a.x)
           r.b.x = r.a.x;


### PR DESCRIPTION
### What
Calculate the point total in the `Probing Point <current>/<total>` UI message from the passed-in area instead of the current print footprint.

### Why
The current UI behavior works fine for probing the print footprint itself, but when the slicer default gcode then goes on to probe the area in the corner for its purge line, it's still reporting a total calculated from the print footprint even though it only needs to probe 3 points (in the CORE One case).

### How
Use the specified area in the point calculation instead of always using `print_area`.  Still default to `print_area` when no area is specified.  I haven't tested this change, since I haven't made the physical modifications necessary to flash custom firmware, but the change is simple enough that maybe someone else can verify that it works.

Addresses https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/4246