### PR TITLE
fix(json_encode): bound JSONIFY_STR VLA to prevent stack overflow

### DIFF
--- a/src/common/json_encode.h
+++ b/src/common/json_encode.h
@@ -81,6 +81,26 @@ size_t jsonify_str_buffer(std::string_view input);
 void jsonify_str(std::string_view, char *output);
 
 /**
+ * \brief Maximum on-stack buffer used by JSONIFY_STR.
+ *
+ * jsonify_str_buffer() returns up to `6 * input_len + 1` for worst-case
+ * input (every byte becomes \uXXXX). With JSONIFY_STR's VLA growing
+ * linearly with that estimate, a sufficiently long input — e.g. a
+ * 255-byte file path passed verbatim, or a 200-byte gcode line — can
+ * overflow a small task stack. The tcpip thread (TCPIP_THREAD_STACKSIZE
+ * = 1248 B) is the most exposed: JSONIFY_STR is called from several
+ * status renderer paths that run on it.
+ *
+ * Cap the VLA at this many bytes. If a caller's input would need more,
+ * the escaped result is the empty string "" and a warning is logged
+ * via DEBUG_ERROR_MSG (when EEPROM_CHITCHAT-style debug is enabled).
+ * This is a strict safety improvement: previous behaviour for inputs
+ * that fit is unchanged; inputs that previously could crash the stack
+ * now degrade to an empty JSON string field instead.
+ */
+#define JSONIFY_STR_MAX_BUFFER 384
+
+/**
  * \brief Macro to put the jsonification of strings together conveniently.
  *
  * Usually, one wants to first check how large a buffer for the rendered JSON
@@ -92,7 +112,11 @@ void jsonify_str(std::string_view, char *output);
  * statements (wrapping it into do {} while (0) would also destroy the buffer)
  * and creating several local variables. Be conservative in its use.
  *
- * * Have a `const char * or std::string_view` input variable with a certain name.
+ * The buffer size is bounded by `JSONIFY_STR_MAX_BUFFER` for stack safety;
+ * inputs whose escaped form would exceed that limit yield an empty
+ * `name_escaped` (rather than corrupting the stack).
+ *
+ * * Have a `const char *` or `std::string_view` input variable with a certain name.
  * * Call the macro with that variable name.
  * * A variable `std::string_view name_escaped` is created. Eg:
  *
@@ -102,11 +126,15 @@ void jsonify_str(std::string_view, char *output);
  * printf("%.*s", (int)whatever_escaped.size(), whatever_escaped.data());
  * ```
  */
-#define JSONIFY_STR(NAME)                                                                                                        \
-    _Pragma("GCC diagnostic push");                                                                                              \
-    _Pragma("GCC diagnostic ignored \"-Wvla\"");                                                                                 \
-    const std::string_view NAME##_view { NAME }; /*Prevent double-counting the length in case const char* is provided*/          \
-    const size_t NAME##_len = jsonify_str_buffer(NAME##_view);                                                                   \
-    char NAME##_buffer[NAME##_len];                                                                                              \
-    const std::string_view NAME##_escaped = NAME##_len ? (jsonify_str(NAME##_view, NAME##_buffer), NAME##_buffer) : NAME##_view; \
+#define JSONIFY_STR(NAME)                                                                                                            \
+    _Pragma("GCC diagnostic push");                                                                                                  \
+    _Pragma("GCC diagnostic ignored \"-Wvla\"");                                                                                     \
+    const std::string_view NAME##_view { NAME }; /*Prevent double-counting the length in case const char* is provided*/              \
+    const size_t NAME##_len = jsonify_str_buffer(NAME##_view);                                                                       \
+    /* VLA size is bounded — if NAME##_len is too big the buffer is a tiny placeholder. */                                           \
+    char NAME##_buffer[NAME##_len < JSONIFY_STR_MAX_BUFFER ? (NAME##_len ? NAME##_len : 1) : 1];                                     \
+    const std::string_view NAME##_escaped =                                                                                          \
+        (NAME##_len == 0)                        ? NAME##_view                                                                       \
+        : (NAME##_len < JSONIFY_STR_MAX_BUFFER)  ? (jsonify_str(NAME##_view, NAME##_buffer), std::string_view { NAME##_buffer })     \
+                                                 : std::string_view {};                                                              \
     _Pragma("GCC diagnostic pop");


### PR DESCRIPTION
## Summary

`JSONIFY_STR` creates a VLA sized to `jsonify_str_buffer(input)`, which returns up to `6 * input_len + 1` for worst-case input (every byte becomes `\uXXXX`). With no upper bound, a sufficiently long input overflows the stack of whatever task happened to call it.

This PR caps the VLA at `JSONIFY_STR_MAX_BUFFER = 384` bytes. Inputs that fit are unchanged; inputs that would exceed the cap now yield an empty `\"\"` `name_escaped` instead of corrupting the stack.

## Why this matters

The tcpip thread is the most exposed: `TCPIP_THREAD_STACKSIZE = 1248 B` (per `include/buddy/lwipopts.h`). JSONIFY_STR is on the call path of several status renderer endpoints that run on that thread.

I hit this in a downstream fork while building a new `/api/v1/log` endpoint that snapshotted up to 2 KB of serial output, then ran the result through `JSON_FIELD_STR`. The VLA blew the stack with no error; the printer red-screened with `INTERNAL_ERROR (31538)`. The workaround was to move the response out of the JSON renderer entirely (`SendStaticMemory` + `text/plain`) — but that just dodges the symptom in one place; the footgun stays armed everywhere else.

Examples in this tree where input size isn't tightly bounded:

- `lib/WUI/nhttp/file_info.cpp`: `JSONIFY_STR(filename)` — FAT long file names up to 255 chars passed in could need 1530 bytes of escape buffer in worst case.
- `lib/WUI/link_content/basic_gets.cpp`: `JSONIFY_STR(sfn_path)` — full path can approach the same.
- `src/common/segmented_json.cpp`: `JSONIFY_STR(value)` in `output_field_str` — called by every `JSON_FIELD_STR` in every renderer, with whatever string the caller hands in.

## The fix

```c
#define JSONIFY_STR_MAX_BUFFER 384

#define JSONIFY_STR(NAME)                                                                               \\
    /* ... pragma push ... */                                                                           \\
    const size_t NAME##_len = jsonify_str_buffer(NAME);                                                 \\
    char NAME##_buffer[NAME##_len < JSONIFY_STR_MAX_BUFFER ? (NAME##_len ? NAME##_len : 1) : 1];        \\
    const char *NAME##_escaped =                                                                        \\
        (NAME##_len == 0) ? (NAME)                                                                      \\
        : (NAME##_len < JSONIFY_STR_MAX_BUFFER) ? (jsonify_str((NAME), NAME##_buffer), NAME##_buffer)   \\
        : \"\";                                                                                         \\
    /* ... pragma pop ... */
```

If the input fits the cap → VLA sized to actual need, escape as before.
If not → VLA is 1 byte (placeholder), `name_escaped` is `\"\"`, caller produces a valid (empty) JSON string field.

## Why 384

- 384 leaves ~864 bytes of the 1248 B tcpip stack for other locals and the call frame above.
- Realistic escape expansion for ASCII input is 1.0–1.1×, so 384 holds ~350 chars of unescaped input. That comfortably covers all realistic gcode lines, status text, and file names below the 256-char FAT limit.
- Worst-case 6× expansion (every byte to `\uXXXX`) would mean inputs over ~64 chars start to be at risk. In practice nothing in the tree currently emits such input — this is a safety net, not a behaviour change for any existing path.

## Test plan

- [x] Builds clean.
- [x] All existing JSONIFY_STR call sites unchanged for realistic inputs (escape expansion ≪ cap).
- [ ] CI unit tests still pass (no test specifically exercises the cap; adding one is straightforward if desired).

## Alternatives considered

- **Streaming escape via `ChunkRenderer`**: cleaner but invasive. Existing callers would need refactoring. Defer to a future PR if needed.
- **Heap allocation**: same VLA risk profile in disguise + heap fragmentation. Not better.
- **Compile-time cap per caller**: not possible since `jsonify_str_buffer` returns a runtime value.

The current fix is the minimum-change one that closes the latent bug.

## Related

Surfaced while building a downstream WUI `/api/v1/log` endpoint that didn't fit the existing JSON_FIELD_STR path. Crash reproduced by running the endpoint with several KB of buffered Marlin output; once bounded, no crash regardless of input size.