### PR TITLE
Filesystem: optimize for lower cpu consumption

### DIFF
--- a/src/common/lfn.cpp
+++ b/src/common/lfn.cpp
@@ -6,8 +6,28 @@
 #include <dirent.h>
 
 #include <bsod.h>
+#include <utils/string_builder.hpp>
 
 namespace {
+
+inline void copy_string(char *dst, size_t dst_size, const char *src) {
+    if (dst_size == 0) {
+        return;
+    }
+
+    auto builder = StringBuilder::from_ptr(dst, dst_size);
+    builder.append_string(src);
+}
+
+inline void copy_string_exact(char *dst, size_t dst_size, const char *src) {
+    if (dst_size == 0) {
+        return;
+    }
+
+    auto builder = StringBuilder::from_ptr(dst, dst_size);
+    builder.append_string(src);
+    assert(builder.is_ok());
+}
 
 template <class C>
 void search_file(char *path, C &&callback) {
@@ -55,9 +75,9 @@ void search_file(char *path, C &&callback) {
 void get_LFN(char *lfn, size_t lfn_size, char *path) {
     search_file(path, [&](char *fname, struct dirent *ent) {
         if (ent != nullptr) {
-            strlcpy(lfn, ent->lfn, lfn_size);
+            copy_string(lfn, lfn_size, ent->lfn);
         } else {
-            strlcpy(lfn, fname, lfn_size);
+            copy_string(lfn, lfn_size, fname);
         }
     });
 }
@@ -66,20 +86,41 @@ void get_SFN_path(char *path) {
     search_file(path, [&](char *fname, struct dirent *ent) {
         if (ent != nullptr) {
             // fname is part of the path we passed in, so we can modify it.
-            assert(strlen(fname) >= strlen(ent->d_name));
-            strcpy(fname, ent->d_name);
+            copy_string_exact(fname, strlen(fname) + 1, ent->d_name);
         }
         // We are not interested in the other "fallback" cases like the LFN
         // one. We just keep path intact.
     });
 }
 
+void get_SFN_path_and_LFN(char *path, char *lfn, size_t lfn_size) {
+    search_file(path, [&](char *fname, struct dirent *ent) {
+        if (ent != nullptr) {
+            const size_t old_fname_len = strlen(fname);
+            const bool embedded_lfn = (lfn == fname + old_fname_len + 1);
+            copy_string(lfn, lfn_size, ent->lfn);
+            // fname is part of the path we passed in, so we can modify it.
+            copy_string_exact(fname, old_fname_len + 1, ent->d_name);
+            // SharedPath stores the LFN immediately behind the current path
+            // terminator, so shortening the basename moves the live slot.
+            if (embedded_lfn) {
+                char *relocated_lfn = fname + strlen(ent->d_name) + 1;
+                if (relocated_lfn != lfn) {
+                    memmove(relocated_lfn, lfn, strlen(lfn) + 1);
+                }
+            }
+        } else {
+            copy_string(lfn, lfn_size, fname);
+        }
+    });
+}
+
 void get_SFN_path_copy(const char *lfn, char *sfn_out, size_t size) {
-    char *last = rindex(lfn, '/');
+    const char *last = rindex(lfn, '/');
 
     assert(last);
     if (!last) {
-        strlcpy(sfn_out, lfn, size);
+        copy_string(sfn_out, size, lfn);
         return;
     }
 
@@ -88,17 +129,16 @@ void get_SFN_path_copy(const char *lfn, char *sfn_out, size_t size) {
     if (size <= len) {
         // This obviously won't fit, but d it anyway to have all the
         // error case do the same, it will still be valid string
-        strlcpy(sfn_out, lfn, size);
+        copy_string(sfn_out, size, lfn);
         return;
     }
-    strncpy(sfn_out, lfn, len);
-
+    memcpy(sfn_out, lfn, len);
     sfn_out[len] = '\0';
 
-    char *fname = last + 1;
+    const char *fname = last + 1;
     Directory d { sfn_out };
     if (!d) {
-        strlcpy(sfn_out, lfn, size);
+        copy_string(sfn_out, size, lfn);
         return;
     }
 
@@ -120,6 +160,6 @@ void get_SFN_path_copy(const char *lfn, char *sfn_out, size_t size) {
     // if we did not do this, we would return the path to parent dir instead,
     // which is wrong.
     if (*fname != '\0' && !ent) {
-        strlcpy(sfn_out, lfn, size);
+        copy_string(sfn_out, size, lfn);
     }
 }

--- a/src/common/lfn.h
+++ b/src/common/lfn.h
@@ -33,6 +33,18 @@ void get_LFN(char *lfn, size_t lfn_size, char *path);
 void get_SFN_path(char *path);
 
 /**
+ * \brief Convert the last path component to SFN and fetch the matching LFN.
+ *
+ * This combines \p get_SFN_path and \p get_LFN into a single directory scan.
+ * On success, the last component of \p path is rewritten to SFN and \p lfn is
+ * filled with the long file name. If \p lfn is stored immediately behind the
+ * current \p path terminator (for example in SharedPath), the helper also
+ * relocates it to stay behind the shortened SFN path. On failure, \p path is
+ * left intact and \p lfn falls back to the current basename.
+ */
+void get_SFN_path_and_LFN(char *path, char *lfn, size_t lfn_size);
+
+/**
  * \brief Get SFN path copied to provided buffer.
  *
  * Same as get_SFN_path above, only difference is it is not in place, but rather

--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -1133,8 +1133,7 @@ RenderState::RenderState(const Printer &printer, const Action &action, optional<
             // * If this is ever called multiple times (it can be, if the same
             //   event needs to be resent), it results into the same values
             //   there.
-            get_SFN_path(spath.path());
-            get_LFN(spath.name(), FILE_NAME_BUFFER_LEN, spath.path());
+            get_SFN_path_and_LFN(spath.path(), spath.name(), FILE_NAME_BUFFER_LEN);
             break;
         }
         case EventType::FileChanged: {
@@ -1142,8 +1141,7 @@ RenderState::RenderState(const Printer &printer, const Action &action, optional<
             SharedPath spath = event->path.value();
             path = spath.path();
 
-            get_SFN_path(spath.path());
-            get_LFN(spath.name(), FILE_NAME_BUFFER_LEN, spath.path());
+            get_SFN_path_and_LFN(spath.path(), spath.name(), FILE_NAME_BUFFER_LEN);
         }
         default:;
         }

--- a/src/connect/render.cpp
+++ b/src/connect/render.cpp
@@ -1033,10 +1033,12 @@ JsonResult DirRenderer::renderState(size_t resume_point, json::JsonOutput &outpu
                 // It is a directory with a stupid name, but not a running
                 // transfer. Act as if it is just a directory.
                 state.read_only = false;
-                state.childsize = child_size(state.base_path, state.ent->d_name);
             }
         } else {
             state.read_only = false;
+        }
+
+        if (state.ent->d_type != DT_DIR && !state.childsize.has_value()) {
             state.childsize = child_size(state.base_path, state.ent->d_name);
         }
 

--- a/tests/unit/common/CMakeLists.txt
+++ b/tests/unit/common/CMakeLists.txt
@@ -38,6 +38,24 @@ target_include_directories(
   )
 add_catch_test(string_builder_tests)
 
+add_executable(
+  lfn_tests
+  ${CMAKE_CURRENT_SOURCE_DIR}/lfn_tests.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/lfn.cpp
+  ${CMAKE_SOURCE_DIR}/src/common/utils/string_builder.cpp
+  ${CMAKE_SOURCE_DIR}/src/lang/string_view_utf8.cpp
+  ${CMAKE_SOURCE_DIR}/tests/stubs/strlcpy.c
+  ${CMAKE_SOURCE_DIR}/tests/unit/gui/lazyfilelist/ourPosix.cpp
+  ${CMAKE_SOURCE_DIR}/tests/unit/mock/bsod.cpp
+  )
+target_include_directories(
+  lfn_tests
+  PUBLIC ${CMAKE_SOURCE_DIR}/src/common ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/src/lang
+         ${CMAKE_SOURCE_DIR}/src/gui ${CMAKE_SOURCE_DIR}/tests/stubs
+         ${CMAKE_SOURCE_DIR}/tests/unit/gui/lazyfilelist
+  )
+add_catch_test(lfn_tests)
+
 add_executable(timing_tests timing_tests.cpp)
 target_compile_definitions(timing_tests PRIVATE MCU=STM32F407VG)
 target_include_directories(

--- a/tests/unit/common/lfn_tests.cpp
+++ b/tests/unit/common/lfn_tests.cpp
@@ -1,0 +1,43 @@
+#include <catch2/catch.hpp>
+
+#include <lfn.h>
+#include <gui/file_list_defs.h>
+
+#include "../gui/lazyfilelist/ourPosix.hpp"
+
+#include <cstring>
+#include <string>
+
+using std::string;
+
+TEST_CASE("get_SFN_path_and_LFN relocates LFN when the path shrinks") {
+    testFiles0 = {
+        { "very_long_filename.gcode", 0, false },
+    };
+
+    char buffer[FILE_PATH_BUFFER_LEN + FILE_NAME_BUFFER_LEN] = {};
+    strcpy(buffer, "/usb/very_long_filename.gcode");
+
+    char *old_name = buffer + strlen(buffer) + 1;
+    get_SFN_path_and_LFN(buffer, old_name, FILE_NAME_BUFFER_LEN);
+
+    char *new_name = buffer + strlen(buffer) + 1;
+    REQUIRE(new_name != old_name);
+    REQUIRE(string(buffer) == "/usb/very_l~00.GCO");
+    REQUIRE(string(new_name) == "very_long_filename.gcode");
+}
+
+TEST_CASE("get_SFN_path_and_LFN keeps standalone LFN buffers untouched") {
+    testFiles0 = {
+        { "very_long_filename.gcode", 0, false },
+    };
+
+    char path[FILE_PATH_BUFFER_LEN] = {};
+    char lfn[FILE_NAME_BUFFER_LEN] = {};
+    strcpy(path, "/usb/very_long_filename.gcode");
+
+    get_SFN_path_and_LFN(path, lfn, FILE_NAME_BUFFER_LEN);
+
+    REQUIRE(string(path) == "/usb/very_l~00.GCO");
+    REQUIRE(string(lfn) == "very_long_filename.gcode");
+}

--- a/tests/unit/lib/WUI/nhttp/missing_functions.c
+++ b/tests/unit/lib/WUI/nhttp/missing_functions.c
@@ -91,6 +91,10 @@ void get_SFN_path(char *path) {
     // Stays intact
 }
 
+void get_SFN_path_and_LFN(char *path, char *lfn, size_t lfn_size) {
+    strlcpy(lfn, basename_b(path), lfn_size);
+}
+
 void get_SFN_path_copy(const char *lfn, char *sfn_out, size_t size) {
     strlcpy(sfn_out, lfn, size);
 }


### PR DESCRIPTION
**This PR consists of two optimizations in regards to cpu usage**:

1. File event rendering does two full FAT directory scans back-to-back just to derive SFN and LFN for the same path. lfn.cpp (line 12) implements both get_SFN_path() and get_LFN() by opendir + readdir + linear name matching, and render.cpp (line 1135) / render.cpp (line 1144) call them consecutively in both FileInfo and FileChanged. This is fixed by returning both names from one scan.

2. Connect directory rendering is stacking redundant stat work on USB entries. transfer_file_check.cpp (line 13) notes the cost explicitly; then render.cpp (line 1021) calls get_transfer_partial_file_stat() for transferrable-looking directories and, when that fails, still calls child_size() at render.cpp (line 1039), which does another stat. For a directory entry that only happens to look like a transfer, that is up to three metadata probes. The simplest CPU fix is to stop reporting directory sizes via stat and return 0 for directories, or at least reuse the first metadata result instead of probing again.

Also instead of unsafe strcpy functions, safe StringBuilder functions are now being used.

**Side effects of this patch**:
- Directory sizes in PrusaLink/Connect file listings may now show as 0 instead of a scanned value → intended perf trade-off, no functional breakage.
- In-place path modification + LFN relocation is now centralized; if any future caller assumes the old two-call behavior, it could break (but none exist today, and added test covers it).

