### PR TITLE
[BFW-8560] gcode: M24 provide proper file path for print_start

### DIFF
--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -1763,7 +1763,7 @@ void print_resume(void) {
         server.print_state = State::PowerPanic_Resume;
 #endif
     } else {
-        print_start(nullptr, GCodeReaderPosition(), marlin_server::PreviewSkipIfAble::all);
+        print_start(marlin_vars().media_SFN_path.get_ptr(), GCodeReaderPosition(), marlin_server::PreviewSkipIfAble::all);
     }
 }
 


### PR DESCRIPTION
This fixes issue #5004.

The bug is in `src/common/marlin_server.cpp` in the print_resume() function (line 1766):
When M24 is called and the printer is not in a paused/resuming state (i.e., starting a new print), the code falls through to the else branch which calls:
`print_start(nullptr, GCodeReaderPosition(), marlin_server::PreviewSkipIfAble::all);`
However, print_start() has an early return at line 1243-1245:

```
if (filename == nullptr) {
    return;
}
```

This causes the print to silently fail because:

M23 <filename> correctly stores the selected file path in "marlin_vars().media_SFN_path"
M24 then calls print_resume() which calls print_start(nullptr, ...)
print_start() immediately returns due to the nullptr check and thus the print never actually starts