### PR TITLE
[BFW-5760] Prusalink: Add support for setting ready state via api

### DIFF
--- a/lib/WUI/link_content/basic_gets.cpp
+++ b/lib/WUI/link_content/basic_gets.cpp
@@ -3,6 +3,7 @@
 #include "marlin_client.hpp"
 #include "lwip/init.h"
 #include "netdev.h"
+#include "wui_api.h"
 #include <config_store/store_instance.hpp>
 #include <option/has_tool_mapping.h>
 
@@ -484,6 +485,18 @@ JsonResult get_storage(size_t resume_point, JsonOutput &output) {
                 JSON_OBJ_END;
             JSON_ARR_END;
         JSON_OBJ_END;
+    JSON_END;
+    // clang-format on
+}
+
+JsonResult get_ready(size_t resume_point, JsonOutput &output) {
+    bool ready = wui_is_printer_ready();
+    // Keep the indentation of the JSON in here!
+    // clang-format off
+    JSON_START;
+    JSON_OBJ_START;
+        JSON_FIELD_BOOL("ready", ready);
+    JSON_OBJ_END;
     JSON_END;
     // clang-format on
 }

--- a/lib/WUI/link_content/basic_gets.h
+++ b/lib/WUI/link_content/basic_gets.h
@@ -30,5 +30,6 @@ json::JsonResult get_job_octoprint(size_t resume_point, json::JsonOutput &output
 json::JsonResult get_job_v1(size_t resume_point, json::JsonOutput &output);
 json::JsonResult get_storage(size_t resume_point, json::JsonOutput &output);
 json::JsonResult get_info(size_t resume_point, json::JsonOutput &output);
+json::JsonResult get_ready(size_t resume_point, json::JsonOutput &output);
 
 } // namespace nhttp::link_content

--- a/lib/WUI/link_content/prusa_link_api_v1.cpp
+++ b/lib/WUI/link_content/prusa_link_api_v1.cpp
@@ -173,6 +173,32 @@ Selector::Accepted PrusaLinkApiV1::accept(const RequestParser &parser, handler::
             out.next = StatusPage(Status::NoContent, parser);
             return Accepted::Accepted;
         }
+    } else if (suffix == "ready") {
+        switch (parser.method) {
+        case Method::Get: {
+            // Return the current ready state
+            get_only(SendJson(EmptyRenderer(get_ready), parser.can_keep_alive()), parser, out);
+            return Accepted::Accepted;
+        }
+        case Method::Put: {
+            // Set the printer as ready
+            if (wui_set_printer_ready(true)) {
+                out.next = StatusPage(Status::NoContent, parser);
+            } else {
+                out.next = StatusPage(Status::Conflict, parser);
+            }
+            return Accepted::Accepted;
+        }
+        case Method::Delete: {
+            // Unset the printer ready state
+            wui_set_printer_ready(false);
+            out.next = StatusPage(Status::NoContent, parser);
+            return Accepted::Accepted;
+        }
+        default:
+            out.next = StatusPage(Status::MethodNotAllowed, StatusPage::CloseHandling::ErrorClose, parser.accepts_json);
+            return Accepted::Accepted;
+        }
     } else if (remove_prefix(suffix, "files").has_value()) {
         static const auto prefix = "/api/v1/files";
         static const size_t prefix_len = strlen(prefix);

--- a/lib/WUI/nhttp/status_renderer.cpp
+++ b/lib/WUI/nhttp/status_renderer.cpp
@@ -5,11 +5,7 @@
 #include <state/printer_state.hpp>
 #include <transfers/monitor.hpp>
 #include <segmented_json_macros.h>
-
-#include <option/buddy_enable_connect.h>
-#if BUDDY_ENABLE_CONNECT()
-    #include <connect/connect.hpp>
-#endif
+#include <wui_api.h>
 
 using namespace marlin_server;
 using transfers::Monitor;
@@ -27,7 +23,7 @@ json::JsonResult StatusRenderer::renderState(size_t resume_point, json::JsonOutp
 
     uint32_t time_to_end = marlin_vars().time_to_end;
     uint32_t time_to_pause = marlin_vars().time_to_pause;
-    auto link_state = printer_state::get_state(false);
+    auto link_state = printer_state::get_state(wui_is_printer_ready());
 
     // Keep the indentation of the JSON in here!
     // clang-format off

--- a/lib/WUI/wui_api.cpp
+++ b/lib/WUI/wui_api.cpp
@@ -18,6 +18,11 @@
 #include <lfn.h>
 #include <state/printer_state.hpp>
 
+#include <option/buddy_enable_connect.h>
+#if BUDDY_ENABLE_CONNECT()
+    #include <connect/marlin_printer.hpp>
+#endif
+
 #include <cassert>
 #include <ctime>
 #include <cstring>
@@ -325,4 +330,21 @@ bool wui_is_file_being_printed(const char *filename) {
 
 bool wui_media_inserted() {
     return marlin_vars().media_inserted;
+}
+
+bool wui_is_printer_ready() {
+#if BUDDY_ENABLE_CONNECT()
+    return connect_client::MarlinPrinter::is_printer_ready();
+#else
+    return false;
+#endif
+}
+
+bool wui_set_printer_ready(bool ready) {
+#if BUDDY_ENABLE_CONNECT()
+    return connect_client::MarlinPrinter::set_printer_ready(ready);
+#else
+    (void)ready;
+    return false;
+#endif
 }

--- a/lib/WUI/wui_api.h
+++ b/lib/WUI/wui_api.h
@@ -176,6 +176,20 @@ bool wui_is_file_being_printed(const char *filename);
 
 bool wui_media_inserted();
 
+////////////////////////////////////////////////////////////////////////////
+/// @brief Check if the printer is marked as ready for remote printing
+///
+/// @return true if the printer is ready, false otherwise
+bool wui_is_printer_ready();
+
+////////////////////////////////////////////////////////////////////////////
+/// @brief Set or unset the printer ready state for remote printing
+///
+/// @param[in] ready true to set ready, false to unset
+/// @return true if the operation succeeded, false if it was not possible
+///         (e.g., trying to set ready while printing)
+bool wui_set_printer_ready(bool ready);
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus


### PR DESCRIPTION
This solves issue #3640 and implements setting ready state via rest api.

Examples : 
```
# Get ready status
GET /api/v1/ready
# Response: {"ready": true}

# Set printer as ready
PUT /api/v1/ready
# Response: 204 No Content (or 409 Conflict if not possible)

# Unset printer ready
DELETE /api/v1/ready
# Response: 204 No Content

# Check status includes ready state
GET /api/v1/status
# Response includes: "printer": {"state": "READY", ...}
```

Implementations in Prusa-Link-Web are prepared, but optional : https://github.com/prusa3d/Prusa-Link-Web/pull/526
