### PR TITLE
Build-System: Add ESP32/ESP8266 build integration into Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,8 @@ if(BOARD IN_LIST BUDDY_BOARDS AND HAS_PUPPIES_BOOTLOADER)
   endif()
 endif()
 
+include(lib/AddEspNicFw.cmake)
+
 # Unittests
 if(UNITTESTS_ENABLE)
   enable_testing()

--- a/lib/AddEspNicFw.cmake
+++ b/lib/AddEspNicFw.cmake
@@ -1,0 +1,136 @@
+# AddEspNicFw.cmake
+#
+# Handles ESP NIC firmware for printers with HAS_ESP_FLASH_TASK.
+#
+# By default the pre-built binaries checked into src/resources/<chip> are used. Set
+# ESP_FW_BINARY_DIR to empty to build the firmware from source via Docker.
+#
+# The Docker image is rebuilt only when the Dockerfile changes; the firmware is rebuilt only when
+# the ESP NIC source files change.
+
+if(NOT HAS_ESP_FLASH_TASK)
+  return()
+endif()
+
+# Derive chip and in-container SDK path from the hardware feature flags.
+if(HAS_EMBEDDED_ESP32)
+  set(ESP_CHIP "esp32")
+  set(ESP_SDK_EXPORT_SH "/esp-idf/export.sh")
+else()
+  set(ESP_CHIP "esp8266")
+  set(ESP_SDK_EXPORT_SH "/ESP8266_RTOS_SDK/export.sh")
+endif()
+
+set(ESP_FW_BINARY_DIR
+    "${CMAKE_SOURCE_DIR}/src/resources/${ESP_CHIP}"
+    CACHE PATH "Directory with ESP NIC firmware binaries (uart_wifi.bin, bootloader.bin, \
+partition-table.bin). Defaults to the pre-built binaries in src/resources. \
+Set to empty to build from source via Docker."
+    )
+
+if(NOT ESP_FW_BINARY_DIR)
+  set(ESP_FW_SOURCE_DIR
+      "${CMAKE_SOURCE_DIR}/lib/${ESP_CHIP}-nic"
+      CACHE PATH "Source directory for the ESP NIC firmware."
+      )
+  set(ESP_FW_BUILD_DIR
+      "${CMAKE_BINARY_DIR}/esp-fw-build"
+      CACHE PATH "Build directory for ESP NIC firmware built from source."
+      )
+endif()
+
+# Source build — only active when ESP_FW_BINARY_DIR is empty and this is a cross-compiled buddy
+# board build.
+if(NOT ESP_FW_BINARY_DIR AND BOARD IN_LIST BUDDY_BOARDS)
+  get_filename_component(
+    ESP_FW_BUILD_DIR "${ESP_FW_BUILD_DIR}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}"
+    )
+  get_filename_component(
+    ESP_FW_SOURCE_DIR "${ESP_FW_SOURCE_DIR}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}"
+    )
+
+  set(_esp_output_dir "${ESP_FW_BUILD_DIR}/output")
+  set(ESP_FW_BINARY_DIR "${_esp_output_dir}")
+  set(_esp_docker_image "buddy-${ESP_CHIP}-nic-build")
+
+  execute_process(
+    COMMAND id -u
+    OUTPUT_VARIABLE _esp_uid
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  execute_process(
+    COMMAND id -g
+    OUTPUT_VARIABLE _esp_gid
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+  # Rebuild the Docker image only when its Dockerfile changes.
+  set(_esp_docker_stamp "${CMAKE_BINARY_DIR}/esp-${ESP_CHIP}-docker.stamp")
+  add_custom_command(
+    OUTPUT "${_esp_docker_stamp}"
+    COMMAND docker build -t "${_esp_docker_image}" "${ESP_FW_SOURCE_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E touch "${_esp_docker_stamp}"
+    DEPENDS "${ESP_FW_SOURCE_DIR}/Dockerfile"
+    COMMENT "Building ${ESP_CHIP} NIC Docker image"
+    VERBATIM
+    )
+
+  # Collect ESP NIC source files for dependency tracking.
+  file(GLOB_RECURSE _esp_sources "${ESP_FW_SOURCE_DIR}/main/*.c" "${ESP_FW_SOURCE_DIR}/main/*.h"
+       "${ESP_FW_SOURCE_DIR}/sdkconfig"
+       )
+  list(APPEND _esp_sources "${ESP_FW_SOURCE_DIR}/CMakeLists.txt")
+
+  # For ESP8266 the flasher stub comes from a separate pre-built esptool repo; copy it into the
+  # output directory so ESP_FW_BINARY_DIR is self-contained.
+  if(NOT HAS_EMBEDDED_ESP32)
+    set(_esp_stub_dir "${CMAKE_SOURCE_DIR}/src/resources/esp8266")
+    set(_esp_copy_stubs
+        COMMAND
+        ${CMAKE_COMMAND}
+        -E
+        copy_if_different
+        "${_esp_stub_dir}/stub_text.bin"
+        "${_esp_output_dir}/stub_text.bin"
+        COMMAND
+        ${CMAKE_COMMAND}
+        -E
+        copy_if_different
+        "${_esp_stub_dir}/stub_data.bin"
+        "${_esp_output_dir}/stub_data.bin"
+        )
+    set(_esp_stub_outputs "${_esp_output_dir}/stub_text.bin" "${_esp_output_dir}/stub_data.bin")
+  else()
+    set(_esp_copy_stubs "")
+    set(_esp_stub_outputs "")
+  endif()
+
+  # Build ESP NIC firmware via Docker, invoking cmake directly. Rebuilds only when source files or
+  # the Dockerfile change.
+  add_custom_command(
+    OUTPUT "${_esp_output_dir}/uart_wifi.bin" "${_esp_output_dir}/bootloader.bin"
+           "${_esp_output_dir}/partition-table.bin" ${_esp_stub_outputs}
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${ESP_FW_BUILD_DIR}"
+    COMMAND
+      docker run --rm --user "${_esp_uid}:${_esp_gid}" -v "${ESP_FW_SOURCE_DIR}:/project" -v
+      "${ESP_FW_BUILD_DIR}:/build" "${_esp_docker_image}" bash -c
+      "source ${ESP_SDK_EXPORT_SH} && cmake -DIDF_TARGET=${ESP_CHIP} -B /build -S /project && cmake --build /build"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${_esp_output_dir}"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${ESP_FW_BUILD_DIR}/uart_wifi.bin"
+            "${_esp_output_dir}/uart_wifi.bin"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${ESP_FW_BUILD_DIR}/bootloader/bootloader.bin"
+            "${_esp_output_dir}/bootloader.bin"
+    COMMAND
+      ${CMAKE_COMMAND} -E copy_if_different
+      "${ESP_FW_BUILD_DIR}/partition_table/partition-table.bin"
+      "${_esp_output_dir}/partition-table.bin" ${_esp_copy_stubs}
+    DEPENDS ${_esp_sources} "${_esp_docker_stamp}"
+    COMMENT "Building ${ESP_CHIP} NIC firmware"
+    USES_TERMINAL VERBATIM
+    )
+
+  add_custom_target(
+    esp-nic-fw ALL DEPENDS "${_esp_output_dir}/uart_wifi.bin" "${_esp_output_dir}/bootloader.bin"
+                           "${_esp_output_dir}/partition-table.bin" ${_esp_stub_outputs}
+    )
+endif()

--- a/lib/esp32-nic/Dockerfile
+++ b/lib/esp32-nic/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:22.04
 
-RUN apt-get update && apt-get -y install \
+RUN apt-get update \
+    && apt-get -y install \
         bash \
         git \
         cmake \
@@ -22,5 +23,13 @@ RUN apt-get update && apt-get -y install \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone -b v5.0.3 --recursive https://github.com/espressif/esp-idf.git
-RUN cd /esp-idf && ./install.sh
-RUN echo "source /esp-idf/export.sh" >> ~/.bashrc
+
+# Install tools into a world-accessible path so the container can be run as
+# an arbitrary non-root user (--user flag) without losing access to the tools.
+# Pin setuptools<82: pkg_resources was removed in setuptools v82, ESP-IDF v5.0 still needs it.
+# Set git safe.directory so export.sh works for non-root users (git >= 2.35.2).
+ENV IDF_TOOLS_PATH=/opt/espressif
+RUN cd /esp-idf && ./install.sh \
+    && /opt/espressif/python_env/idf5.0_py3.10_env/bin/pip install "setuptools<82" \
+    && chmod -R a+rX /opt/espressif \
+    && git config --system --add safe.directory /esp-idf

--- a/lib/esp8266-nic/Dockerfile
+++ b/lib/esp8266-nic/Dockerfile
@@ -1,13 +1,24 @@
 FROM ubuntu:22.04
 
 ENV TZ=Etc/UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-RUN apt-get update
-RUN apt-get -y install bash git cmake python3 python3-pip python3-virtualenv python3-cryptography python3-future python3-click python3-serial python3-wheel python3-pyparsing python3-pyelftools
-# idf.py menuconfig dependencies
-#RUN apt-get -y install gperf flex bison libncurses-dev
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+    && apt-get update \
+    && apt-get -y install \
+        bash \
+        git \
+        cmake \
+        python3 \
+        python3-pip \
+        python3-virtualenv \
+        python3-cryptography \
+        python3-future \
+        python3-click \
+        python3-serial \
+        python3-wheel \
+        python3-pyparsing \
+        python3-pyelftools \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/python3 /usr/bin/python
 
 # Workaround. The repo 2 levels deep got moved, but the redirect is broken and
 # wrong. Needs a bit of manual intervention to fetch from the right place.
@@ -21,5 +32,12 @@ RUN git clone https://github.com/espressif/ESP8266_RTOS_SDK.git \
     && cd ../../.. \
     && git submodule update --init --recursive
 
-RUN cd /ESP8266_RTOS_SDK && PYTHONPATH=/usr/lib/python3.9/site-packages ./install.sh
-RUN echo "source /ESP8266_RTOS_SDK/export.sh" >> ~/.bashrc
+# Install tools into a world-accessible path so the container can be run as
+# an arbitrary non-root user (--user flag) without losing access to the tools.
+# Pin setuptools<82: pkg_resources was removed in setuptools v82, ESP8266_RTOS_SDK still needs it.
+# Set git safe.directory so export.sh works for non-root users (git >= 2.35.2).
+ENV IDF_TOOLS_PATH=/opt/espressif
+RUN cd /ESP8266_RTOS_SDK && PYTHONPATH=/usr/lib/python3.9/site-packages ./install.sh \
+    && find /opt/espressif/python_env -name python3 -type f -exec {} -m pip install "setuptools<82" \; \
+    && chmod -R a+rX /opt/espressif \
+    && git config --system --add safe.directory /ESP8266_RTOS_SDK

--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -51,34 +51,34 @@ add_tar_image(resources-tarball)
 if(HAS_ESP)
   set(ESP_PARTS ${CMAKE_CURRENT_BINARY_DIR}/include/esp_parts.gen)
   if(HAS_EMBEDDED_ESP32)
-    add_resource("esp32/uart_wifi.bin" "/esp/uart_wifi.bin")
-    add_resource("esp32/bootloader.bin" "/esp/bootloader.bin")
-    add_resource("esp32/partition-table.bin" "/esp/partition-table.bin")
+    add_resource("${ESP_FW_BINARY_DIR}/uart_wifi.bin" "/esp/uart_wifi.bin")
+    add_resource("${ESP_FW_BINARY_DIR}/bootloader.bin" "/esp/bootloader.bin")
+    add_resource("${ESP_FW_BINARY_DIR}/partition-table.bin" "/esp/partition-table.bin")
     add_custom_command(
       OUTPUT ${ESP_PARTS}
       COMMAND
         "${Python3_EXECUTABLE}" ${CMAKE_SOURCE_DIR}/utils/gen_esp_parts.py ARGS --output
-        ${ESP_PARTS} --basedir ${CMAKE_CURRENT_SOURCE_DIR}/esp32/ --flash
-        partition-table.bin:0x08000 --flash bootloader.bin:0x01000 --flash uart_wifi.bin:0x10000
-      DEPENDS esp32/uart_wifi.bin esp32/bootloader.bin esp32/partition-table.bin
-              ${CMAKE_SOURCE_DIR}/utils/gen_esp_parts.py
+        ${ESP_PARTS} --basedir ${ESP_FW_BINARY_DIR}/ --flash partition-table.bin:0x08000 --flash
+        bootloader.bin:0x01000 --flash uart_wifi.bin:0x10000
+      DEPENDS ${ESP_FW_BINARY_DIR}/uart_wifi.bin ${ESP_FW_BINARY_DIR}/bootloader.bin
+              ${ESP_FW_BINARY_DIR}/partition-table.bin ${CMAKE_SOURCE_DIR}/utils/gen_esp_parts.py
       )
   else()
-    add_resource("esp8266/uart_wifi.bin" "/esp/uart_wifi.bin")
-    add_resource("esp8266/bootloader.bin" "/esp/bootloader.bin")
-    add_resource("esp8266/partition-table.bin" "/esp/partition-table.bin")
-    add_resource("esp8266/stub_text.bin" "/esp/stub_text.bin")
-    add_resource("esp8266/stub_data.bin" "/esp/stub_data.bin")
+    add_resource("${ESP_FW_BINARY_DIR}/uart_wifi.bin" "/esp/uart_wifi.bin")
+    add_resource("${ESP_FW_BINARY_DIR}/bootloader.bin" "/esp/bootloader.bin")
+    add_resource("${ESP_FW_BINARY_DIR}/partition-table.bin" "/esp/partition-table.bin")
+    add_resource("${ESP_FW_BINARY_DIR}/stub_text.bin" "/esp/stub_text.bin")
+    add_resource("${ESP_FW_BINARY_DIR}/stub_data.bin" "/esp/stub_data.bin")
     add_custom_command(
       OUTPUT ${ESP_PARTS}
       COMMAND
         "${Python3_EXECUTABLE}" ${CMAKE_SOURCE_DIR}/utils/gen_esp_parts.py ARGS --output
-        ${ESP_PARTS} --basedir ${CMAKE_CURRENT_SOURCE_DIR}/esp8266/ --flash
-        partition-table.bin:0x08000 --flash bootloader.bin:0x00000 --flash uart_wifi.bin:0x10000
-        --memory stub_text.bin:0x4010d000 --memory stub_data.bin:0x3fff01b4
-      DEPENDS esp8266/uart_wifi.bin esp8266/bootloader.bin esp8266/partition-table.bin
-              esp8266/stub_text.bin esp8266/stub_data.bin
-              ${CMAKE_SOURCE_DIR}/utils/gen_esp_parts.py
+        ${ESP_PARTS} --basedir ${ESP_FW_BINARY_DIR}/ --flash partition-table.bin:0x08000 --flash
+        bootloader.bin:0x00000 --flash uart_wifi.bin:0x10000 --memory stub_text.bin:0x4010d000
+        --memory stub_data.bin:0x3fff01b4
+      DEPENDS ${ESP_FW_BINARY_DIR}/uart_wifi.bin ${ESP_FW_BINARY_DIR}/bootloader.bin
+              ${ESP_FW_BINARY_DIR}/partition-table.bin ${ESP_FW_BINARY_DIR}/stub_text.bin
+              ${ESP_FW_BINARY_DIR}/stub_data.bin ${CMAKE_SOURCE_DIR}/utils/gen_esp_parts.py
       )
   endif()
   add_custom_target(esp-parts DEPENDS ${ESP_PARTS})


### PR DESCRIPTION
This integrates building the esp32/esp8266 wifi firmware into the existing cmake ecosystem, but using Docker for compiling the wifi firmware. For that, ESP_FW_BINARY_DIR was introduced. By default is uses the already precompiled wifi binary paths and thus the docker build system won't be run. In order to run Docker and force building the wifi firmware, it is thus required to use ESP_FW_BINARY_DIR=""

Example:
```shell
cmake --preset coreone_release_boot -B build -DESP_FW_BINARY_DIR=""
cmake --build build
```