### PR TITLE
feat(wui): expose M0/QuickPause dialog message in /api/v1/status

### DIFF
--- a/lib/WUI/nhttp/status_renderer.cpp
+++ b/lib/WUI/nhttp/status_renderer.cpp
@@ -6,6 +6,8 @@
 #include <transfers/monitor.hpp>
 #include <segmented_json_macros.h>
 
+#include <marlin_server_types/general_response.hpp>
+
 #include <option/buddy_enable_connect.h>
 #if BUDDY_ENABLE_CONNECT()
     #include <connect/connect.hpp>
@@ -27,7 +29,12 @@ json::JsonResult StatusRenderer::renderState(size_t resume_point, json::JsonOutp
 
     uint32_t time_to_end = marlin_vars().time_to_end;
     uint32_t time_to_pause = marlin_vars().time_to_pause;
-    auto link_state = printer_state::get_state(false);
+    auto state_with_dialog = printer_state::get_state_with_dialog(false);
+    auto link_state = state_with_dialog.device_state;
+    bool has_dialog = state_with_dialog.dialog.has_value();
+    uint32_t dialog_id = has_dialog ? state_with_dialog.dialog->dialog_id.to_uint32_t() : 0;
+    uint32_t dialog_code = state_with_dialog.code_num();
+    const Response *dialog_buttons = state_with_dialog.buttons();
 
     // Keep the indentation of the JSON in here!
     // clang-format off
@@ -76,6 +83,17 @@ json::JsonResult StatusRenderer::renderState(size_t resume_point, json::JsonOutp
             JSON_FIELD_INT("fan_hotend", marlin_vars().active_hotend().heatbreak_fan_rpm) JSON_COMMA;
             JSON_FIELD_INT("fan_print", marlin_vars().active_hotend().print_fan_rpm);
         JSON_OBJ_END;
+        if (has_dialog) {
+            JSON_COMMA;
+            JSON_FIELD_OBJ("dialog");
+                JSON_FIELD_INT("id", dialog_id) JSON_COMMA;
+                JSON_FIELD_INT("code", dialog_code) JSON_COMMA;
+                JSON_FIELD_STR("button0", (dialog_buttons && dialog_buttons[0] != Response::_none) ? to_str(dialog_buttons[0]) : "") JSON_COMMA;
+                JSON_FIELD_STR("button1", (dialog_buttons && dialog_buttons[0] != Response::_none && dialog_buttons[1] != Response::_none) ? to_str(dialog_buttons[1]) : "") JSON_COMMA;
+                JSON_FIELD_STR("button2", (dialog_buttons && dialog_buttons[0] != Response::_none && dialog_buttons[1] != Response::_none && dialog_buttons[2] != Response::_none) ? to_str(dialog_buttons[2]) : "") JSON_COMMA;
+                JSON_FIELD_STR("button3", (dialog_buttons && dialog_buttons[0] != Response::_none && dialog_buttons[1] != Response::_none && dialog_buttons[2] != Response::_none && dialog_buttons[3] != Response::_none) ? to_str(dialog_buttons[3]) : "");
+            JSON_OBJ_END;
+        }
     JSON_OBJ_END;
     JSON_END;
     // clang-format on

--- a/lib/WUI/nhttp/status_renderer.cpp
+++ b/lib/WUI/nhttp/status_renderer.cpp
@@ -35,6 +35,9 @@ json::JsonResult StatusRenderer::renderState(size_t resume_point, json::JsonOutp
     uint32_t dialog_id = has_dialog ? state_with_dialog.dialog->dialog_id.to_uint32_t() : 0;
     uint32_t dialog_code = state_with_dialog.code_num();
     const Response *dialog_buttons = state_with_dialog.buttons();
+    // Optional user-facing message (currently populated by Prusa's M0 handler
+    // — see src/marlin_stubs/M0.cpp; the pointer is packed into PhaseData).
+    const char *dialog_message = has_dialog ? state_with_dialog.dialog->text : nullptr;
 
     // Keep the indentation of the JSON in here!
     // clang-format off
@@ -88,6 +91,7 @@ json::JsonResult StatusRenderer::renderState(size_t resume_point, json::JsonOutp
             JSON_FIELD_OBJ("dialog");
                 JSON_FIELD_INT("id", dialog_id) JSON_COMMA;
                 JSON_FIELD_INT("code", dialog_code) JSON_COMMA;
+                JSON_FIELD_STR("message", dialog_message ? dialog_message : "") JSON_COMMA;
                 JSON_FIELD_STR("button0", (dialog_buttons && dialog_buttons[0] != Response::_none) ? to_str(dialog_buttons[0]) : "") JSON_COMMA;
                 JSON_FIELD_STR("button1", (dialog_buttons && dialog_buttons[0] != Response::_none && dialog_buttons[1] != Response::_none) ? to_str(dialog_buttons[1]) : "") JSON_COMMA;
                 JSON_FIELD_STR("button2", (dialog_buttons && dialog_buttons[0] != Response::_none && dialog_buttons[1] != Response::_none && dialog_buttons[2] != Response::_none) ? to_str(dialog_buttons[2]) : "") JSON_COMMA;

--- a/lib/WUI/nhttp/status_renderer.h
+++ b/lib/WUI/nhttp/status_renderer.h
@@ -8,6 +8,8 @@ namespace nhttp::handler {
 class StatusState {
 public:
     std::optional<transfers::TransferId> transfer_id { std::nullopt };
+    size_t iter = 0;
+    bool need_comma = false;
     StatusState(std::optional<transfers::TransferId> id)
         : transfer_id(id) {}
 };

--- a/src/state/printer_state.cpp
+++ b/src/state/printer_state.cpp
@@ -422,7 +422,14 @@ StateWithDialog get_state_with_dialog(bool ready) {
                 const Response *buttons = ClientResponses::get_available_responses(GetEnumFromPhaseIndex<PhasesLoadUnload>(data.GetPhase())).data();
                 return { state, attention_code, fsm_gen, buttons };
             }
-        } // TODO: handle normal load unload
+        } else {
+            // Normal (non-printing) load/unload: expose dialog if there are buttons
+            auto phase = GetEnumFromPhaseIndex<PhasesLoadUnload>(data.GetPhase());
+            const auto &responses = ClientResponses::get_available_responses(phase);
+            if (responses[0] != Response::_none) {
+                return { state, ErrCode::CONNECT_FILAMENT_RUNOUT, fsm_gen, responses.data() };
+            }
+        }
         break;
     case ClientFSM::QuickPause: {
         const Response *available_responses = ClientResponses::get_available_responses(GetEnumFromPhaseIndex<PhasesQuickPause>(data.GetPhase())).data();

--- a/src/state/printer_state.cpp
+++ b/src/state/printer_state.cpp
@@ -433,8 +433,15 @@ StateWithDialog get_state_with_dialog(bool ready) {
         break;
     case ClientFSM::QuickPause: {
         const Response *available_responses = ClientResponses::get_available_responses(GetEnumFromPhaseIndex<PhasesQuickPause>(data.GetPhase())).data();
-        return { state, ErrCode::CONNECT_QUICK_PAUSE, fsm_gen, available_responses };
-        break;
+        StateWithDialog result { state, ErrCode::CONNECT_QUICK_PAUSE, fsm_gen, available_responses };
+        // Prusa's M0 handler (src/marlin_stubs/M0.cpp) packs the message
+        // pointer (parser.string_arg) into PhaseData. Unpack it so remote
+        // clients can see the user-facing text (e.g. "Insert magnets").
+        const char *msg = fsm::deserialize_data<const char *>(data.GetData());
+        if (result.dialog.has_value()) {
+            result.dialog->text = msg;
+        }
+        return result;
     }
 #if ENABLED(CRASH_RECOVERY)
     case ClientFSM::CrashRecovery:


### PR DESCRIPTION
## Summary

Extends the dialog object from #5230 to include the human-readable text of an active `M0`/`M1` (Prusa's `QuickPause` FSM).

Requested by @jabdoa2 in [#5230 comment](https://github.com/prusa3d/Prusa-Firmware-Buddy/pull/5230#issuecomment-5085081334) for Home Assistant integration.

## Example

`M0 Insert magnets` now produces:

```json
{
  "dialog": {
    "id": 12345,
    "code": 31829,
    "message": "Insert magnets",
    "button0": "Continue",
    "button1": "",
    "button2": "",
    "button3": ""
  }
}
```

## Motivation

Currently the message from an `M0`/`M1` is only logged to serial once (via `SERIAL_ECHOLN(args)`) and never re-emitted. Any HTTP/API client that connects AFTER the printer stopped for user input has no way to know what the printer is asking for. This is a real gap flagged by users trying to build Home Assistant / dashboard integrations.

The message is already present in the firmware — Prusa's `M0` handler (`src/marlin_stubs/M0.cpp`) packs the message pointer (`parser.string_arg`) into `fsm::PhaseData`. This PR just unpacks it and threads it into the JSON.

## Implementation

- `src/state/printer_state.cpp` — in the `ClientFSM::QuickPause` case of `get_state_with_dialog`, use the existing `fsm::deserialize_data<const char *>()` helper to unpack the message pointer, then set `dialog->text`.
- `lib/WUI/nhttp/status_renderer.cpp` — read `dialog->text` and emit as a `"message"` field in the JSON.
- Emits empty string (`""`) when the parameter-less form of M0 was called, to keep the JSON schema stable.

## Pointer lifetime

`parser.string_arg` points into Marlin's global command-line buffer. Its lifetime is bounded by the M0 handler's scope, which is guaranteed to outlive the FSM because:

1. `planner.synchronize()` empties the planner queue before entering the response-wait loop.
2. `idle(true)` during the wait doesn't advance the gcode queue.
3. No other gcode can be parsed while M0 blocks — meaning `parser.string_arg` cannot be overwritten.

## Dependency

Depends on **#5230** for the base dialog object structure. Once #5230 lands, this PR's diff against `master` becomes just the two-line addition of unpacking the message + emitting the JSON field.

## Test plan

- [x] Firmware builds cleanly (`--preset coreone --bootloader no --skip-bootstrap`)
- [ ] Runtime verification on a Core One+: send `M0 test message`, poll `/api/v1/status`, confirm `dialog.message == "test message"`
- [ ] Parameter-less `M0` case: confirm `dialog.message == ""`

Happy to bench-test on my Core One+ once #5230 is merged.