### PR TITLE
feat(wui): Add unified POST /api/v1/control endpoint

### DIFF
--- a/lib/WUI/CMakeLists.txt
+++ b/lib/WUI/CMakeLists.txt
@@ -24,6 +24,8 @@ target_sources(
             nhttp/headers.cpp
             nhttp/job_command.cpp
             nhttp/job_command_marlin.cpp
+            nhttp/control_command.cpp
+            nhttp/control_command_marlin.cpp
             nhttp/req_parser.cpp
             nhttp/send_file.cpp
             nhttp/send_json.cpp

--- a/lib/WUI/link_content/prusa_link_api_v1.cpp
+++ b/lib/WUI/link_content/prusa_link_api_v1.cpp
@@ -5,6 +5,7 @@
 #include "../nhttp/headers.h"
 #include "../nhttp/gcode_upload.h"
 #include "../nhttp/job_command.h"
+#include "../nhttp/control_command.h"
 #include "../nhttp/send_json.h"
 #include "../nhttp/status_renderer.h"
 #include "../wui_api.h"
@@ -114,6 +115,17 @@ Selector::Accepted PrusaLinkApiV1::accept(const RequestParser &parser, handler::
 
     if (suffix == "storage") {
         get_only(SendJson(EmptyRenderer(get_storage), parser.can_keep_alive()), parser, out);
+        return Accepted::Accepted;
+    } else if (suffix == "control") {
+        if (parser.method == Method::Post) {
+            if (parser.content_length.has_value()) {
+                out.next = nhttp::printer::ControlCommand(*parser.content_length, parser.can_keep_alive(), parser.accepts_json);
+            } else {
+                out.next = StatusPage(Status::LengthRequired, StatusPage::CloseHandling::ErrorClose, parser.accepts_json);
+            }
+        } else {
+            out.next = StatusPage(Status::MethodNotAllowed, StatusPage::CloseHandling::ErrorClose, parser.accepts_json);
+        }
         return Accepted::Accepted;
     } else if (suffix == "info") {
         get_only(SendJson(EmptyRenderer(get_info), parser.can_keep_alive()), parser, out);

--- a/lib/WUI/nhttp/control_command.cpp
+++ b/lib/WUI/nhttp/control_command.cpp
@@ -1,0 +1,207 @@
+#include "control_command.h"
+#include "handler.h"
+#include "json_parser.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <cmath>
+#include <optional>
+
+namespace nhttp::printer {
+
+using namespace handler;
+using http::Status;
+using json::Event;
+using json::Type;
+using std::nullopt;
+using std::optional;
+using std::string_view;
+
+ControlCommand::ControlCommand(size_t content_length, bool can_keep_alive, bool json_errors)
+    : content_length(content_length)
+    , can_keep_alive(can_keep_alive)
+    , json_errors(json_errors) {
+    memset(buffer.data(), 0, buffer.size());
+}
+
+StatusPage ControlCommand::process() {
+    optional<int> nozzle;
+    optional<int> bed;
+    optional<int> chamber;
+    optional<int> speed;
+    optional<int> flow;
+    optional<int> fan_print;
+    optional<int> chamber_fan;
+    optional<int> led;
+
+    bool do_home = false, home_x = false, home_y = false, home_z = false;
+    optional<float> move_x, move_y, move_z, move_e;
+    optional<int> feedrate;
+
+    bool do_load_filament = false, do_unload_filament = false;
+    bool do_purge = false, do_filament_change = false;
+    bool do_cooldown = false, do_motors_off = false;
+    bool do_stop = false, do_reboot = false;
+    // String fields need null-terminated copies. The JSON parser returns
+    // string_views with explicit length pointing into the request buffer
+    // (NOT null-terminated). Anything that subsequently reads until \0
+    // picks up trailing JSON syntax (e.g. the closing quote/brace) — for
+    // gcode this leaks into echo:enqueueing output, for dialog_response
+    // it breaks the exact-match Response lookup.
+    char gcode_cmd_buf[120] = { 0 };  // M-code lines are short; cap with margin
+    bool gcode_cmd_set = false;
+    char dialog_btn_buf[32] = { 0 };
+    bool dialog_btn_set = false;
+
+    bool got_any_field = false;
+
+    const auto parse_result = parse_command(reinterpret_cast<char *>(buffer.data()), buffer_used, [&](const Event &event) {
+        if (event.depth != 1) {
+            return;
+        }
+        const auto &key = event.key.value();
+        const auto &val = event.value.value();
+
+        if (event.type == Type::String) {
+            if (key == "gcode") {
+                const size_t copy_len = std::min(val.size(), sizeof(gcode_cmd_buf) - 1);
+                memcpy(gcode_cmd_buf, val.data(), copy_len);
+                gcode_cmd_buf[copy_len] = '\0';
+                gcode_cmd_set = true;
+                got_any_field = true;
+            } else if (key == "dialog_response") {
+                const size_t copy_len = std::min(val.size(), sizeof(dialog_btn_buf) - 1);
+                memcpy(dialog_btn_buf, val.data(), copy_len);
+                dialog_btn_buf[copy_len] = '\0';
+                dialog_btn_set = true;
+                got_any_field = true;
+            }
+            return;
+        }
+
+        if (event.type == Type::Primitive) {
+            if (val == "true") {
+                if (key == "home") { do_home = true; home_x = home_y = home_z = true; }
+                else if (key == "home_x") { do_home = true; home_x = true; }
+                else if (key == "home_y") { do_home = true; home_y = true; }
+                else if (key == "home_z") { do_home = true; home_z = true; }
+                else if (key == "load_filament") { do_load_filament = true; }
+                else if (key == "unload_filament") { do_unload_filament = true; }
+                else if (key == "purge") { do_purge = true; }
+                else if (key == "filament_change") { do_filament_change = true; }
+                else if (key == "cooldown") { do_cooldown = true; }
+                else if (key == "motors_off") { do_motors_off = true; }
+                else if (key == "stop") { do_stop = true; }
+                else if (key == "reboot") { do_reboot = true; }
+                got_any_field = true;
+                return;
+            }
+            if (val == "false") {
+                got_any_field = true;
+                return;
+            }
+
+            bool is_float = false;
+            for (auto c : val) {
+                if (c == '.') { is_float = true; break; }
+            }
+
+            if (is_float) {
+                float fval = strtof(val.data(), nullptr);
+                if (key == "move_x") { move_x = fval; }
+                else if (key == "move_y") { move_y = fval; }
+                else if (key == "move_z") { move_z = fval; }
+                else if (key == "move_e") { move_e = fval; }
+            } else {
+                int ival = atoi(val.data());
+                if (key == "nozzle") { nozzle = ival; }
+                else if (key == "bed") { bed = ival; }
+                else if (key == "chamber") { chamber = ival; }
+                else if (key == "speed") { speed = ival; }
+                else if (key == "flow") { flow = ival; }
+                else if (key == "fan_print") { fan_print = ival; }
+                else if (key == "chamber_fan") { chamber_fan = ival; }
+                else if (key == "led") { led = ival; }
+                else if (key == "feedrate") { feedrate = ival; }
+                else if (key == "move_x") { move_x = static_cast<float>(ival); }
+                else if (key == "move_y") { move_y = static_cast<float>(ival); }
+                else if (key == "move_z") { move_z = static_cast<float>(ival); }
+                else if (key == "move_e") { move_e = static_cast<float>(ival); }
+            }
+            got_any_field = true;
+        }
+    });
+
+    switch (parse_result) {
+    case JsonParseResult::ErrMem:
+        return StatusPage(Status::PayloadTooLarge, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, nullopt, "Too many JSON tokens");
+    case JsonParseResult::ErrReq:
+        return StatusPage(Status::BadRequest, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, nullopt, "Couldn't parse JSON");
+    case JsonParseResult::Ok:
+        break;
+    }
+
+    if (!got_any_field) {
+        return StatusPage(Status::BadRequest, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors, nullopt, "No control fields provided");
+    }
+
+    if (do_stop) {
+        emergency_stop();
+        return StatusPage(Status::NoContent, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
+    }
+
+    if (nozzle.has_value()) set_nozzle_temp(*nozzle);
+    if (bed.has_value()) set_bed_temp(*bed);
+    if (chamber.has_value()) set_chamber_temp(*chamber);
+    if (speed.has_value()) set_speed(*speed);
+    if (flow.has_value()) set_flow(*flow);
+    if (fan_print.has_value()) set_fan_print(*fan_print);
+    if (chamber_fan.has_value()) set_chamber_fan(*chamber_fan);
+    if (led.has_value()) set_led(*led);
+
+    if (do_load_filament) load_filament();
+    if (do_unload_filament) unload_filament();
+    if (do_purge) purge();
+    if (do_filament_change) filament_change();
+    if (do_cooldown) cooldown();
+    if (do_motors_off) motors_off();
+
+    if (do_home) home_axes(home_x, home_y, home_z);
+    if (move_x.has_value() || move_y.has_value() || move_z.has_value() || move_e.has_value()) {
+        relative_move(move_x.value_or(0), move_y.value_or(0), move_z.value_or(0), move_e.value_or(0), feedrate.value_or(1000));
+    }
+
+    if (gcode_cmd_set) send_gcode(gcode_cmd_buf);
+    if (dialog_btn_set) dialog_response(dialog_btn_buf);
+    if (do_reboot) reboot();
+
+    return StatusPage(Status::NoContent, can_keep_alive ? StatusPage::CloseHandling::KeepAlive : StatusPage::CloseHandling::Close, json_errors);
+}
+
+void ControlCommand::step(string_view input, bool terminated_by_client, uint8_t *, size_t, Step &out) {
+    if (content_length > buffer.size()) {
+        out = Step { 0, 0, StatusPage(Status::PayloadTooLarge, StatusPage::CloseHandling::ErrorClose, json_errors) };
+        return;
+    }
+
+    const size_t rest = content_length - buffer_used;
+    const size_t to_read = std::min(input.size(), rest);
+
+    memcpy(buffer.data() + buffer_used, input.data(), to_read);
+    buffer_used += to_read;
+
+    if (content_length > buffer_used) {
+        if (terminated_by_client) {
+            out = Step { to_read, 0, StatusPage(Status::BadRequest, StatusPage::CloseHandling::ErrorClose, json_errors, nullopt, "Truncated request") };
+            return;
+        } else {
+            out = Step { to_read, 0, Continue() };
+            return;
+        }
+    }
+
+    out = Step { to_read, 0, process() };
+}
+
+} // namespace nhttp::printer

--- a/lib/WUI/nhttp/control_command.h
+++ b/lib/WUI/nhttp/control_command.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "status_page.h"
+
+#include <http/types.h>
+
+#include <array>
+#include <string_view>
+
+namespace nhttp::printer {
+
+/**
+ * \brief Handler for POST /api/v1/control — unified printer control endpoint.
+ *
+ * Accepts a JSON body with any combination of optional fields.
+ * All fields are optional — omitted fields leave the printer state unchanged.
+ *
+ * Temperatures:
+ *   "nozzle": 215        - nozzle target (M104), 0 = off
+ *   "bed": 60            - bed target (M140), 0 = off
+ *   "chamber": 40        - chamber target, 0 = off
+ *
+ * Print parameters:
+ *   "speed": 100         - print speed % (M220)
+ *   "flow": 100          - flow rate % (M221)
+ *
+ * Fans:
+ *   "fan_print": 255     - print fan PWM 0-255 (M106/M107)
+ *   "chamber_fan": 50    - chamber fan PWM %, -1 = auto
+ *
+ * Lighting:
+ *   "led": 100           - chamber LED intensity 0-100 %
+ *
+ * Motion:
+ *   "home": true         - home all axes (G28)
+ *   "home_x": true       - home X axis
+ *   "home_y": true       - home Y axis
+ *   "home_z": true       - home Z axis
+ *   "move_x": 10.0       - relative X move [mm]
+ *   "move_y": 10.0       - relative Y move [mm]
+ *   "move_z": 5.0        - relative Z move [mm]
+ *   "move_e": 5.0        - relative extrude [mm]
+ *   "feedrate": 1000     - feedrate for moves [mm/min]
+ *
+ * Filament:
+ *   "load_filament": true
+ *   "unload_filament": true
+ *   "purge": true
+ *   "filament_change": true
+ *
+ * State:
+ *   "cooldown": true     - all heaters + fans off
+ *   "motors_off": true   - disable steppers (M18)
+ *   "stop": true         - emergency stop (M112)
+ *   "reboot": true       - reboot printer (M997)
+ *
+ * G-code:
+ *   "gcode": "M220 S100" - send arbitrary G-code command
+ *
+ * Dialog response:
+ *   "dialog_response": "Continue" - respond to active dialog (button name).
+ *                       Mirrors the buttons reported in the "dialog" object
+ *                       of /api/v1/status. Mapped to Response enum values
+ *                       like "Continue", "Yes", "No", "Abort", "Print", "PRINT".
+ */
+class ControlCommand {
+private:
+    static const constexpr size_t BUFFER_LEN = 256;
+    std::array<uint8_t, BUFFER_LEN> buffer;
+    size_t buffer_used = 0;
+    size_t content_length;
+    bool can_keep_alive;
+    bool json_errors;
+
+    handler::StatusPage process();
+
+    void set_nozzle_temp(int temp);
+    void set_bed_temp(int temp);
+    void set_chamber_temp(int temp);
+    void set_speed(int percent);
+    void set_flow(int percent);
+    void set_fan_print(int pwm);
+    void set_chamber_fan(int percent);
+    void set_led(int percent);
+    void home_axes(bool x, bool y, bool z);
+    void relative_move(float x, float y, float z, float e, int feedrate);
+    void load_filament();
+    void unload_filament();
+    void purge();
+    void filament_change();
+    void cooldown();
+    void motors_off();
+    void emergency_stop();
+    void reboot();
+    void send_gcode(const char *gcode);
+    void dialog_response(const char *button_name);
+
+public:
+    ControlCommand(size_t content_length, bool can_keep_alive, bool json_errors);
+    bool want_read() const { return true; }
+    bool want_write() const { return false; }
+    void step(std::string_view input, bool terminated_by_client, uint8_t *buffer, size_t buffer_size, handler::Step &out);
+};
+
+} // namespace nhttp::printer

--- a/lib/WUI/nhttp/control_command_marlin.cpp
+++ b/lib/WUI/nhttp/control_command_marlin.cpp
@@ -1,0 +1,185 @@
+#include "control_command.h"
+
+#include <marlin_client.hpp>
+#include <cstdio>
+#include <state/printer_state.hpp>
+#include <marlin_server_types/general_response.hpp>
+#include <marlin_server_types/client_fsm_types.h>
+#include <marlin_vars.hpp>
+
+#include <option/has_xbuddy_extension.h>
+#if HAS_XBUDDY_EXTENSION()
+    #include <feature/chamber/chamber.hpp>
+    #include <feature/xbuddy_extension/xbuddy_extension.hpp>
+    #include <pwm_utils.hpp>
+#endif
+
+#include <option/has_side_leds.h>
+#if HAS_SIDE_LEDS()
+    #include <leds/side_strip_handler.hpp>
+#endif
+
+namespace nhttp::printer {
+
+void ControlCommand::set_nozzle_temp(int temp) {
+    char gcode[20];
+    snprintf(gcode, sizeof(gcode), "M104 S%d", temp);
+    marlin_client::gcode(gcode);
+}
+
+void ControlCommand::set_bed_temp(int temp) {
+    char gcode[20];
+    snprintf(gcode, sizeof(gcode), "M140 S%d", temp);
+    marlin_client::gcode(gcode);
+}
+
+void ControlCommand::set_chamber_temp(int temp) {
+#if HAS_XBUDDY_EXTENSION()
+    if (temp <= 0) {
+        buddy::chamber().set_target_temperature(std::nullopt);
+    } else {
+        buddy::chamber().set_target_temperature(temp);
+    }
+#else
+    (void)temp;
+#endif
+}
+
+void ControlCommand::set_speed(int percent) {
+    char gcode[20];
+    snprintf(gcode, sizeof(gcode), "M220 S%d", percent);
+    marlin_client::gcode(gcode);
+}
+
+void ControlCommand::set_flow(int percent) {
+    char gcode[20];
+    snprintf(gcode, sizeof(gcode), "M221 S%d", percent);
+    marlin_client::gcode(gcode);
+}
+
+void ControlCommand::set_fan_print(int pwm) {
+    if (pwm <= 0) {
+        marlin_client::gcode("M107");
+    } else {
+        char gcode[20];
+        snprintf(gcode, sizeof(gcode), "M106 S%d", pwm > 255 ? 255 : pwm);
+        marlin_client::gcode(gcode);
+    }
+}
+
+void ControlCommand::set_chamber_fan(int percent) {
+#if HAS_XBUDDY_EXTENSION()
+    buddy::xbuddy_extension().set_fan_target_pwm(
+        buddy::XBuddyExtension::Fan::cooling_fan_1,
+        percent < 0
+            ? buddy::XBuddyExtension::FanPWMOrAuto(pwm_auto)
+            : buddy::XBuddyExtension::FanPWM::from_percent(percent > 100 ? 100 : percent));
+#else
+    (void)percent;
+#endif
+}
+
+void ControlCommand::set_led(int percent) {
+#if HAS_SIDE_LEDS()
+    uint8_t brightness = static_cast<uint8_t>(percent > 100 ? 100 : (percent < 0 ? 0 : percent)) * 255 / 100;
+    leds::SideStripHandler::instance().set_max_brightness(brightness);
+    leds::SideStripHandler::instance().activity_ping();
+#else
+    (void)percent;
+#endif
+}
+
+void ControlCommand::home_axes(bool x, bool y, bool z) {
+    char gcode[20] = "G28";
+    if (!(x && y && z)) {
+        char *p = gcode + 3;
+        if (x) { *p++ = ' '; *p++ = 'X'; }
+        if (y) { *p++ = ' '; *p++ = 'Y'; }
+        if (z) { *p++ = ' '; *p++ = 'Z'; }
+        *p = '\0';
+    }
+    marlin_client::gcode(gcode);
+}
+
+void ControlCommand::relative_move(float x, float y, float z, float e, int feedrate) {
+    marlin_client::gcode("G91");
+    char gcode[80];
+    snprintf(gcode, sizeof(gcode), "G1 F%d X%.2f Y%.2f Z%.2f E%.2f",
+             feedrate, (double)x, (double)y, (double)z, (double)e);
+    marlin_client::gcode(gcode);
+    marlin_client::gcode("G90");
+}
+
+void ControlCommand::load_filament() {
+    marlin_client::gcode("M701");
+}
+
+void ControlCommand::unload_filament() {
+    marlin_client::gcode("M702");
+}
+
+void ControlCommand::purge() {
+    marlin_client::gcode("M701 L0");
+}
+
+void ControlCommand::filament_change() {
+    marlin_client::gcode("M600");
+}
+
+void ControlCommand::cooldown() {
+    marlin_client::gcode("M104 S0");
+    marlin_client::gcode("M140 S0");
+    marlin_client::gcode("M107");
+#if HAS_XBUDDY_EXTENSION()
+    buddy::chamber().set_target_temperature(std::nullopt);
+    buddy::xbuddy_extension().set_fan_target_pwm(
+        buddy::XBuddyExtension::Fan::cooling_fan_1,
+        buddy::XBuddyExtension::FanPWMOrAuto(pwm_auto));
+#endif
+}
+
+void ControlCommand::motors_off() {
+    marlin_client::gcode("M18");
+}
+
+void ControlCommand::emergency_stop() {
+    marlin_client::gcode("M112");
+}
+
+void ControlCommand::reboot() {
+    marlin_client::gcode("M997");
+}
+
+void ControlCommand::send_gcode(const char *gcode) {
+    marlin_client::gcode(gcode);
+}
+
+void ControlCommand::dialog_response(const char *button_name) {
+    Response resp = from_str(std::string_view(button_name));
+    if (resp == Response::_none) {
+        return; // Invalid button name
+    }
+
+    // Get current dialog state
+    auto state = printer_state::get_state_with_dialog(false);
+    if (!state.dialog.has_value()) {
+        return; // No active dialog
+    }
+
+    // Get the current FSM top state for the response
+    std::optional<fsm::States::Top> top;
+    marlin_vars().peek_fsm_states([&](const auto &states) {
+        top = states.get_top();
+    });
+
+    if (!top) {
+        return;
+    }
+
+    marlin_client::FSM_encoded_response(EncodedFSMResponse {
+        .response = FSMResponseVariant::make(resp),
+        .fsm_and_phase = FSMAndPhase(top->fsm_type, top->data.GetPhase()),
+    });
+}
+
+} // namespace nhttp::printer

--- a/lib/WUI/nhttp/handler.h
+++ b/lib/WUI/nhttp/handler.h
@@ -33,6 +33,7 @@
 #include "gcode_upload.h"
 #include "gcode_preview.h"
 #include "job_command.h"
+#include "control_command.h"
 #include "req_parser.h"
 #include "send_file.h"
 #include "send_json.h"
@@ -151,6 +152,7 @@ namespace handler {
         printer::GcodeUpload,
         printer::GCodePreview,
         printer::JobCommand,
+        printer::ControlCommand,
         printer::FileInfo,
         printer::FileCommand,
 #if NETWORKING_BENCHMARK_ENABLED


### PR DESCRIPTION
## Summary

Add a single `POST /api/v1/control` endpoint for controlling the printer via the local PrusaLink HTTP API. This enables local network automation and Home Assistant integration without depending on Prusa Connect.

**Motivation:** The local PrusaLink API currently provides read-only status and job control, but no way to set temperatures, speed, fan settings, or trigger filament operations. Users wanting local automation (e.g. Home Assistant, custom scripts) must use the Prusa Connect cloud API. This PR adds a local-first alternative.

## API

`POST /api/v1/control` with a JSON body. All fields optional — omitted fields leave the state unchanged.

```json
{
  "nozzle": 215,          "bed": 60,              "chamber": 40,
  "speed": 100,           "flow": 100,
  "fan_print": 255,       "chamber_fan": -1,      "led": 100,
  "home": true,           "move_z": 5.0,          "feedrate": 1000,
  "load_filament": true,  "unload_filament": true,
  "cooldown": true,       "motors_off": true,     "reboot": true,
  "gcode": "M220 S100"
}
```

## Implementation

- New `ControlCommand` handler (same pattern as `JobCommand`/`FileCommand`)
- JSON parsing via existing `json_parser.h` infrastructure
- Marlin interaction via `marlin_client::gcode()` for standard commands
- Chamber/fan/LED use native APIs (`buddy::chamber()`, `buddy::xbuddy_extension()`, `leds::SideStripHandler`) gated behind `HAS_XBUDDY_EXTENSION()` and `HAS_SIDE_LEDS()`
- Route registered in `prusa_link_api_v1.cpp`

## Files changed

| File | Change |
|------|--------|
| `control_command.h` | Handler class declaration |
| `control_command.cpp` | JSON parsing + dispatch |
| `control_command_marlin.cpp` | Marlin/hardware interaction (separated for test isolation) |
| `prusa_link_api_v1.cpp` | Route registration (+12 lines) |
| `handler.h` | Variant type registration (+2 lines) |
| `CMakeLists.txt` | Build files (+2 lines) |

## Test plan

- [ ] `curl -X POST ... -d '{"speed": 150}'` sets speed to 150%
- [ ] `curl -X POST ... -d '{"nozzle": 215, "bed": 60}'` sets targets
- [ ] `curl -X POST ... -d '{"cooldown": true}'` turns off all heaters
- [ ] `curl -X POST ... -d '{"home": true}'` homes all axes
- [ ] `curl -X POST ... -d '{"gcode": "M115"}'` sends G-code
- [ ] `curl -X POST ... -d '{"chamber": 40}'` sets chamber (Core One only)
- [ ] Verify no regressions on existing endpoints
- [ ] Tested on Prusa Core One with custom build