### PR TITLE
feat(wui): Add dialog state to /api/v1/status + normal load/unload dialogs

### DIFF
--- a/lib/WUI/nhttp/status_renderer.cpp
+++ b/lib/WUI/nhttp/status_renderer.cpp
@@ -6,6 +6,8 @@
 #include <transfers/monitor.hpp>
 #include <segmented_json_macros.h>
 
+#include <marlin_server_types/general_response.hpp>
+
 #include <option/buddy_enable_connect.h>
 #if BUDDY_ENABLE_CONNECT()
     #include <connect/connect.hpp>
@@ -27,7 +29,12 @@ json::JsonResult StatusRenderer::renderState(size_t resume_point, json::JsonOutp
 
     uint32_t time_to_end = marlin_vars().time_to_end;
     uint32_t time_to_pause = marlin_vars().time_to_pause;
-    auto link_state = printer_state::get_state(false);
+    auto state_with_dialog = printer_state::get_state_with_dialog(false);
+    auto link_state = state_with_dialog.device_state;
+    bool has_dialog = state_with_dialog.dialog.has_value();
+    uint32_t dialog_id = has_dialog ? state_with_dialog.dialog->dialog_id.to_uint32_t() : 0;
+    uint32_t dialog_code = state_with_dialog.code_num();
+    const Response *dialog_buttons = state_with_dialog.buttons();
 
     // Keep the indentation of the JSON in here!
     // clang-format off
@@ -76,6 +83,17 @@ json::JsonResult StatusRenderer::renderState(size_t resume_point, json::JsonOutp
             JSON_FIELD_INT("fan_hotend", marlin_vars().active_hotend().heatbreak_fan_rpm) JSON_COMMA;
             JSON_FIELD_INT("fan_print", marlin_vars().active_hotend().print_fan_rpm);
         JSON_OBJ_END;
+        if (has_dialog) {
+            JSON_COMMA;
+            JSON_FIELD_OBJ("dialog");
+                JSON_FIELD_INT("id", dialog_id) JSON_COMMA;
+                JSON_FIELD_INT("code", dialog_code) JSON_COMMA;
+                JSON_FIELD_STR("button0", (dialog_buttons && dialog_buttons[0] != Response::_none) ? to_str(dialog_buttons[0]) : "") JSON_COMMA;
+                JSON_FIELD_STR("button1", (dialog_buttons && dialog_buttons[0] != Response::_none && dialog_buttons[1] != Response::_none) ? to_str(dialog_buttons[1]) : "") JSON_COMMA;
+                JSON_FIELD_STR("button2", (dialog_buttons && dialog_buttons[0] != Response::_none && dialog_buttons[1] != Response::_none && dialog_buttons[2] != Response::_none) ? to_str(dialog_buttons[2]) : "") JSON_COMMA;
+                JSON_FIELD_STR("button3", (dialog_buttons && dialog_buttons[0] != Response::_none && dialog_buttons[1] != Response::_none && dialog_buttons[2] != Response::_none && dialog_buttons[3] != Response::_none) ? to_str(dialog_buttons[3]) : "");
+            JSON_OBJ_END;
+        }
     JSON_OBJ_END;
     JSON_END;
     // clang-format on

--- a/lib/WUI/nhttp/status_renderer.h
+++ b/lib/WUI/nhttp/status_renderer.h
@@ -8,6 +8,8 @@ namespace nhttp::handler {
 class StatusState {
 public:
     std::optional<transfers::TransferId> transfer_id { std::nullopt };
+    size_t iter = 0;
+    bool need_comma = false;
     StatusState(std::optional<transfers::TransferId> id)
         : transfer_id(id) {}
 };

--- a/src/state/printer_state.cpp
+++ b/src/state/printer_state.cpp
@@ -422,7 +422,14 @@ StateWithDialog get_state_with_dialog(bool ready) {
                 const Response *buttons = ClientResponses::get_available_responses(GetEnumFromPhaseIndex<PhasesLoadUnload>(data.GetPhase())).data();
                 return { state, attention_code, fsm_gen, buttons };
             }
-        } // TODO: handle normal load unload
+        } else {
+            // Normal (non-printing) load/unload: expose dialog if there are buttons
+            auto phase = GetEnumFromPhaseIndex<PhasesLoadUnload>(data.GetPhase());
+            const auto &responses = ClientResponses::get_available_responses(phase);
+            if (responses[0] != Response::_none) {
+                return { state, ErrCode::CONNECT_FILAMENT_RUNOUT, fsm_gen, responses.data() };
+            }
+        }
         break;
     case ClientFSM::QuickPause: {
         const Response *available_responses = ClientResponses::get_available_responses(GetEnumFromPhaseIndex<PhasesQuickPause>(data.GetPhase())).data();


### PR DESCRIPTION
## Summary

Expose active printer dialogs in the `/api/v1/status` response and implement the upstream TODO for normal filament load/unload dialog reporting.

## Changes

1. **Dialog in status API**: When the printer shows a dialog (filament prompt, crash recovery, warning), the status response includes a `dialog` object with the dialog ID, error code, and available button names.

2. **Normal load/unload dialogs** (`printer_state.cpp`): Implements the TODO at line 393 — dialogs for non-printing load/unload operations are now exposed with their available response buttons, not just while-printing ones.

## Response format

```json
{
  "printer": { "state": "BUSY", ... },
  "dialog": {
    "id": 12345,
    "code": 31829,
    "button0": "Stop",
    "button1": "",
    "button2": "",
    "button3": ""
  }
}
```

The `dialog` object is only present when a dialog is active. Button fields are empty strings when not available.

## Motivation

This enables remote printer management tools (Home Assistant, custom dashboards) to detect and display printer dialogs. Combined with a control endpoint (separate PR #5228), this allows fully remote dialog response.

## Test plan

- [ ] Trigger filament unload → dialog appears in status with "Stop" button
- [ ] No dialog object when printer is idle
- [ ] Crash recovery dialog shows correct buttons
- [ ] Warning dialogs reported correctly