### PR TITLE
feat(wui): Add GET /api/v1/log — USB CDC serial capture

### DIFF
--- a/lib/WUI/CMakeLists.txt
+++ b/lib/WUI/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(
             nhttp/status_renderer.cpp
             nhttp/transfer_renderer.cpp
             pbuf_rx.cpp
+            serial_log.cpp
             sntp/sntp.c
             sntp/sntp_client.c
             wui.cpp

--- a/lib/WUI/link_content/basic_gets.cpp
+++ b/lib/WUI/link_content/basic_gets.cpp
@@ -3,6 +3,7 @@
 #include "marlin_client.hpp"
 #include "lwip/init.h"
 #include "netdev.h"
+#include "../serial_log.h"
 #include <config_store/store_instance.hpp>
 #include <option/has_tool_mapping.h>
 
@@ -249,6 +250,19 @@ JsonResult get_info(size_t resume_point, JsonOutput &output) {
     JSON_OBJ_END;
     JSON_END;
     // clang-format on
+}
+
+// log endpoint moved out of the JSON renderer set — it returns plain text
+// via SendStaticMemory instead (see prusa_link_api_v1.cpp). The whole
+// JSON-escape-on-tiny-stack path is avoided.
+
+std::string_view snapshot_serial_log_into_static() {
+    // Static so the buffer outlives this function call (SendStaticMemory
+    // borrows the string_view's data). Single-threaded by the HTTP server,
+    // so no synchronization beyond the snapshot's own mutex is needed.
+    static char buf[nhttp::printer::SerialLog::BUFFER_SIZE + 1];
+    const size_t n = nhttp::printer::serial_log.snapshot_into(buf, sizeof(buf));
+    return std::string_view(buf, n);
 }
 
 JsonResult get_job_octoprint(size_t resume_point, JsonOutput &output) {

--- a/lib/WUI/link_content/basic_gets.h
+++ b/lib/WUI/link_content/basic_gets.h
@@ -2,6 +2,8 @@
 
 #include <segmented_json.h>
 
+#include <string_view>
+
 #define PL_VERSION_MAJOR    2
 #define PL_VERSION_MINOR    0
 #define PL_VERSION_REVISION 0
@@ -30,5 +32,6 @@ json::JsonResult get_job_octoprint(size_t resume_point, json::JsonOutput &output
 json::JsonResult get_job_v1(size_t resume_point, json::JsonOutput &output);
 json::JsonResult get_storage(size_t resume_point, json::JsonOutput &output);
 json::JsonResult get_info(size_t resume_point, json::JsonOutput &output);
+std::string_view snapshot_serial_log_into_static();
 
 } // namespace nhttp::link_content

--- a/lib/WUI/link_content/prusa_link_api_v1.cpp
+++ b/lib/WUI/link_content/prusa_link_api_v1.cpp
@@ -6,6 +6,7 @@
 #include "../nhttp/gcode_upload.h"
 #include "../nhttp/job_command.h"
 #include "../nhttp/send_json.h"
+#include "../nhttp/static_mem.h"
 #include "../nhttp/status_renderer.h"
 #include "../wui_api.h"
 #include "prusa_api_helpers.hpp"
@@ -117,6 +118,12 @@ Selector::Accepted PrusaLinkApiV1::accept(const RequestParser &parser, handler::
         return Accepted::Accepted;
     } else if (suffix == "info") {
         get_only(SendJson(EmptyRenderer(get_info), parser.can_keep_alive()), parser, out);
+        return Accepted::Accepted;
+    } else if (suffix == "log") {
+        // Plain-text response. Avoids any JSON-escape stack allocation;
+        // SendStaticMemory just streams the bytes directly.
+        const std::string_view snapshot = snapshot_serial_log_into_static();
+        out.next = SendStaticMemory(snapshot, http::ContentType::TextPlain, parser.can_keep_alive());
         return Accepted::Accepted;
     } else if (auto job_suffix_opt = remove_prefix(suffix, "job/"); job_suffix_opt.has_value()) {
         auto job_suffix = *job_suffix_opt;

--- a/lib/WUI/serial_log.cpp
+++ b/lib/WUI/serial_log.cpp
@@ -1,0 +1,125 @@
+#include "serial_log.h"
+
+#include <USBSerial.h>
+#include <freertos/mutex.hpp>
+
+#include <array>
+#include <atomic>
+#include <cstring>
+#include <mutex>
+
+namespace nhttp::printer {
+
+namespace {
+    // Storage and synchronization for the ring buffer. Kept in an anon namespace
+    // so internal state is hidden from headers; one global SerialLog instance
+    // shares this state.
+    std::array<uint8_t, SerialLog::BUFFER_SIZE> ring {};
+    size_t head { 0 };  ///< write index (next slot to overwrite)
+    bool wrapped { false };  ///< true once we've written ≥ BUFFER_SIZE bytes
+    std::atomic<uint32_t> total_written { 0 };
+
+    // Lazy-initialized mutex. Constructing freertos::Mutex at C++ static-init
+    // time runs BEFORE the FreeRTOS scheduler is up, which yields a broken
+    // handle. A function-local static is initialized on first call (which is
+    // after the WUI task starts), so the scheduler is already running.
+    freertos::Mutex &ring_mutex() {
+        static freertos::Mutex m;
+        return m;
+    }
+
+    void append_locked(const uint8_t *data, size_t len) {
+        // Memcpy in up to two segments, wrapping at the ring end.
+        while (len > 0) {
+            const size_t space_to_end = SerialLog::BUFFER_SIZE - head;
+            const size_t chunk = (len < space_to_end) ? len : space_to_end;
+            std::memcpy(&ring[head], data, chunk);
+            head += chunk;
+            if (head >= SerialLog::BUFFER_SIZE) {
+                head = 0;
+                wrapped = true;
+            }
+            data += chunk;
+            len -= chunk;
+        }
+    }
+
+    void on_serial_line(const uint8_t *buf, int len) {
+        if (len <= 0 || !buf) {
+            return;
+        }
+        std::lock_guard lock { ring_mutex() };
+        append_locked(buf, static_cast<size_t>(len));
+        total_written.fetch_add(static_cast<uint32_t>(len), std::memory_order_relaxed);
+    }
+} // namespace
+
+SerialLog::SerialLog() = default;
+
+void SerialLog::append(const uint8_t *data, size_t len) {
+    if (len == 0 || !data) {
+        return;
+    }
+    std::lock_guard lock { ring_mutex() };
+    append_locked(data, len);
+    total_written.fetch_add(static_cast<uint32_t>(len), std::memory_order_relaxed);
+}
+
+size_t SerialLog::snapshot_into(char *dst, size_t dst_size) const {
+    if (!dst || dst_size == 0) {
+        return 0;
+    }
+
+    std::lock_guard lock { ring_mutex() };
+
+    // Compute current size and oldest-first layout
+    const size_t cur_size = wrapped ? BUFFER_SIZE : head;
+    if (cur_size == 0) {
+        dst[0] = '\0';
+        return 0;
+    }
+
+    static constexpr char kTruncMarker[] = "... (truncated)\n";
+    static constexpr size_t kTruncLen = sizeof(kTruncMarker) - 1;
+
+    size_t out = 0;
+    size_t src_skip = 0;
+    if (cur_size > dst_size - 1) {
+        // Reserve room for marker + null terminator. Skip the oldest bytes.
+        const size_t reserve = kTruncLen;
+        if (dst_size > reserve + 1) {
+            std::memcpy(dst, kTruncMarker, kTruncLen);
+            out = kTruncLen;
+            src_skip = cur_size - (dst_size - 1 - kTruncLen);
+        } else {
+            // dst too small for marker; just take the tail
+            src_skip = cur_size - (dst_size - 1);
+        }
+    }
+
+    // The ring starts at `head` when wrapped (oldest there), at 0 when not.
+    const size_t start = wrapped ? head : 0;
+    for (size_t i = src_skip; i < cur_size && out < dst_size - 1; ++i) {
+        dst[out++] = ring[(start + i) % BUFFER_SIZE];
+    }
+    dst[out] = '\0';
+    return out;
+}
+
+uint32_t SerialLog::bytes_written() const {
+    return total_written.load(std::memory_order_relaxed);
+}
+
+void SerialLog::clear() {
+    std::lock_guard lock { ring_mutex() };
+    head = 0;
+    wrapped = false;
+}
+
+SerialLog serial_log;
+
+void serial_log_install_hook() {
+    SerialUSB.lineBufferHook = &on_serial_line;
+}
+
+} // namespace nhttp::printer

--- a/lib/WUI/serial_log.h
+++ b/lib/WUI/serial_log.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+namespace nhttp::printer {
+
+/// Lock-protected ring buffer that captures Marlin's USB serial output.
+/// Hooked into Arduino USBSerial::lineBufferHook so every complete line
+/// emitted on the USB CDC also lands here.
+///
+/// Reads via snapshot_into() are safe from any task; writes happen from
+/// whichever task drains the USB CDC line buffer.
+class SerialLog {
+public:
+    static constexpr size_t BUFFER_SIZE = 8192;
+
+    SerialLog();
+
+    /// Append raw bytes to the ring. Safe to call from the USB drain task.
+    /// Bytes overwrite the oldest data when the ring fills.
+    void append(const uint8_t *data, size_t len);
+
+    /// Copy out a snapshot of the current ring (oldest first), up to dst_size
+    /// bytes. Returns the number of bytes copied. If the ring contains more
+    /// than dst_size, the oldest entries are truncated and a marker
+    /// "... (truncated)\n" is prepended.
+    size_t snapshot_into(char *dst, size_t dst_size) const;
+
+    /// Total bytes appended since boot (modular). Useful for incremental polling.
+    uint32_t bytes_written() const;
+
+    /// Reset the ring (does not reset bytes_written counter).
+    void clear();
+};
+
+extern SerialLog serial_log;
+
+/// Wire up the lineBufferHook on SerialUSB so output starts being captured.
+/// Idempotent; safe to call multiple times.
+void serial_log_install_hook();
+
+} // namespace nhttp::printer

--- a/lib/WUI/wui_api.cpp
+++ b/lib/WUI/wui_api.cpp
@@ -14,6 +14,7 @@
 #include "stm32f4xx_hal.h"
 #include "print_utils.hpp"
 #include "marlin_client.hpp"
+#include "serial_log.h"
 
 #include <lfn.h>
 #include <state/printer_state.hpp>
@@ -38,6 +39,8 @@ void wui_marlin_client_init(void) {
     marlin_client::init(); // init the client
     // force update variables when starts
     marlin_client::set_event_notify(marlin_server::EVENT_MSK_DEF);
+    // Capture USB CDC serial output into a ring buffer for /api/v1/log
+    nhttp::printer::serial_log_install_hook();
 }
 
 struct ini_load_def {


### PR DESCRIPTION
## Summary

Adds an 8 KB in-RAM ring buffer that tees every line Marlin emits to USB CDC into memory, exposed via `GET /api/v1/log` as `text/plain`. Closes the "no remote visibility into Marlin serial output" gap.

## Why

Marlin emits useful diagnostic output to USB serial (M115 capabilities, M303 PID tune progress, M118 host messages, warnings, error contexts) — but with PrusaLink-only setups (no host PC plugged in) this output is invisible. The web UI cannot show debug context, and remote support / scripted workflows have to guess at internal state.

Examples of things now observable remotely:

- `M115` firmware capabilities (handy for compatibility checks)
- `M303` PID autotune cycle progress and results
- `M118` user-emitted messages (Klipper-style)
- Free-form Marlin warnings/errors that would otherwise scroll past

## Implementation

The `USBSerial` class in `lib/Arduino_Core_Buddy` already had an **unused** `lineBufferHook` callback that fires once per newline-terminated line. We install a hook that copies each line into a mutex-protected ring buffer (`lib/WUI/serial_log.{h,cpp}`).

Two non-obvious points:

1. **Mutex is lazy-initialized via a function-local static.** A raw global `freertos::Mutex` is constructed at C++ static-init time, which runs *before* the FreeRTOS scheduler. The resulting handle is broken; it appears to work under light use but crashes the scheduler under contention (verified by running `M303` against a global-mutex variant — the printer red-screens with INTERNAL_ERROR 31538). Function-local statics defer construction to first call, by which point the scheduler is up.

2. **Response uses `SendStaticMemory` with `Content-Type: text/plain`**, not the segmented JSON renderer. The tcpip thread stack is only 1248 B (`TCPIP_THREAD_STACKSIZE` in `include/buddy/lwipopts.h`). The standard JSON path's internal `JSONIFY_STR` VLA scales with input size and overflows the stack for snapshots larger than ~150 B — verified by stack-overflow crash during testing. Plain text avoids escaping entirely; the snapshot lives in a static buffer that `SendStaticMemory` borrows via `string_view`.

## Caveats

- **Long Marlin lines (>125 chars) are truncated by the upstream `USBSerial::LineBufferAppend` logic** with a `..` marker appended. This is pre-existing behaviour we observe but don't modify. Affects things like the `FIRMWARE_NAME:...` line in M115 output.
- **Ring buffer is 8 KB**; older lines drop FIFO. Plenty for short bursts (M303 fits comfortably); for very long captures, callers should poll periodically.
- **No filtering or auth beyond what `/api/v1/*` already enforces.** Anything Marlin writes to USB shows up here. No sensitive data unless someone runs `M118` with secrets in it.

## Test plan

- [x] `curl /api/v1/log` empty immediately after boot (no Marlin output yet)
- [x] After `M115` via control endpoint, `/api/v1/log` contains the FIRMWARE_NAME + Cap: lines
- [x] `M303` autotune cycle: full progress output visible in real time via repeated GETs
- [x] Mutex stress: ran 8+ M303 cycles concurrently with status polls — no crashes
- [x] Stack: confirmed get_log path doesn't grow stack via static buffers + SendStaticMemory
- [x] Content-Type header is `text/plain`, Content-Length matches snapshot bytes

## Notes

- Independent of, but complements, PRs #5228 (POST /api/v1/control) and #5229 (extended /api/v1/status). With all three plus #5302 (settings dump), remote diagnostics on Buddy printers reach OctoPrint-equivalent coverage without needing a Raspberry Pi.
- Tested on CORE One+ 6.5.3. The `lineBufferHook` mechanism is generic; should work on any printer using USBSerial.