### PR TITLE
feat(wui): Add GET /api/v1/settings — persistent config dump

### DIFF
--- a/lib/WUI/link_content/basic_gets.cpp
+++ b/lib/WUI/link_content/basic_gets.cpp
@@ -251,6 +251,131 @@ JsonResult get_info(size_t resume_point, JsonOutput &output) {
     // clang-format on
 }
 
+JsonResult get_settings(size_t resume_point, JsonOutput &output) {
+    auto &cs = config_store();
+    auto &vars = marlin_vars();
+
+    // PID
+    const float hot_p = cs.pid_nozzle_p.get();
+    const float hot_i = cs.pid_nozzle_i.get();
+    const float hot_d = cs.pid_nozzle_d.get();
+    const float bed_p = cs.pid_bed_p.get();
+    const float bed_i = cs.pid_bed_i.get();
+    const float bed_d = cs.pid_bed_d.get();
+
+    // Steppers (steps per mm)
+    const float spm_x = cs.axis_steps_per_unit_x.get();
+    const float spm_y = cs.axis_steps_per_unit_y.get();
+    const float spm_z = cs.axis_steps_per_unit_z.get();
+    const float spm_e = cs.axis_steps_per_unit_e0.get();
+
+    // Microsteps (0 = default)
+    const uint16_t ms_x = cs.axis_microsteps_X_.get();
+    const uint16_t ms_y = cs.axis_microsteps_Y_.get();
+    const uint16_t ms_z = cs.axis_microsteps_Z_.get();
+    const uint16_t ms_e = cs.axis_microsteps_E0_.get();
+
+    // RMS current (mA, 0 = default)
+    const uint16_t rms_x = cs.axis_rms_current_ma_X_.get();
+    const uint16_t rms_y = cs.axis_rms_current_ma_Y_.get();
+    const uint16_t rms_z = cs.axis_rms_current_ma_Z_.get();
+    const uint16_t rms_e = cs.axis_rms_current_ma_E0_.get();
+
+    // Homing
+    const int16_t hsens_x = cs.homing_sens_x.get();
+    const int16_t hsens_y = cs.homing_sens_y.get();
+
+    // Hardware
+    const float nozzle_diameter = cs.get_nozzle_diameter(0);
+    const float z_offset = vars.z_offset;
+    const float travel_accel = vars.travel_acceleration;
+    const uint16_t extrude_min_temp = vars.extrude_min_temp;
+
+    // Filament sensor (Core One always has one)
+    const bool fsensor_enabled = cs.fsensor_enabled.get();
+
+    // Input shaper (Core One has it; struct has frequency, damping_ratio, type, vibration_reduction)
+    const bool is_x_en = cs.input_shaper_axis_x_enabled.get();
+    const bool is_y_en = cs.input_shaper_axis_y_enabled.get();
+    const auto is_x_cfg = cs.input_shaper_axis_x_config.get();
+    const auto is_y_cfg = cs.input_shaper_axis_y_config.get();
+
+    // Keep the indentation of the JSON in here!
+    // clang-format off
+    JSON_START;
+    JSON_OBJ_START;
+        JSON_FIELD_OBJ("hardware");
+            JSON_FIELD_FFIXED("nozzle_diameter", static_cast<double>(nozzle_diameter), 2) JSON_COMMA;
+            JSON_FIELD_FFIXED("z_offset", static_cast<double>(z_offset), 3) JSON_COMMA;
+            JSON_FIELD_INT("extrude_min_temp", extrude_min_temp);
+        JSON_OBJ_END JSON_COMMA;
+
+        JSON_FIELD_OBJ("pid");
+            JSON_FIELD_OBJ("hotend");
+                JSON_FIELD_FFIXED("p", static_cast<double>(hot_p), 3) JSON_COMMA;
+                JSON_FIELD_FFIXED("i", static_cast<double>(hot_i), 3) JSON_COMMA;
+                JSON_FIELD_FFIXED("d", static_cast<double>(hot_d), 3);
+            JSON_OBJ_END JSON_COMMA;
+            JSON_FIELD_OBJ("bed");
+                JSON_FIELD_FFIXED("p", static_cast<double>(bed_p), 3) JSON_COMMA;
+                JSON_FIELD_FFIXED("i", static_cast<double>(bed_i), 3) JSON_COMMA;
+                JSON_FIELD_FFIXED("d", static_cast<double>(bed_d), 3);
+            JSON_OBJ_END;
+        JSON_OBJ_END JSON_COMMA;
+
+        JSON_FIELD_OBJ("steppers");
+            JSON_FIELD_OBJ("steps_per_mm");
+                JSON_FIELD_FFIXED("x", static_cast<double>(spm_x), 3) JSON_COMMA;
+                JSON_FIELD_FFIXED("y", static_cast<double>(spm_y), 3) JSON_COMMA;
+                JSON_FIELD_FFIXED("z", static_cast<double>(spm_z), 3) JSON_COMMA;
+                JSON_FIELD_FFIXED("e", static_cast<double>(spm_e), 3);
+            JSON_OBJ_END JSON_COMMA;
+            JSON_FIELD_OBJ("microsteps");
+                JSON_FIELD_INT("x", ms_x) JSON_COMMA;
+                JSON_FIELD_INT("y", ms_y) JSON_COMMA;
+                JSON_FIELD_INT("z", ms_z) JSON_COMMA;
+                JSON_FIELD_INT("e", ms_e);
+            JSON_OBJ_END JSON_COMMA;
+            JSON_FIELD_OBJ("rms_current_ma");
+                JSON_FIELD_INT("x", rms_x) JSON_COMMA;
+                JSON_FIELD_INT("y", rms_y) JSON_COMMA;
+                JSON_FIELD_INT("z", rms_z) JSON_COMMA;
+                JSON_FIELD_INT("e", rms_e);
+            JSON_OBJ_END;
+        JSON_OBJ_END JSON_COMMA;
+
+        JSON_FIELD_OBJ("motion");
+            JSON_FIELD_FFIXED("travel_acceleration", static_cast<double>(travel_accel), 1);
+        JSON_OBJ_END JSON_COMMA;
+
+        JSON_FIELD_OBJ("homing");
+            JSON_FIELD_INT("sensitivity_x", hsens_x) JSON_COMMA;
+            JSON_FIELD_INT("sensitivity_y", hsens_y);
+        JSON_OBJ_END JSON_COMMA;
+
+        JSON_FIELD_OBJ("input_shaper");
+            JSON_FIELD_OBJ("x");
+                JSON_FIELD_BOOL("enabled", is_x_en) JSON_COMMA;
+                JSON_FIELD_FFIXED("frequency", static_cast<double>(is_x_cfg.frequency), 2) JSON_COMMA;
+                JSON_FIELD_FFIXED("damping_ratio", static_cast<double>(is_x_cfg.damping_ratio), 3) JSON_COMMA;
+                JSON_FIELD_INT("type", static_cast<int>(is_x_cfg.type));
+            JSON_OBJ_END JSON_COMMA;
+            JSON_FIELD_OBJ("y");
+                JSON_FIELD_BOOL("enabled", is_y_en) JSON_COMMA;
+                JSON_FIELD_FFIXED("frequency", static_cast<double>(is_y_cfg.frequency), 2) JSON_COMMA;
+                JSON_FIELD_FFIXED("damping_ratio", static_cast<double>(is_y_cfg.damping_ratio), 3) JSON_COMMA;
+                JSON_FIELD_INT("type", static_cast<int>(is_y_cfg.type));
+            JSON_OBJ_END;
+        JSON_OBJ_END JSON_COMMA;
+
+        JSON_FIELD_OBJ("filament_sensor");
+            JSON_FIELD_BOOL("enabled", fsensor_enabled);
+        JSON_OBJ_END;
+    JSON_OBJ_END;
+    JSON_END;
+    // clang-format on
+}
+
 JsonResult get_job_octoprint(size_t resume_point, JsonOutput &output) {
     // Note about the marlin vars: It's true that on resumption we may get
     // different values. But they would still be reasonably "sane". If we eg.

--- a/lib/WUI/link_content/basic_gets.h
+++ b/lib/WUI/link_content/basic_gets.h
@@ -30,5 +30,6 @@ json::JsonResult get_job_octoprint(size_t resume_point, json::JsonOutput &output
 json::JsonResult get_job_v1(size_t resume_point, json::JsonOutput &output);
 json::JsonResult get_storage(size_t resume_point, json::JsonOutput &output);
 json::JsonResult get_info(size_t resume_point, json::JsonOutput &output);
+json::JsonResult get_settings(size_t resume_point, json::JsonOutput &output);
 
 } // namespace nhttp::link_content

--- a/lib/WUI/link_content/prusa_link_api_v1.cpp
+++ b/lib/WUI/link_content/prusa_link_api_v1.cpp
@@ -118,6 +118,9 @@ Selector::Accepted PrusaLinkApiV1::accept(const RequestParser &parser, handler::
     } else if (suffix == "info") {
         get_only(SendJson(EmptyRenderer(get_info), parser.can_keep_alive()), parser, out);
         return Accepted::Accepted;
+    } else if (suffix == "settings") {
+        get_only(SendJson(EmptyRenderer(get_settings), parser.can_keep_alive()), parser, out);
+        return Accepted::Accepted;
     } else if (auto job_suffix_opt = remove_prefix(suffix, "job/"); job_suffix_opt.has_value()) {
         auto job_suffix = *job_suffix_opt;
         auto id = get_job_id(job_suffix);


### PR DESCRIPTION
## Summary

Adds a `GET /api/v1/settings` endpoint that serializes the relevant slice of the persistent `config_store` (PID, steps/mm, microsteps, RMS current, input shaper, homing, filament sensor, motion limits) as JSON. Read-only.

Useful for inspecting firmware configuration remotely without needing the LCD menu or USB serial, e.g. for diagnostics, support, comparing settings between printers, or building external dashboards.

## Why

There is currently no way to read persistent printer settings via the HTTP API. The LCD Settings menu is the only path, which is impractical for remote diagnostics. `M503` over USB serial would also work in principle but its output is not exposed via the HTTP API.

## What's returned

```json
{
  "hardware": {
    "nozzle_diameter": 0.40,
    "z_offset": 0.000,
    "extrude_min_temp": 170
  },
  "pid": {
    "hotend": { "p": 14.000, "i": 0.160, "d": 625.000 },
    "bed":    { "p": 50.000, "i": 0.123, "d": 187.500 }
  },
  "steppers": {
    "steps_per_mm":     { "x": -100.000, "y": -100.000, "z": 400.000, "e": 380.000 },
    "microsteps":       { "x": 0, "y": 0, "z": 16, "e": 16 },
    "rms_current_ma":   { "x": 0, "y": 0, "z": 600, "e": 450 }
  },
  "motion":  { "travel_acceleration": 1500.0 },
  "homing":  { "sensitivity_x": 32767, "sensitivity_y": 32767 },
  "input_shaper": {
    "x": { "enabled": true, "frequency": 60.00, "damping_ratio": 0.100, "type": 2 },
    "y": { "enabled": true, "frequency": 48.00, "damping_ratio": 0.100, "type": 2 }
  },
  "filament_sensor": { "enabled": true }
}
```

Microsteps/RMS values of `0` mean "use firmware default" (per the store definition). Homing sensitivity `32767` (INT16_MAX) means uncalibrated/default.

## Implementation

- One new function `get_settings()` in `lib/WUI/link_content/basic_gets.{cpp,h}` that pulls each field via `config_store().<name>.get()` (or `marlin_vars()` where relevant) and renders via the segmented JSON renderer like other endpoints.
- One new route `/api/v1/settings` in `prusa_link_api_v1.cpp`.

No changes to `config_store` itself — strictly read-only.

## Test plan

- [x] `curl /api/v1/settings` returns the JSON shape above on a CORE One+
- [x] All fields match values configurable via the LCD Settings menu
- [x] Endpoint is GET-only (POST/PUT return 405 via the existing route fallthrough)

## Notes

- I've tested this on a CORE One+ running 6.5.3 + this patch. The fields exposed reflect what's actually in `config_store` for that printer model. For other printer models (XL, MK4, MK3.x), I haven't verified each field is present — could refine if there's interest.
- Bundles naturally with PRs #5228 (POST /api/v1/control) and #5229 (extended /api/v1/status) as a third basic endpoint that closes the "remote configuration introspection" gap.