### PR TITLE
Network: Fix issues with large UDP packets

### DIFF
--- a/lib/WUI/pbuf_rx.cpp
+++ b/lib/WUI/pbuf_rx.cpp
@@ -2,17 +2,30 @@
 
 #include <ring_allocator.hpp>
 #include <freertos/mutex.hpp>
+#include <device/board.h>
 
 namespace {
 
-// TODO: The size (derive from somewhere)
-constexpr size_t mtu_size = 1024;
+// Standard Ethernet frames are up to 1518 bytes (1500 IP + 14 Eth header + 4 CRC-stripped);
+// 1536 covers this with margin.
+constexpr size_t mtu_size = 1536;
 constexpr size_t alloc_record = 4;
 constexpr size_t pbuf_head = LWIP_MEM_ALIGN_SIZE(sizeof(struct pbuf_custom));
+
+// Boards with Ethernet (XBUDDY / XLBUDDY, 192 KB RAM) need a larger pool: large UDP datagrams
+// fragment into up to 4 frames each, and multiple concurrent broadcast sources can exhaust the
+// pool before lwIP finishes reassembly, causing ICMP "Fragment Reassembly Time Exceeded".
+// The Buddy board (MINI, 128 KB RAM) uses WiFi only; keep a smaller pool to stay within budget.
+#if BOARD_IS_BUDDY()
 constexpr size_t mtu_cnt = 10;
+constexpr size_t buffer_tail = 500;
+#else
+constexpr size_t mtu_cnt = 32;
+constexpr size_t buffer_tail = 2000;
+#endif
 
 // A bit more for "small" packets.
-constexpr size_t buffer_size = mtu_cnt * (mtu_size + alloc_record + pbuf_head) + 500;
+constexpr size_t buffer_size = mtu_cnt * (mtu_size + alloc_record + pbuf_head) + buffer_tail;
 
 alignas(buddy::RingAllocator::alignment) std::array<uint8_t, buffer_size> rx_allocator_buffer;
 buddy::RingAllocator rx_allocator(rx_allocator_buffer);


### PR DESCRIPTION
This resolves issue #5115.

Each full-size Ethernet fragment (1500 bytes) uses ~1524 bytes in the pool. The pool can hold ~33 full-size frames simultaneously, thus the current MTU size is chosen being too small.

The 4 fragments of one 5128-byte UDP datagram need ~6100 bytes combined. With broadcasts arriving continuously from multiple devices and lwIP's reassembly timeout being several seconds, the pool routinely holds fragments from multiple concurrent datagrams — easily exhausting the 11 KB pool.

When the pool is exhausted, pbuf_alloc_rx returns nullptr ([pbuf_rx.cpp:38](vscode-webview://0nlg5e5786b63sa70pivctm76trd7q3isnrfjbmmenmrikbin5np/lib/WUI/pbuf_rx.cpp#L38)), and the driver drops the incoming frame entirely before lwIP ever sees it. lwIP has some fragments of a datagram but never receives the others. lwIP sends ICMP "Reassembly Time Exceeded". When the reassembly timer fires on an incomplete datagram, lwIP frees the partial fragments it does hold and sends an ICMP Type 11 Code 1 ("Fragment Reassembly Time Exceeded") back to the sender. This is exactly what the reporter observed: ICMP ip reassembly time exceeded messages being sent by the printer to every OpenWrt device, even ones the printer never contacted.

For the mk4_release_boot build:

RAM: 149,704 / 196,608 bytes used, 46,904 bytes free, about 45.8 KiB
CCMRAM: 61,180 / 65,536 bytes used, 4,356 bytes free, about 4.3 KiB
FLASH: 1,804,204 / 1,965,056 bytes used, 160,852 bytes free, about 157.1 KiB
The actual RX pool symbol in the built firmware: rx_allocator_buffer is 51,920 bytes. From the old constants it was 10,980 bytes, so this PR adds 40,940 bytes of static main RAM on XBUDDY/XLBUDDY. Even with that increase, the final linked MK4 image still has 46,904 bytes of normal RAM headroom, and the buffer lives in regular RAM, not CCMRAM.

The only caution is that CCMRAM is generally fairly full at 93.35%

If ram usage increase is generally inacceptable (which might be the case), I wrote a PR #5208 for filtering UDP packets instead.