### PR TITLE
gui: Add stop option if stuck filament is detected

### DIFF
--- a/lib/Prusa-Error-Codes/yaml/buddy-error-codes.yaml
+++ b/lib/Prusa-Error-Codes/yaml/buddy-error-codes.yaml
@@ -26,7 +26,7 @@ Errors:
     printers: [MK4, COREONE, COREONEL, iX]
     title: "STUCK FILAMENT DETECTED"
     text: "The filament seems to be stuck, please unload it from nextruder and load it again."
-    action: [Unload]
+    action: [Unload, StopPrint]
     id: "STUCK_FILAMENT_DETECTED"
     gui_layout: "warning_dialog"
     approved: true
@@ -98,7 +98,7 @@ Errors:
     printers: [XL]
     title: "STUCK FILAMENT DETECTED"
     text: "The filament seems to be stuck, please unload it from nextruder and load it again."
-    action: [Unload]
+    action: [Unload, StopPrint]
     gui_layout: "red_screen"
     id: "STUCK_FILAMENT_DETECTED"
     approved: true

--- a/src/marlin_stubs/pause/pause.cpp
+++ b/src/marlin_stubs/pause/pause.cpp
@@ -1156,6 +1156,8 @@ void Pause::filament_stuck_ask_process(Response response) {
 
     if (response == Response::Unload) {
         set(LoadState::unload_wait_temp);
+    } else if (response == Response::Stop) {
+        settings.do_stop = true;
     }
 }
 #endif


### PR DESCRIPTION
This solves issue #4545, adds a StopPrint option in case the filament got stuck and unload shouldn't happen.
