### PR TITLE
fix(USBSerial): bump per-line capture buffer 128 → 512 bytes

### DIFF
--- a/lib/Arduino_Core_Buddy/cores/arduino/USBSerial.h
+++ b/lib/Arduino_Core_Buddy/cores/arduino/USBSerial.h
@@ -8,7 +8,16 @@ class USBSerial : public Stream {
 private:
     bool enabled;
     bool isWriteOnly;
-    std::array<uint8_t, 128> lineBuffer;
+    // Per-line capture buffer fed by every char written to USB. Used by
+    // the lineBufferHook callback (e.g. WUI's /api/v1/log serial capture).
+    // 128 B was too small for several common Marlin lines: M115's
+    // FIRMWARE_NAME response is ~240 chars, full M503 settings dumps can
+    // exceed 200, and M118 user messages have no documented cap. Anything
+    // over the buffer was truncated to "..\n" in the hook output with no
+    // way for downstream tooling to recover the rest of the line.
+    // 512 B comfortably fits M115/M503/typical M118 with margin; the
+    // ".." truncation marker still triggers if a line happens to exceed.
+    std::array<uint8_t, 512> lineBuffer;
     decltype(lineBuffer)::size_type lineBufferUsed;
     static constexpr int32_t writeTimeoutUs = 3'000'000;
 


### PR DESCRIPTION
## Summary

`USBSerial::lineBuffer` is the per-line capture buffer fed to `lineBufferHook` callbacks (e.g. when WUI's `/api/v1/log` snapshots Marlin serial output). Its size was 128 bytes; any line longer than 125 chars was truncated mid-content with `..` appended.

This is below several common Marlin responses:

- **`M115` FIRMWARE_NAME line** — concatenates `FIRMWARE_NAME`, version, source URL, `PROTOCOL_VERSION`, `MACHINE_TYPE`, `EXTRUDER_COUNT`, and `UUID`. ~240 chars on most printers. UUID (the last field) is silently dropped — support cases sometimes need it.
- **`M503`** settings dumps — many lines over 100 chars.
- **`M118`** user-emitted messages — no documented length cap.

Bump to 512 bytes. Trade-off is one extra ~384-byte static buffer (single global `USBSerial` instance) on a 196 KB-RAM xBuddy MCU. The `..` truncation marker still triggers if a line exceeds the new size, so degradation is graceful — only the threshold moves up.

The truncation logic in `LineBufferAppend()` already uses `lineBuffer.size()`, so no code change there.

## Test plan

- [x] Builds clean.
- [ ] `M115` over USB serial shows the full line (including UUID).
- [ ] Hook callback (`/api/v1/log` in our fork) emits the full line without `..`.

## Related

Hit while debugging `/api/v1/log` in a downstream fork — the captured M115 output was missing the UUID and Cap: lines were partially garbled. Fixing the buffer size at the root is cleaner than working around it in every hook consumer.