### PR TITLE
Prusalink: Add missing urlencode, fix bounds check and add url tests

### DIFF
--- a/src/common/http/url_decode.cpp
+++ b/src/common/http/url_decode.cpp
@@ -14,18 +14,18 @@ bool url_decode(std::string_view url, char *decoded_url, size_t decoded_url_len)
             decoded_url[out_index] = ' ';
             break;
         case '%': {
-            if (decoded_url_len < i + 3) {
-                return false;
+            if (i + 2 < url.size()) {
+                int ascii_value;
+                auto curr_iter = url.begin() + i;
+                auto result = from_chars_light(curr_iter + 1, curr_iter + 3, ascii_value, 16);
+                if (result.ec == std::errc {}) {
+                    decoded_url[out_index] = static_cast<char>(ascii_value);
+                    i = i + 2;
+                    break;
+                }
             }
-            int ascii_value;
-            auto curr_iter = url.begin() + i;
-            auto result = from_chars_light(curr_iter + 1, curr_iter + 3, ascii_value, 16);
-            if (result.ec != std::errc {}) {
-                return false;
-            }
-
-            decoded_url[out_index] = static_cast<char>(ascii_value);
-            i = i + 2;
+            // Not a valid percent-encoded sequence; treat '%' as a literal character.
+            decoded_url[out_index] = '%';
             break;
         }
         default:

--- a/tests/unit/common/url_decode_tests.cpp
+++ b/tests/unit/common/url_decode_tests.cpp
@@ -44,4 +44,25 @@ TEST_CASE("url decode", "[url]") {
         REQUIRE(url_decode(url, decoded_url, sizeof(decoded_url)));
         REQUIRE(strcmp(decoded_url, "") == 0);
     }
+
+    SECTION("bare percent at end of url") {
+        std::string url = "/a/v/f/file50%";
+        char decoded_url[url.size() + 1];
+        REQUIRE(url_decode(url, decoded_url, sizeof(decoded_url)));
+        REQUIRE(strcmp(decoded_url, "/a/v/f/file50%") == 0);
+    }
+
+    SECTION("bare percent followed by non-hex chars") {
+        std::string url = "/a/v/f/file50%.gcode";
+        char decoded_url[url.size() + 1];
+        REQUIRE(url_decode(url, decoded_url, sizeof(decoded_url)));
+        REQUIRE(strcmp(decoded_url, "/a/v/f/file50%.gcode") == 0);
+    }
+
+    SECTION("encoded percent decodes correctly") {
+        std::string url = "/a/v/f/file50%25.gcode";
+        char decoded_url[url.size() + 1];
+        REQUIRE(url_decode(url, decoded_url, sizeof(decoded_url)));
+        REQUIRE(strcmp(decoded_url, "/a/v/f/file50%.gcode") == 0);
+    }
 }


### PR DESCRIPTION
This solves issue #5112.  If files with percent sign are being uploaded, these aren't url encoded as they should be.
The second commit makes sure that the url_decode bounds check is handled properly and that if percent signs are used, they are identified as special characters correctly if applicable (percent-encoded sequence). To make sure that everything works correctly, tests have been added (here: claude code has been used for implementing the tests).

This PR requires prior adaption of https://github.com/prusa3d/Prusa-Link-Web/pull/525

